### PR TITLE
Fix issue48, where concurrent upload failed intermittently.

### DIFF
--- a/cpp/util/StreamSplitter.hpp
+++ b/cpp/util/StreamSplitter.hpp
@@ -38,11 +38,7 @@ public:
     return m_dataBuffer;
   }
 
-  inline void * updateSize(long updatedSize)
-  {
-    this->setg(m_dataBuffer, m_dataBuffer, m_dataBuffer + updatedSize);
-    this->size = updatedSize;
-  }
+  void * updateSize(long updatedSize);
 
   inline long getSize()
   {
@@ -56,8 +52,6 @@ private:
   long size;
 
   char * m_dataBuffer;
-
-  virtual int underflow();
 };
 
 /**
@@ -72,7 +66,7 @@ public:
 
   ~StreamSplitter();
 
-  ByteArrayStreamBuf * FillAndGetBuf(int bufIndex);
+  ByteArrayStreamBuf * FillAndGetBuf(int bufIndex, int &partIndex);
 
   unsigned int getTotalParts(long long int streamSize);
 
@@ -83,6 +77,8 @@ private:
   std::basic_iostream<char> * m_inputStream;
 
   unsigned int m_partMaxSize;
+
+  int m_currentPartIndex;
 
   std::vector<ByteArrayStreamBuf *> buffers;
 };

--- a/tests/test_parallel_upload.cpp
+++ b/tests/test_parallel_upload.cpp
@@ -114,6 +114,8 @@ void test_parallel_upload_core(int fileNumber)
     assert_string_equal((char *) c2.value, "LOADED");
   }
   assert_int_equal(status, SF_STATUS_EOF);
+
+
   snowflake_stmt_term(sfstmt);
 
   /* close and term */
@@ -168,7 +170,7 @@ static int gr_teardown(void **unused)
 int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test_teardown(test_small_file_concurrent_upload, teardown),
-    //cmocka_unit_test_teardown(test_large_file_multipart_upload, teardown),
+    cmocka_unit_test_teardown(test_large_file_multipart_upload, teardown),
   };
   int ret = cmocka_run_group_tests(tests, gr_setup, gr_teardown);
   return ret;

--- a/tests/test_unit_stream_splitter.cpp
+++ b/tests/test_unit_stream_splitter.cpp
@@ -34,14 +34,16 @@ void test_stream_splitter(void **unused)
   Snowflake::Client::Util::StreamSplitter splitter(&ss, threadNum, partSize);
   Snowflake::Client::Util::ThreadPool tp(threadNum);
 
-  char result[splitParts][partSize];
+  char result[splitParts][partSize + 1] = {0};
   for (int i=0; i<splitParts; i++)
   {
     tp.AddJob([&, i]
               {
                   int threadIdx = tp.GetThreadIdx();
-                  std::basic_iostream<char> byteStreamArray(splitter.FillAndGetBuf(threadIdx));
-                  byteStreamArray.read(result[i], partSize);
+                  int partId;
+                  std::basic_iostream<char> byteStreamArray(
+                    splitter.FillAndGetBuf(threadIdx, partId));
+                  byteStreamArray.read(result[partId], partSize);
               });
   }
 


### PR DESCRIPTION
Travis succeed for consecutive 5 runs. 
Local succeed for consecutive 20 runs.

Basically, this is a race conditions, where each parts in multi part upload is not encrypted into the target part of the buffer. 