### PR TITLE
C++ Wrapper API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,17 @@ set (SOURCE_FILES_PUT_GET
         cpp/crypto/HashContext.cpp
         cpp/crypto/HashContext.hpp)
 
+set(SOURCE_FILES_CPP_WRAPPER
+        include/snowflake/Connection.hpp
+        include/snowflake/Statement.hpp
+        include/snowflake/Column.hpp
+        include/snowflake/Param.hpp
+        include/snowflake/Exceptions.hpp
+        cpp/lib/Exceptions.cpp
+        cpp/lib/Connection.cpp
+        cpp/lib/Statement.cpp
+        cpp/lib/Column.cpp)
+
 if (UNIX)
     # Linux and OSX
     find_library(CURL_LIB libcurl.a PATHS deps-build/${PLATFORM}/curl/lib/ REQUIRED)
@@ -161,11 +172,12 @@ message("libaws-cpp-sdk-core is located at " ${AWS_CORE_LIB})
 message("libaws-cpp-sdk-s3 is located at " ${AWS_S3_LIB})
 
 if (LINUX)
-    add_library(snowflakeclient STATIC ${SOURCE_FILES} ${SOURCE_FILES_PUT_GET})
+    add_library(snowflakeclient STATIC ${SOURCE_FILES} ${SOURCE_FILES_PUT_GET} ${SOURCE_FILES_CPP_WRAPPER})
 else()
     add_library(snowflakeclient STATIC ${SOURCE_FILES})
 endif()
 
+set_target_properties(snowflakeclient PROPERTIES LINKER_LANGUAGE CXX)
 set_property(TARGET snowflakeclient PROPERTY C_STANDARD 99)
 #set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/lib/Column.cpp
+++ b/cpp/lib/Column.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <snowflake/Column.hpp>
+
+Snowflake::Client::Column::Column(SF_COLUMN_DESC *column_desc_) {}
+
+Snowflake::Client::Column::~Column() {}
+
+int32 Snowflake::Client::Column::asInt32() {}

--- a/cpp/lib/Connection.cpp
+++ b/cpp/lib/Connection.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <snowflake/Connection.hpp>
+
+Snowflake::Client::Connection::Connection() {
+    this->m_connection = snowflake_init();
+}
+
+Snowflake::Client::Connection::~Connection() {
+    snowflake_term(this->m_connection);
+}
+
+void Snowflake::Client::Connection::connect() {
+    SF_STATUS status = snowflake_connect(this->m_connection);
+
+    switch (status) {
+        // TODO implement exception throwing based on return status
+    }
+}
+
+void Snowflake::Client::Connection::setAttribute(SF_ATTRIBUTE type_, const void *value_) {
+    // TODO implement this
+}
+
+

--- a/cpp/lib/Exceptions.cpp
+++ b/cpp/lib/Exceptions.cpp
@@ -1,0 +1,4 @@
+//
+// Created by vagrant on 2/27/18.
+//
+

--- a/cpp/lib/Exceptions.cpp
+++ b/cpp/lib/Exceptions.cpp
@@ -1,4 +1,4 @@
-//
-// Created by vagrant on 2/27/18.
-//
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
 

--- a/cpp/lib/Statement.cpp
+++ b/cpp/lib/Statement.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <snowflake/Statement.hpp>
+
+Snowflake::Client::Statement::Statement(Connection &connection_) {
+    this->m_connection = &connection_;
+}
+
+Snowflake::Client::Statement::~Statement() {
+    // TODO implement this
+}
+
+Snowflake::Client::Column& Snowflake::Client::Statement::column(size_t i) {
+    // TODO implement this
+}
+
+void Snowflake::Client::Statement::query(const std::string &command_) {
+    // TODO implement this
+}
+
+SF_STATUS Snowflake::Client::Statement::fetch() {
+    // TODO implement this
+}
+
+

--- a/include/snowflake/Column.hpp
+++ b/include/snowflake/Column.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_COLUMN_HPP
+#define SNOWFLAKECLIENT_COLUMN_HPP
+
+#include <string>
+#include "client.h"
+
+namespace Snowflake {
+    namespace Client {
+        class Column {
+        public:
+
+            Column(SF_COLUMN_DESC* column_desc_);
+
+            ~Column();
+
+            // Column Output data
+            bool isNull();
+
+            size_t idx();
+
+            size_t len();
+
+            // Column Description
+            std::string name();
+
+            bool nullOk();
+
+            int64 precision();
+
+            int64 scale();
+
+            SF_DB_TYPE dbDataType();
+
+            SF_C_TYPE cDataType();
+
+            // Data Conversions (as needed)
+            bool asBool();
+
+            int8 asInt8();
+
+            int32 asInt32();
+
+            int64 asInt64();
+
+            uint8 asUInt8();
+
+            uint32 asUInt32();
+
+            uint64 asUInt64();
+
+            float32 asFloat32();
+
+            float64 asFloat64();
+
+            std::string asString();
+
+            const char *asCString();
+
+        private:
+            SF_BIND_OUTPUT m_column;
+            SF_COLUMN_DESC *m_desc;
+        };
+    }
+}
+
+#endif //SNOWFLAKECLIENT_COLUMN_HPP

--- a/include/snowflake/Connection.hpp
+++ b/include/snowflake/Connection.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_SNOWFLAKECONNECTION_HPP
+#define SNOWFLAKECLIENT_SNOWFLAKECONNECTION_HPP
+
+#include <string>
+#include "client.h"
+
+namespace Snowflake {
+    namespace Client {
+        class Connection {
+            friend class Statement;
+        public:
+
+            /* Construct a blank Snowflake Connection */
+            Connection(void);
+
+            ~Connection(void);
+
+            void connect();
+
+            void setAttribute(SF_ATTRIBUTE type_,
+                                                    const void *value_);
+
+            void getAttribute(SF_ATTRIBUTE type_,
+                                                    void **value_);
+
+            void beginTransaction();
+
+            void commitTransaction();
+
+            void rollbackTransaction();
+
+            //TODO Instead of returning error struct, translate error codes into exceptions
+
+            /*
+             * Get error message from error struct. Error message is set when there is an exception
+             */
+            const std::string err_msg();
+
+        private:
+            SF_CONNECT *m_connection;
+        };
+    }
+}
+
+#endif //SNOWFLAKECLIENT_SNOWFLAKECONNECTION_HPP

--- a/include/snowflake/Exceptions.hpp
+++ b/include/snowflake/Exceptions.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_EXCEPTIONS_HPP
+#define SNOWFLAKECLIENT_EXCEPTIONS_HPP
+
+#include <exception>
+#include "client.h"
+
+class SnowflakeException: public std::exception {
+public:
+    SnowflakeException(SF_ERROR_STRUCT *error);
+
+    const char * what() const throw();
+
+    SF_STATUS code();
+
+    const char *sqlstate();
+
+    const char *msg();
+
+    const char *sfqid();
+
+    const char *file();
+
+    int line();
+
+protected:
+    SF_ERROR_STRUCT *error;
+};
+
+class GeneralException: public SnowflakeException {
+public:
+    GeneralException(SF_ERROR_STRUCT *error) : SnowflakeException(error) {};
+};
+
+#endif //SNOWFLAKECLIENT_EXCEPTIONS_HPP

--- a/include/snowflake/Param.hpp
+++ b/include/snowflake/Param.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_PARAM_HPP
+#define SNOWFLAKECLIENT_PARAM_HPP
+
+#include "client.h"
+
+namespace Snowflake {
+    namespace Client {
+        class Param {
+        public:
+            Param();
+
+            ~Param();
+
+            size_t len();
+
+            void set_len(size_t len_);
+
+            SF_DB_TYPE dbDataType();
+
+            void set_dbDataType(SF_DB_TYPE type_);
+
+            SF_C_TYPE cDataType();
+
+            void set_cDataType(SF_C_TYPE type_);
+
+            void* value();
+            
+            void set_value(void *value_, SF_C_TYPE type_);
+
+        private:
+            SF_BIND_INPUT m_param;
+        };
+    }
+}
+
+#endif //SNOWFLAKECLIENT_PARAM_HPP

--- a/include/snowflake/Param.hpp
+++ b/include/snowflake/Param.hpp
@@ -15,21 +15,21 @@ namespace Snowflake {
 
             ~Param();
 
-            size_t len();
+            size_t length();
 
-            void set_len(size_t len_);
+            void setLength(size_t len_);
 
             SF_DB_TYPE dbDataType();
 
-            void set_dbDataType(SF_DB_TYPE type_);
+            void setDbDataType(SF_DB_TYPE type_);
 
             SF_C_TYPE cDataType();
 
-            void set_cDataType(SF_C_TYPE type_);
+            void setCDataType(SF_C_TYPE type_);
 
             void* value();
             
-            void set_value(void *value_, SF_C_TYPE type_);
+            void setValue(void *value_, SF_C_TYPE type_);
 
         private:
             SF_BIND_INPUT m_param;

--- a/include/snowflake/Statement.hpp
+++ b/include/snowflake/Statement.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_SNOWFLAKESTATEMENT_HPP
+#define SNOWFLAKECLIENT_SNOWFLAKESTATEMENT_HPP
+
+#include <string>
+#include "client.h"
+#include "Connection.hpp"
+#include "Column.hpp"
+#include "Param.hpp"
+
+namespace Snowflake {
+    namespace Client {
+        class Statement {
+        public:
+
+            Statement(Connection &connection_);
+
+            ~Statement(void);
+
+            void query(const std::string &command_);
+
+            int64 affectedRows();
+
+            uint64 numRows();
+
+            uint64 numFields();
+
+            const char *sqlState();
+
+            SF_COLUMN_DESC *desc();
+
+            void prepare(const std::string &command_);
+
+            void setAttribute(SF_STMT_ATTRIBUTE type_,
+                                                    const void *value);
+
+            void getAttribute(SF_STMT_ATTRIBUTE type_,
+                                                    void **value);
+
+            void execute();
+
+            SF_STATUS fetch();
+
+            uint64 numParams();
+
+            Param& param(size_t i);
+
+            // TODO add method parameters to create a SF_BIND_INPUT
+            Param& createParam();
+
+            void destroyParams();
+
+            Column& column(size_t i);
+
+            const char *sfqid();
+
+            const std::string err_msg();
+
+        private:
+            // C API struct to operate on
+            SF_STMT *m_stmt;
+            // Pointer to the connection object that the statement struct will to
+            // connect to Snowflake.
+            Connection *m_connection;
+            // Array of pointers to created columns
+            Column **m_columns;
+            // Array of pointers to created parameters
+            Param **m_params;
+        };
+    }
+}
+
+
+#endif //SNOWFLAKECLIENT_SNOWFLAKESTATEMENT_HPP

--- a/include/snowflake/Statement.hpp
+++ b/include/snowflake/Statement.hpp
@@ -57,7 +57,7 @@ namespace Snowflake {
 
             const char *sfqid();
 
-            const std::string err_msg();
+            const std::string errMsg();
 
         private:
             // C API struct to operate on

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -65,21 +65,21 @@ extern "C" {
  *
  * Use snowflake_type_to_string to get the string representation.
  */
-typedef enum SF_TYPE {
-    SF_TYPE_FIXED,
-    SF_TYPE_REAL,
-    SF_TYPE_TEXT,
-    SF_TYPE_DATE,
-    SF_TYPE_TIMESTAMP_LTZ,
-    SF_TYPE_TIMESTAMP_NTZ,
-    SF_TYPE_TIMESTAMP_TZ,
-    SF_TYPE_VARIANT,
-    SF_TYPE_OBJECT,
-    SF_TYPE_ARRAY,
-    SF_TYPE_BINARY,
-    SF_TYPE_TIME,
-    SF_TYPE_BOOLEAN
-} SF_TYPE;
+typedef enum SF_DB_TYPE {
+    SF_DB_TYPE_FIXED,
+    SF_DB_TYPE_REAL,
+    SF_DB_TYPE_TEXT,
+    SF_DB_TYPE_DATE,
+    SF_DB_TYPE_TIMESTAMP_LTZ,
+    SF_DB_TYPE_TIMESTAMP_NTZ,
+    SF_DB_TYPE_TIMESTAMP_TZ,
+    SF_DB_TYPE_VARIANT,
+    SF_DB_TYPE_OBJECT,
+    SF_DB_TYPE_ARRAY,
+    SF_DB_TYPE_BINARY,
+    SF_DB_TYPE_TIME,
+    SF_DB_TYPE_BOOLEAN
+} SF_DB_TYPE;
 
 /**
  * C data types
@@ -283,7 +283,7 @@ typedef struct SF_CONNECT {
  */
 typedef struct SF_COLUMN_DESC {
     char *name;
-    SF_TYPE type;
+    SF_DB_TYPE type;
     SF_C_TYPE c_type;
     int64 byte_size;
     int64 internal_size;
@@ -334,7 +334,7 @@ typedef struct {
     SF_C_TYPE c_type; /* input data type in C */
     void *value; /* input value */
     size_t len; /* input value length. valid only for SF_C_TYPE_STRING */
-    SF_TYPE type; /* (optional) target Snowflake data type */
+    SF_DB_TYPE type; /* (optional) target Snowflake data type */
 } SF_BIND_INPUT;
 
 /**
@@ -660,7 +660,7 @@ const char *STDCALL snowflake_sfqid(SF_STMT *sfstmt);
  * @param type SF_TYPE enum
  * @return a string representation of Snowflake Type
  */
-const char *STDCALL snowflake_type_to_string(SF_TYPE type);
+const char *STDCALL snowflake_type_to_string(SF_DB_TYPE type);
 
 /**
  * Converts Snowflake C Type enum value to a string representation

--- a/lib/client.c
+++ b/lib/client.c
@@ -163,7 +163,7 @@ static void log_lock_func(void *udata, int lock) {
  * @return SF_BOOLEAN_TRUE if success otherwise SF_BOOLEAN_FALSE
  */
 static sf_bool _extract_timestamp(
-    SF_BIND_OUTPUT *result, SF_TYPE sftype,
+    SF_BIND_OUTPUT *result, SF_DB_TYPE sftype,
     const char *src, const char *timezone, int64 scale) {
     time_t nsec = 0L;
     time_t sec = 0L;
@@ -196,7 +196,7 @@ static sf_bool _extract_timestamp(
     }
     log_info("sec: %lld, nsec: %lld", sec, nsec);
 
-    if (sftype == SF_TYPE_TIMESTAMP_TZ) {
+    if (sftype == SF_DB_TYPE_TIMESTAMP_TZ) {
         /* make up Timezone name from the tzoffset */
         ldiv_t dm = ldiv((long) tzoffset, 60L);
         sprintf(tzname, "UTC%c%02ld:%02ld",
@@ -205,11 +205,11 @@ static sf_bool _extract_timestamp(
     }
 
     /* replace a dot character with NULL */
-    if (sftype == SF_TYPE_TIMESTAMP_NTZ ||
-        sftype == SF_TYPE_TIME) {
+    if (sftype == SF_DB_TYPE_TIMESTAMP_NTZ ||
+        sftype == SF_DB_TYPE_TIME) {
         tm_ptr = sf_gmtime(&sec, &tm_obj);
-    } else if (sftype == SF_TYPE_TIMESTAMP_LTZ ||
-               sftype == SF_TYPE_TIMESTAMP_TZ) {
+    } else if (sftype == SF_DB_TYPE_TIMESTAMP_LTZ ||
+               sftype == SF_DB_TYPE_TIMESTAMP_TZ) {
         /* set the environment variable TZ to the session timezone
          * so that localtime_tz honors it.
          */
@@ -232,7 +232,7 @@ static sf_bool _extract_timestamp(
         return SF_BOOLEAN_FALSE;
     }
     const char *fmt0;
-    if (sftype != SF_TYPE_TIME) {
+    if (sftype != SF_DB_TYPE_TIME) {
         fmt0 = "%Y-%m-%d %H:%M:%S";
     } else {
         fmt0 = "%H:%M:%S";
@@ -248,7 +248,7 @@ static sf_bool _extract_timestamp(
             result->max_length - result->len, fmt,
             nsec);
     }
-    if (sftype == SF_TYPE_TIMESTAMP_TZ) {
+    if (sftype == SF_DB_TYPE_TIMESTAMP_TZ) {
         /* Timezone info */
         ldiv_t dm = ldiv((long) tzoffset, 60L);
         result->len += snprintf(
@@ -1318,7 +1318,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
         switch (result->c_type) {
             case SF_C_TYPE_INT8:
                 switch (sfstmt->desc[i].type) {
-                    case SF_TYPE_BOOLEAN:
+                    case SF_DB_TYPE_BOOLEAN:
                         *(int8 *) result->value = cJSON_IsTrue(raw_result)
                                                   ? SF_BOOLEAN_TRUE
                                                   : SF_BOOLEAN_FALSE;
@@ -1351,7 +1351,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
                 break;
             case SF_C_TYPE_STRING:
                 switch (sfstmt->desc[i].type) {
-                    case SF_TYPE_BOOLEAN:
+                    case SF_DB_TYPE_BOOLEAN:
                         log_info("value: %p, max_length: %lld, len: %lld",
                                  result->value, result->max_length,
                                  result->len);
@@ -1367,7 +1367,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
                             result->len = sizeof(SF_BOOLEAN_TRUE_STR) - 1;
                         }
                         break;
-                    case SF_TYPE_DATE:
+                    case SF_DB_TYPE_DATE:
                         sec =
                             (time_t) strtol(raw_result->valuestring, NULL, 10) *
                             86400L;
@@ -1386,10 +1386,10 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
                             result->value, result->max_length,
                             "%Y-%m-%d", &tm_obj);
                         break;
-                    case SF_TYPE_TIME:
-                    case SF_TYPE_TIMESTAMP_NTZ:
-                    case SF_TYPE_TIMESTAMP_LTZ:
-                    case SF_TYPE_TIMESTAMP_TZ:
+                    case SF_DB_TYPE_TIME:
+                    case SF_DB_TYPE_TIMESTAMP_NTZ:
+                    case SF_DB_TYPE_TIMESTAMP_LTZ:
+                    case SF_DB_TYPE_TIMESTAMP_TZ:
                         if (!_extract_timestamp(
                             result,
                             sfstmt->desc[i].type,
@@ -1587,7 +1587,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
             }
             // TODO check if input is null and either set error or write msg to log
             type = snowflake_type_to_string(
-                c_type_to_snowflake(input->c_type, SF_TYPE_TIMESTAMP_NTZ));
+                c_type_to_snowflake(input->c_type, SF_DB_TYPE_TIMESTAMP_NTZ));
             value = value_to_string(input->value, input->len, input->c_type);
             binding = cJSON_CreateObject();
             char idxbuf[20];

--- a/lib/results.c
+++ b/lib/results.c
@@ -32,66 +32,66 @@ static size_t _bin2hex(
     return dlen;
 }
 
-SF_TYPE string_to_snowflake_type(const char *string) {
+SF_DB_TYPE string_to_snowflake_type(const char *string) {
     if (strcmp(string, "fixed") == 0) {
-        return SF_TYPE_FIXED;
+        return SF_DB_TYPE_FIXED;
     } else if (strcmp(string, "real") == 0) {
-        return SF_TYPE_REAL;
+        return SF_DB_TYPE_REAL;
     } else if (strcmp(string, "text") == 0) {
-        return SF_TYPE_TEXT;
+        return SF_DB_TYPE_TEXT;
     } else if (strcmp(string, "date") == 0) {
-        return SF_TYPE_DATE;
+        return SF_DB_TYPE_DATE;
     } else if (strcmp(string, "timestamp_ltz") == 0) {
-        return SF_TYPE_TIMESTAMP_LTZ;
+        return SF_DB_TYPE_TIMESTAMP_LTZ;
     } else if (strcmp(string, "timestamp_ntz") == 0) {
-        return SF_TYPE_TIMESTAMP_NTZ;
+        return SF_DB_TYPE_TIMESTAMP_NTZ;
     } else if (strcmp(string, "timestamp_tz") == 0) {
-        return SF_TYPE_TIMESTAMP_TZ;
+        return SF_DB_TYPE_TIMESTAMP_TZ;
     } else if (strcmp(string, "variant") == 0) {
-        return SF_TYPE_VARIANT;
+        return SF_DB_TYPE_VARIANT;
     } else if (strcmp(string, "object") == 0) {
-        return SF_TYPE_OBJECT;
+        return SF_DB_TYPE_OBJECT;
     } else if (strcmp(string, "array") == 0) {
-        return SF_TYPE_ARRAY;
+        return SF_DB_TYPE_ARRAY;
     } else if (strcmp(string, "binary") == 0) {
-        return SF_TYPE_BINARY;
+        return SF_DB_TYPE_BINARY;
     } else if (strcmp(string, "time") == 0) {
-        return SF_TYPE_TIME;
+        return SF_DB_TYPE_TIME;
     } else if (strcmp(string, "boolean") == 0) {
-        return SF_TYPE_BOOLEAN;
+        return SF_DB_TYPE_BOOLEAN;
     } else {
         // Everybody loves a string, so lets return it by default
-        return SF_TYPE_TEXT;
+        return SF_DB_TYPE_TEXT;
     }
 }
 
-const char *STDCALL snowflake_type_to_string(SF_TYPE type) {
+const char *STDCALL snowflake_type_to_string(SF_DB_TYPE type) {
     switch (type) {
-        case SF_TYPE_FIXED:
+        case SF_DB_TYPE_FIXED:
             return "FIXED";
-        case SF_TYPE_REAL:
+        case SF_DB_TYPE_REAL:
             return "REAL";
-        case SF_TYPE_TEXT:
+        case SF_DB_TYPE_TEXT:
             return "TEXT";
-        case SF_TYPE_DATE:
+        case SF_DB_TYPE_DATE:
             return "DATE";
-        case SF_TYPE_TIMESTAMP_LTZ:
+        case SF_DB_TYPE_TIMESTAMP_LTZ:
             return "TIMESTAMP_LTZ";
-        case SF_TYPE_TIMESTAMP_NTZ:
+        case SF_DB_TYPE_TIMESTAMP_NTZ:
             return "TIMESTAMP_NTZ";
-        case SF_TYPE_TIMESTAMP_TZ:
+        case SF_DB_TYPE_TIMESTAMP_TZ:
             return "TIMESTAMP_TZ";
-        case SF_TYPE_VARIANT:
+        case SF_DB_TYPE_VARIANT:
             return "VARIANT";
-        case SF_TYPE_OBJECT:
+        case SF_DB_TYPE_OBJECT:
             return "OBJECT";
-        case SF_TYPE_ARRAY:
+        case SF_DB_TYPE_ARRAY:
             return "ARRAY";
-        case SF_TYPE_BINARY:
+        case SF_DB_TYPE_BINARY:
             return "BINARY";
-        case SF_TYPE_TIME:
+        case SF_DB_TYPE_TIME:
             return "TIME";
-        case SF_TYPE_BOOLEAN:
+        case SF_DB_TYPE_BOOLEAN:
             return "BOOLEAN";
         default:
             return "TEXT";
@@ -124,27 +124,27 @@ const char * STDCALL snowflake_c_type_to_string(SF_C_TYPE type) {
 }
 
 
-SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale) {
-    if (type == SF_TYPE_FIXED) {
+SF_C_TYPE snowflake_to_c_type(SF_DB_TYPE type, int64 precision, int64 scale) {
+    if (type == SF_DB_TYPE_FIXED) {
         if (scale > 0 || precision >= 19) {
             return SF_C_TYPE_FLOAT64;
         } else {
             return SF_C_TYPE_INT64;
         }
-    } else if (type == SF_TYPE_REAL) {
+    } else if (type == SF_DB_TYPE_REAL) {
         return SF_C_TYPE_FLOAT64;
-    } else if (type == SF_TYPE_TIMESTAMP_LTZ ||
-            type == SF_TYPE_TIMESTAMP_NTZ ||
-            type == SF_TYPE_TIMESTAMP_TZ) {
+    } else if (type == SF_DB_TYPE_TIMESTAMP_LTZ ||
+            type == SF_DB_TYPE_TIMESTAMP_NTZ ||
+            type == SF_DB_TYPE_TIMESTAMP_TZ) {
         return SF_C_TYPE_TIMESTAMP;
-    } else if (type == SF_TYPE_BOOLEAN) {
+    } else if (type == SF_DB_TYPE_BOOLEAN) {
         return SF_C_TYPE_BOOLEAN;
-    } else if (type == SF_TYPE_TEXT ||
-            type == SF_TYPE_VARIANT ||
-            type == SF_TYPE_OBJECT ||
-            type == SF_TYPE_ARRAY) {
+    } else if (type == SF_DB_TYPE_TEXT ||
+            type == SF_DB_TYPE_VARIANT ||
+            type == SF_DB_TYPE_OBJECT ||
+            type == SF_DB_TYPE_ARRAY) {
         return SF_C_TYPE_STRING;
-    } else if (type == SF_TYPE_BINARY) {
+    } else if (type == SF_DB_TYPE_BINARY) {
         return SF_C_TYPE_BINARY;
     } else {
         // by default return string, since we can do everything with a string
@@ -152,28 +152,28 @@ SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale) {
     }
 }
 
-SF_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_TYPE tsmode) {
+SF_DB_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_DB_TYPE tsmode) {
     switch (c_type) {
         case SF_C_TYPE_INT8:
-            return SF_TYPE_FIXED;
+            return SF_DB_TYPE_FIXED;
         case SF_C_TYPE_UINT8:
-            return SF_TYPE_FIXED;
+            return SF_DB_TYPE_FIXED;
         case SF_C_TYPE_INT64:
-            return SF_TYPE_FIXED;
+            return SF_DB_TYPE_FIXED;
         case SF_C_TYPE_UINT64:
-            return SF_TYPE_FIXED;
+            return SF_DB_TYPE_FIXED;
         case SF_C_TYPE_FLOAT64:
-            return SF_TYPE_REAL;
+            return SF_DB_TYPE_REAL;
         case SF_C_TYPE_STRING:
-            return SF_TYPE_TEXT;
+            return SF_DB_TYPE_TEXT;
         case SF_C_TYPE_TIMESTAMP:
             return tsmode;
         case SF_C_TYPE_BOOLEAN:
-            return SF_TYPE_BOOLEAN;
+            return SF_DB_TYPE_BOOLEAN;
         case SF_C_TYPE_BINARY:
-            return SF_TYPE_BINARY;
+            return SF_DB_TYPE_BINARY;
         default:
-            return SF_TYPE_TEXT;
+            return SF_DB_TYPE_TEXT;
     }
 }
 
@@ -274,7 +274,7 @@ SF_COLUMN_DESC * set_description(const cJSON *rowtype) {
             desc[i].type = string_to_snowflake_type(blob->valuestring);
         } else {
             // TODO Replace with default type
-            desc[i].type = SF_TYPE_FIXED;
+            desc[i].type = SF_DB_TYPE_FIXED;
         }
         desc[i].c_type = snowflake_to_c_type(desc[i].type, desc[i].precision, desc[i].scale);
         log_debug("Found type and ctype; %i: %i", desc[i].type, desc[i].c_type);

--- a/lib/results.h
+++ b/lib/results.h
@@ -13,9 +13,9 @@ extern "C" {
 #include "snowflake/platform.h"
 #include "cJSON.h"
 
-SF_TYPE string_to_snowflake_type(const char *string);
-SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale);
-SF_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_TYPE tsmode);
+SF_DB_TYPE string_to_snowflake_type(const char *string);
+SF_C_TYPE snowflake_to_c_type(SF_DB_TYPE type, int64 precision, int64 scale);
+SF_DB_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_DB_TYPE tsmode);
 char *value_to_string(void *value, size_t len, SF_C_TYPE c_type);
 SF_COLUMN_DESC * set_description(const cJSON *rowtype);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,11 +45,15 @@ SET(TESTS_CXX
         test_unit_file_type_detect
         test_unit_stream_splitter
         test_unit_thread_pool
-        )
+        test_cpp_select1)
 
 set(SOURCE_UTILS
         utils/test_setup.c
         utils/test_setup.h)
+
+set(SOURCE_UTILS_CXX
+        utils/TestSetup.cpp
+        utils/TestSetup.hpp)
 
 if (UNIX)
     find_library(CMOCKA_LIB libcmocka.a PATHS ../deps-build/${PLATFORM}/cmocka/lib/ REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,7 +100,7 @@ ENDFOREACH ()
 
 if (LINUX)
     FOREACH(T ${TESTS_CXX})
-        add_executable(${T} ${SOURCE_UTILS} ${T}.cpp)
+        add_executable(${T} ${SOURCE_UTILS} ${SOURCE_UTILS_CXX} ${T}.cpp)
         target_include_directories(
                 ${T} PUBLIC
                 ../deps-build/${PLATFORM}/cmocka/include

--- a/tests/test_cpp_select1.cpp
+++ b/tests/test_cpp_select1.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include "utils/test_setup.h"
+#include "utils/TestSetup.hpp"
+
+void test_select1_cpp(void **unused) {
+    Snowflake::Client::Connection *cnx = TestSetup::connectionFactory();
+    SF_STATUS status;
+
+    try {
+        cnx->connect();
+        Snowflake::Client::Statement *stmt = new Snowflake::Client::Statement(*cnx);
+        std::string command("select 1;");
+        stmt->query(command);
+
+        int counter = 0;
+        while ((status = stmt->fetch()) == SF_STATUS_SUCCESS) {
+            assert_int_equal(stmt->column(1).asInt32(), 1);
+            ++counter;
+        }
+        //assert_int_equal(status, SF_STATUS_EOF);
+
+        delete stmt;
+        delete cnx;
+    } catch (...) /* Catch all error handler */ {
+        // Handle errors
+    }
+}
+
+int main(void) {
+    initialize_test(SF_BOOLEAN_FALSE);
+    const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_select1_cpp),
+    };
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    snowflake_global_term();
+    return ret;
+}

--- a/tests/test_crud.c
+++ b/tests/test_crud.c
@@ -44,7 +44,7 @@ void _fetch_data(SF_STMT *sfstmt, int64 expected_sum) {
         switch (i) {
             case 0:
                 assert_string_equal(descs[i].name, "C1");
-                assert_int_equal(descs[i].type, SF_TYPE_FIXED);
+                assert_int_equal(descs[i].type, SF_DB_TYPE_FIXED);
                 assert_int_equal(descs[i].c_type, SF_C_TYPE_INT64);
                 assert_int_equal(descs[i].byte_size, 0);
                 assert_int_equal(descs[i].internal_size, 0);
@@ -54,7 +54,7 @@ void _fetch_data(SF_STMT *sfstmt, int64 expected_sum) {
                 break;
             case 1:
                 assert_string_equal(descs[i].name, "C2");
-                assert_int_equal(descs[i].type, SF_TYPE_TEXT);
+                assert_int_equal(descs[i].type, SF_DB_TYPE_TEXT);
                 assert_int_equal(descs[i].c_type, SF_C_TYPE_STRING);
                 assert_int_equal(descs[i].byte_size, 16777216);
                 assert_int_equal(descs[i].internal_size, 16777216);

--- a/tests/utils/TestSetup.cpp
+++ b/tests/utils/TestSetup.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <cstdlib>
+#include "TestSetup.hpp"
+
+Snowflake::Client::Connection* TestSetup::connectionFactory() {
+    return TestSetup::connectionWithAutocommitFactory("UTC", true);
+}
+
+Snowflake::Client::Connection* TestSetup::connectionWithAutocommitFactory(const std::string timezone,
+                                                                          bool autocommit) {
+    Snowflake::Client::Connection *cnx = new Snowflake::Client::Connection();
+
+    cnx->setAttribute(SF_CON_ACCOUNT,
+                      getenv("SNOWFLAKE_TEST_ACCOUNT"));
+    cnx->setAttribute(SF_CON_USER,
+                      getenv("SNOWFLAKE_TEST_USER"));
+    cnx->setAttribute(SF_CON_PASSWORD,
+                      getenv("SNOWFLAKE_TEST_PASSWORD"));
+    cnx->setAttribute(SF_CON_DATABASE,
+                      getenv("SNOWFLAKE_TEST_DATABASE"));
+    cnx->setAttribute(SF_CON_SCHEMA,
+                      getenv("SNOWFLAKE_TEST_SCHEMA"));
+    cnx->setAttribute(SF_CON_ROLE,
+                      getenv("SNOWFLAKE_TEST_ROLE"));
+    cnx->setAttribute(SF_CON_WAREHOUSE,
+                      getenv("SNOWFLAKE_TEST_WAREHOUSE"));
+    cnx->setAttribute(SF_CON_AUTOCOMMIT,
+                      &autocommit);
+    cnx->setAttribute(SF_CON_TIMEZONE,
+                      timezone.c_str());
+    char *host, *port, *protocol;
+    host = getenv("SNOWFLAKE_TEST_HOST");
+    if (host) {
+        cnx->setAttribute(SF_CON_HOST, host);
+    }
+    port = getenv("SNOWFLAKE_TEST_PORT");
+    if (port) {
+        cnx->setAttribute(SF_CON_PORT, port);
+    }
+    protocol = getenv("SNOWFLAKE_TEST_PROTOCOL");
+    if (protocol) {
+        cnx->setAttribute(SF_CON_PROTOCOL, protocol);
+    }
+    return cnx;
+}

--- a/tests/utils/TestSetup.hpp
+++ b/tests/utils/TestSetup.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_TESTSETUP_HPP
+#define SNOWFLAKECLIENT_TESTSETUP_HPP
+
+#include <snowflake/client.h>
+#include <snowflake/Connection.hpp>
+#include <snowflake/Statement.hpp>
+
+class TestSetup {
+public:
+    static Snowflake::Client::Connection *connectionFactory();
+
+    static Snowflake::Client::Connection *connectionWithAutocommitFactory(const std::string timezone,
+                                                                   bool autocommit);
+
+private:
+    TestSetup() {};
+};
+
+
+#endif //SNOWFLAKECLIENT_TESTSETUP_HPP


### PR DESCRIPTION
Added basic C++ Wrapper API. An example of how the API works is shown in "test_cpp_select1.cpp". Updated SF_TYPE to SF_DB_TYPE to solve naming conflict with Windows.