### PR TITLE
Update pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ matrix:
       - sudo apt-get install lcov
       - openssl aes-256-cbc -k "$super_secret_password" -in parameters.json.enc -out parameters.json -d
       - pyenv local 3.6
-      - pip install -U pip
+      - curl -O https://bootstrap.pypa.io/get-pip.py
+      - python get-pip.py
+      - pip --version
       - pip install -U virtualenv
       - virtualenv env
       - source env/bin/activate
@@ -41,7 +43,9 @@ matrix:
       - sudo apt-get install lcov valgrind
       - openssl aes-256-cbc -k "$super_secret_password" -in parameters.json.enc -out parameters.json -d
       - pyenv local 3.6
-      - pip install -U pip
+      - curl -O https://bootstrap.pypa.io/get-pip.py
+      - python get-pip.py
+      - pip --version
       - pip install -U virtualenv
       - virtualenv env
       - source env/bin/activate

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ before_build:
             $env:VCVARS_PLATFORM="x64"
         }
   - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
-  - ps: Invoke-WebRequest -OutFile get-pip.py http://superuser.co://bootstrap.pypa.io/get-pip.py
+  - ps: Invoke-WebRequest -OutFile get-pip.py https://bootstrap.pypa.io/get-pip.py
   - call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ before_build:
             $env:VCVARS_PLATFORM="x64"
         }
   - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
+  - ps: Invoke-WebRequest -OutFile get-pip.py http://superuser.co://bootstrap.pypa.io/get-pip.py
   - call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
 
 build_script:
@@ -30,5 +31,7 @@ build_script:
 test_script:
   - C:\Python36-x64\python -m venv env
   - call env\Scripts\activate
+  - python get-pip.py
+  - pip --version
   - pip install -U snowflake-connector-python
   - .\scripts\run_tests.bat %VCVARS_PLATFORM% Release


### PR DESCRIPTION
This is to prepare for TLS 1.2 enforcement for pip.
https://status.python.org/incidents/hdx7w97m5hr8

pip upgrade itself won't work after April 8.

```
>pip install -v -U pip
1 location(s) to search for versions of pip:
* https://pypi.python.org/simple/pip/
Getting page https://pypi.python.org/simple/pip/
Looking up "https://pypi.python.org/simple/pip/" in the cache
No cache entry available
Starting new HTTPS connection (1): pypi.python.org
"GET /simple/pip/ HTTP/1.1" 403 109
Status code 403 not in [200, 203, 300, 301]
Could not fetch URL https://pypi.python.org/simple/pip/: 403 Client Error: Brownout of Legacy TLS for url: https://pypi.python.org/simple/pip/ - skipping
Installed version (9.0.1) is most up-to-date (past versions: none)
Requirement already up-to-date: pip in /private/tmp/kkk/lib/python3.5/site-packages
Cleaning up...
You are using pip version 9.0.1, however version 9.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

To solve this, do this for Linux and Mac:
```
curl -O https://bootstrap.pypa.io/get-pip.py
python get-pip.py
```
or for Windows
```
ps: Invoke-WebRequest -OutFile get-pip.py https://bootstrap.pypa.io/get-pip.py
```