### PR TITLE
Fix logging

### DIFF
--- a/include/snowflake/logger.h
+++ b/include/snowflake/logger.h
@@ -44,4 +44,6 @@ void log_set_quiet(int enable);
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);
 
+SF_LOG_LEVEL log_from_str_to_level(const char* level_in_str);
+
 #endif /* SNOWFLAKE_LOGGER_H */

--- a/include/snowflake/platform.h
+++ b/include/snowflake/platform.h
@@ -98,6 +98,9 @@ int STDCALL _mutex_unlock(SF_MUTEX_HANDLE *lock);
 
 int STDCALL _mutex_term(SF_MUTEX_HANDLE *lock);
 
+const char *STDCALL sf_os_name();
+
+void STDCALL sf_os_version(char *ret);
 
 #ifdef __cplusplus
 }

--- a/include/snowflake/platform.h
+++ b/include/snowflake/platform.h
@@ -102,6 +102,8 @@ const char *STDCALL sf_os_name();
 
 void STDCALL sf_os_version(char *ret);
 
+int STDCALL sf_strncasecmp(const char *s1, const char *s2, size_t n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/arraylist.c
+++ b/lib/arraylist.c
@@ -38,8 +38,8 @@ void STDCALL sf_array_list_grow(ARRAY_LIST *al, size_t min_size) {
 }
 
 void STDCALL sf_array_list_set(ARRAY_LIST *al, void *item, size_t index) {
-    if (al->size < index) {
-        sf_array_list_grow(al, index);
+    if (al->size <= index) {
+        sf_array_list_grow(al, index+1);
     }
     // If element we are writing to is NULL and item is not NULL, we want to increment 'used'.
     // Otherwise we are writing to a spot that already contains an element
@@ -54,5 +54,8 @@ void STDCALL sf_array_list_set(ARRAY_LIST *al, void *item, size_t index) {
 }
 
 void* STDCALL sf_array_list_get(ARRAY_LIST *al, size_t index) {
+    if (al->size <= index) {
+        sf_array_list_grow(al, index+1);
+    }
     return al->data[index];
 }

--- a/lib/client.c
+++ b/lib/client.c
@@ -627,6 +627,13 @@ SF_STATUS STDCALL snowflake_connect(SF_CONNECT *sf) {
     // Reset error context
     clear_snowflake_error(&sf->error);
 
+    char os_version[128];
+    sf_os_version(os_version);
+
+    log_info("Snowflake C/C++ API: %s, OS: %s, OS Version: %s",
+             SF_API_VERSION,
+             sf_os_name(),
+             os_version);
     cJSON *body = NULL;
     cJSON *data = NULL;
     cJSON *resp = NULL;

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -133,35 +133,14 @@ cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
     cJSON *data;
     cJSON *client_env;
     cJSON *session_parameters;
+    char os_version[128];
 
     //Create Client Environment JSON blob
     client_env = cJSON_CreateObject();
     cJSON_AddStringToObject(client_env, "APPLICATION", application);
-#if defined(_WIN32)
-    cJSON_AddStringToObject(client_env, "OS_VERSION", "Windows");
-#else
-    // Linux and OSX
-    struct utsname u;
-    if (uname(&u) >= 0) {
-        char buf[1024];
-        strcpy(buf, u.sysname);
-        strcat(buf, "-");
-        strcat(buf, u.release);
-        strcat(buf, "-");
-        strcat(buf, u.version);
-        strcat(buf, "-");
-        strcat(buf, u.machine);
-        cJSON_AddStringToObject(client_env, "OS_VERSION", buf);
-    } else {
-#  if defined(linux)
-        cJSON_AddStringToObject(client_env, "OS_VERSION", "Linux");
-#  elif defined(__APPLE__)
-        cJSON_AddStringToObject(client_env, "OS_VERSION", "MacOS");
-#  else
-        cJSON_AddStringToObject(client_env, "OS_VERSION", "Unknown");
-#  endif
-    }
-#endif
+    cJSON_AddStringToObject(client_env, "OS", sf_os_name());
+    sf_os_version(os_version);
+    cJSON_AddStringToObject(client_env, "OS_VERSION", os_version);
 
     session_parameters = cJSON_CreateObject();
     cJSON_AddStringToObject(
@@ -715,7 +694,7 @@ ARRAY_LIST *json_get_object_keys(const cJSON *item) {
 size_t
 json_resp_cb(char *data, size_t size, size_t nmemb, RAW_JSON_BUFFER *raw_json) {
     size_t data_size = size * nmemb;
-    log_debug("Curl response size: %zu\n", data_size);
+    log_debug("Curl response size: %zu", data_size);
     raw_json->buffer = (char *) SF_REALLOC(raw_json->buffer,
                                            raw_json->size + data_size + 1);
     // Start copying where last null terminator existed

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -26,6 +26,7 @@
 #include <time.h>
 
 #include <snowflake/logger.h>
+#include <snowflake/platform.h>
 #include <string.h>
 
 static struct {
@@ -139,7 +140,7 @@ SF_LOG_LEVEL log_from_str_to_level(const char *level_in_str) {
     int idx = 0, last = 0;
     for (idx = 0, last = (int) SF_LOG_FATAL; idx <= last; ++idx) {
         size_t len = strlen(level_names[idx]);
-        if (strncasecmp(level_names[idx], level_in_str, len) == 0) {
+        if (sf_strncasecmp(level_names[idx], level_in_str, len) == 0) {
             return (SF_LOG_LEVEL) idx;
         }
     }

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -138,8 +138,8 @@ void log_log(int level, const char *file, int line, const char *fmt, ...) {
 SF_LOG_LEVEL log_from_str_to_level(const char *level_in_str) {
     int idx = 0, last = 0;
     for (idx = 0, last = (int) SF_LOG_FATAL; idx <= last; ++idx) {
-        if (strncasecmp(level_names[idx], level_in_str,
-                        sizeof(level_names[idx])) == 0) {
+        size_t len = strlen(level_names[idx]);
+        if (strncasecmp(level_names[idx], level_in_str, len) == 0) {
             return (SF_LOG_LEVEL) idx;
         }
     }

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -26,110 +26,122 @@
 #include <time.h>
 
 #include <snowflake/logger.h>
+#include <string.h>
 
 static struct {
-  void *udata;
-  log_LockFn lock;
-  FILE *fp;
-  int level;
-  int quiet;
+    void *udata;
+    log_LockFn lock;
+    FILE *fp;
+    int level;
+    int quiet;
 } L;
 
 
 static const char *level_names[] = {
-  "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"
+    "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"
 };
 
 #ifdef LOG_USE_COLOR
 static const char *level_colors[] = {
-  "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"
+    "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"
 };
 #endif
 
 
-static void lock(void)   {
-  if (L.lock) {
-    L.lock(L.udata, 1);
-  }
+static void lock(void) {
+    if (L.lock) {
+        L.lock(L.udata, 1);
+    }
 }
 
 
 static void unlock(void) {
-  if (L.lock) {
-    L.lock(L.udata, 0);
-  }
+    if (L.lock) {
+        L.lock(L.udata, 0);
+    }
 }
 
 
 void log_set_udata(void *udata) {
-  L.udata = udata;
+    L.udata = udata;
 }
 
 
 void log_set_lock(log_LockFn fn) {
-  L.lock = fn;
+    L.lock = fn;
 }
 
 
 void log_set_fp(FILE *fp) {
-  L.fp = fp;
+    L.fp = fp;
 }
 
 
 void log_set_level(int level) {
-  L.level = level;
+    L.level = level;
 }
 
 
 void log_set_quiet(int enable) {
-  L.quiet = enable ? 1 : 0;
+    L.quiet = enable ? 1 : 0;
 }
 
 
 void log_log(int level, const char *file, int line, const char *fmt, ...) {
-  if (level < L.level) {
-    return;
-  }
+    if (level < L.level) {
+        return;
+    }
 
-  /* Acquire lock */
-  lock();
+    /* Acquire lock */
+    lock();
 
-  /* Get current time */
-  time_t t = time(NULL);
-  struct tm *lt = localtime(&t);
+    /* Get current time */
+    time_t t = time(NULL);
+    struct tm *lt = localtime(&t);
 
-  /* Log to stderr */
-  if (!L.quiet) {
-    va_list args;
-    char buf[16];
-    buf[strftime(buf, sizeof(buf), "%H:%M:%S", lt)] = '\0';
+    /* Log to stderr */
+    if (!L.quiet) {
+        va_list args;
+        char buf[16];
+        buf[strftime(buf, sizeof(buf), "%H:%M:%S", lt)] = '\0';
 #ifdef LOG_USE_COLOR
-    fprintf(
-      stderr, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
-      buf, level_colors[level], level_names[level], file, line);
+        fprintf(
+            stderr, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
+            buf, level_colors[level], level_names[level], file, line);
 #else
-    fprintf(stderr, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
+        fprintf(stderr, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
 #endif
-    va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
-    fprintf(stderr, "\n");
-    fflush(stderr);
-  }
+        va_start(args, fmt);
+        vfprintf(stderr, fmt, args);
+        va_end(args);
+        fprintf(stderr, "\n");
+        fflush(stderr);
+    }
 
-  /* Log to file */
-  if (L.fp) {
-    va_list args;
-    char buf[32];
-    buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt)] = '\0';
-    fprintf(L.fp, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
-    va_start(args, fmt);
-    vfprintf(L.fp, fmt, args);
-    va_end(args);
-    fprintf(L.fp, "\n");
-    fflush(L.fp);
-  }
+    /* Log to file */
+    if (L.fp) {
+        va_list args;
+        char buf[32];
+        buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt)] = '\0';
+        fprintf(L.fp, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
+        va_start(args, fmt);
+        vfprintf(L.fp, fmt, args);
+        va_end(args);
+        fprintf(L.fp, "\n");
+        fflush(L.fp);
+    }
 
-  /* Release lock */
-  unlock();
+    /* Release lock */
+    unlock();
+}
+
+SF_LOG_LEVEL log_from_str_to_level(const char *level_in_str) {
+    int idx = 0, last = 0;
+    for (idx = 0, last = (int) SF_LOG_FATAL; idx <= last; ++idx) {
+        if (strncasecmp(level_names[idx], level_in_str,
+                        sizeof(level_names[idx])) == 0) {
+            return (SF_LOG_LEVEL) idx;
+        }
+    }
+    return SF_LOG_FATAL;
 }

--- a/lib/platform.c
+++ b/lib/platform.c
@@ -9,6 +9,7 @@
 
 #include <regex.h>
 #include <string.h>
+#include <ctype.h>
 
 #endif
 
@@ -364,4 +365,19 @@ void STDCALL sf_os_version(char *ret) {
 #endif // _WIN64
     );
 #endif // Unknown Platform
+}
+
+int STDCALL sf_strncasecmp(const char *s1, const char *s2, size_t n) {
+    if (n == 0) {
+        return 0;
+    }
+
+    while (n-- != 0 && tolower(*s1) == tolower(*s2)) {
+        if (n == 0 || *s1 == '\0' || *s2 == '\0')
+            break;
+        s1++;
+        s2++;
+    }
+
+    return tolower(*(unsigned char *) s1) - tolower(*(unsigned char *) s2);
 }

--- a/lib/platform.c
+++ b/lib/platform.c
@@ -5,6 +5,10 @@
 #include <snowflake/platform.h>
 #include <snowflake/basic_types.h>
 
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
+
 #ifndef _WIN32
 
 #include <regex.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(TESTS_C
         test_timestamp_ltz
         test_timestamp_tz
         test_timezone
+        test_logger
         )
 
 SET(TESTS_CXX

--- a/tests/test_logger.c
+++ b/tests/test_logger.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include "utils/test_setup.h"
+
+/**
+ * Tests converting a string representation of log level to the log level enum
+ * @param unused
+ */
+void test_log_str_to_level(void **unused) {
+    assert_int_equal(log_from_str_to_level("TRACE"), SF_LOG_TRACE);
+    assert_int_equal(log_from_str_to_level("DEBUG"), SF_LOG_DEBUG);
+    assert_int_equal(log_from_str_to_level("INFO"), SF_LOG_INFO);
+    assert_int_equal(log_from_str_to_level("wArN"), SF_LOG_WARN);
+    assert_int_equal(log_from_str_to_level("erroR"), SF_LOG_ERROR);
+    assert_int_equal(log_from_str_to_level("fatal"), SF_LOG_FATAL);
+
+    /* negative */
+    assert_int_equal(log_from_str_to_level("hahahaha"), SF_LOG_FATAL);
+}
+
+int main(void) {
+    initialize_test(SF_BOOLEAN_FALSE);
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_log_str_to_level),
+    };
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    snowflake_global_term();
+    return ret;
+}


### PR DESCRIPTION
- Added CAPI version INFO to the log. This is consistent with the recent ODBC change.
- Fixed memory leak in sf_array_list when binding results. If the result buffer is not bound and the returned column is more than 8, fetch attempts to read uninitialized buffer.
- Added a function converting a debug level string to enum.