### PR TITLE
Added basic API for C++ Wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,12 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 if (UNIX)
     # Linux and OSX
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fPIC -Werror")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -std=gnu++0x")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fPIC -Werror -std=c++0x -std=gnu++0x")
 endif ()
 if (LINUX)
     # Linux. MacOS doesn't require pthread option
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 endif ()
 
 if (LINUX)
@@ -109,7 +110,8 @@ include_directories(
         deps-build/${PLATFORM}/openssl/include
         deps-build/${PLATFORM}/zlib/include
         deps-build/${PLATFORM}/aws/include
-        include)
+        include
+        cpp/include)
 
 message("libcurl is located at " ${CURL_LIB})
 message("libssl is located at " ${SSL_LIB})
@@ -142,5 +144,6 @@ if (WIN32)
     target_link_libraries(snowflakeclient)
 endif ()
 
+add_subdirectory(cpp)
 add_subdirectory(examples)
 add_subdirectory(tests)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) 2017 Snowflake Computing, Inc. All rights reserved.
+#
+# CMakeList for Snowflake Client++
+#
+
+set(SOURCE_FILES_CXX
+        include/snowflake++/SnowflakeInclude.hpp
+        include/snowflake++/SnowflakeConnection.hpp
+        include/snowflake++/SnowflakeStatement.hpp
+        lib/SnowflakeConnection.cpp
+        lib/SnowflakeStatement.cpp)
+
+set(TESTLIB_OPTS_CXX snowflakeclient -Wl,--whole-archive curl ssl crypto pthread aws-cpp-sdk-core aws-cpp-sdk-s3 -Wl,--no-whole-archive)
+
+add_library(snowflakeclient++ STATIC ${SOURCE_FILES_CXX})
+
+set_target_properties(snowflakeclient++ PROPERTIES LINKER_LANGUAGE CXX)
+
+target_link_libraries(snowflakeclient++ ${TESTLIB_OPTS_CXX})

--- a/cpp/include/snowflake++/SnowflakeConnection.hpp
+++ b/cpp/include/snowflake++/SnowflakeConnection.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_SNOWFLAKECONNECTION_HPP
+#define SNOWFLAKECLIENT_SNOWFLAKECONNECTION_HPP
+
+#include "SnowflakeInclude.hpp"
+
+namespace Snowflake {
+    namespace Client {
+        class SnowflakeConnection {
+        public:
+
+            /* Construct a blank Snowflake Connection */
+            SnowflakeConnection(void);
+
+            /*
+             * Construct with a connection pointer. Copies connection info from
+             * passed in connection
+             */
+            SnowflakeConnection(Snowflake::CAPI::SF_CONNECT &connection_);
+
+            ~SnowflakeConnection(void);
+
+            Snowflake::CAPI::SF_STATUS connect();
+
+            Snowflake::CAPI::SF_STATUS setAttribute(Snowflake::CAPI::SF_ATTRIBUTE type_,
+                                                    const void *value_);
+
+            Snowflake::CAPI::SF_STATUS getAttribute(Snowflake::CAPI::SF_ATTRIBUTE type_,
+                                                    void **value_);
+
+            Snowflake::CAPI::SF_STATUS beginTransaction();
+
+            Snowflake::CAPI::SF_STATUS commitTransaction();
+
+            Snowflake::CAPI::SF_STATUS rollbackTransaction();
+
+            //TODO Instead of returning error struct, translate error codes into exceptions
+
+
+
+        private:
+            Snowflake::CAPI::SF_CONNECT *m_connection;
+            bool m_connection_created = 0;
+        };
+    }
+}
+
+#endif //SNOWFLAKECLIENT_SNOWFLAKECONNECTION_HPP

--- a/cpp/include/snowflake++/SnowflakeInclude.hpp
+++ b/cpp/include/snowflake++/SnowflakeInclude.hpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_SNOWFLAKEINCLUDE_H
+#define SNOWFLAKECLIENT_SNOWFLAKEINCLUDE_H
+
+namespace Snowflake {
+    namespace CAPI {
+#include <snowflake/client.h>
+#undef inline
+#undef class
+    }
+}
+
+//namespace Snowflake {
+//    namespace Client {
+//        using Snowflake::CAPI::SF_CONNECT;
+//        using Snowflake::CAPI::SF_STMT;
+//    }
+//}
+
+#endif //SNOWFLAKECLIENT_SNOWFLAKEINCLUDE_H

--- a/cpp/include/snowflake++/SnowflakeStatement.hpp
+++ b/cpp/include/snowflake++/SnowflakeStatement.hpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_SNOWFLAKESTATEMENT_HPP
+#define SNOWFLAKECLIENT_SNOWFLAKESTATEMENT_HPP
+
+#include <SnowflakeInclude.hpp>
+#include <string>
+#include "SnowflakeConnection.hpp"
+
+namespace Snowflake {
+    namespace Client {
+        class SnowflakeStatement {
+            friend class SnowflakeConnection;
+        public:
+
+            SnowflakeStatement(SnowflakeConnection &connection_);
+
+            SnowflakeStatement(Snowflake::CAPI::SF_STMT &sf_stmt_);
+
+            ~SnowflakeStatement(void);
+
+            //TODO error structs or exceptions?
+
+            Snowflake::CAPI::SF_STATUS query(const std::string &command_);
+
+            Snowflake::CAPI::int64 affectedRows();
+
+            Snowflake::CAPI::uint64 numRows();
+
+            Snowflake::CAPI::uint64 numFields();
+
+            const char *sqlState();
+
+            Snowflake::CAPI::SF_COLUMN_DESC *desc();
+
+            Snowflake::CAPI::SF_STATUS prepare(const std::string &command_);
+
+            Snowflake::CAPI::SF_STATUS setAttribute(Snowflake::CAPI::SF_STMT_ATTRIBUTE type_,
+                                                    const void *value);
+
+            Snowflake::CAPI::SF_STATUS getAttribute(Snowflake::CAPI::SF_STMT_ATTRIBUTE type_,
+                                                    void **value);
+
+            Snowflake::CAPI::SF_STATUS execute();
+
+            Snowflake::CAPI::SF_STATUS fetch();
+
+            Snowflake::CAPI::uint64 numParams();
+
+            Snowflake::CAPI::SF_STATUS bindParam(Snowflake::CAPI::SF_BIND_INPUT &sfbind_);
+
+            Snowflake::CAPI::SF_STATUS bindParamArray(Snowflake::CAPI::SF_BIND_INPUT &sfbind_array_,
+                                                      size_t size_);
+
+            Snowflake::CAPI::SF_STATUS bindResult(Snowflake::CAPI::SF_BIND_OUTPUT &sfbind_);
+
+            Snowflake::CAPI::SF_STATUS bindResultArray(Snowflake::CAPI::SF_BIND_OUTPUT &sfbind_array_,
+                                                       size_t size_);
+
+            const char *sfqid();
+
+        private:
+            // C API struct to operate on
+            Snowflake::CAPI::SF_STMT m_stmt;
+            // Pointer to the connection object that the statement struct will to
+            // connect to Snowflake.
+            SnowflakeConnection *m_connection;
+        };
+    }
+}
+
+
+#endif //SNOWFLAKECLIENT_SNOWFLAKESTATEMENT_HPP

--- a/cpp/lib/SnowflakeConnection.cpp
+++ b/cpp/lib/SnowflakeConnection.cpp
@@ -1,0 +1,4 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+

--- a/cpp/lib/SnowflakeStatement.cpp
+++ b/cpp/lib/SnowflakeStatement.cpp
@@ -1,0 +1,4 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+


### PR DESCRIPTION
The C++ wrapper is under the Snowflake::Client namespace while all of the C API structs and functions are under the Snowflake::CAPI namespace. This will allow a user to use either the C API or C++ wrapper in their code. Only a connection and statement class are defined. Structs that only hold data (input/output bindings, error struct) are not defined as classes since there are no internal operations for those structs.