### PR TITLE
Add realloc memory hook for fetching data

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -215,7 +215,7 @@ typedef enum SF_GLOBAL_ATTRIBUTE {
  * Attributes for Snowflake statement context.
  */
 typedef enum SF_STMT_ATTRIBUTE {
-    INTERNAL
+    SF_STMT_USER_REALLOC_FUNC
 } SF_STMT_ATTRIBUTE;
 
 /**
@@ -322,6 +322,12 @@ typedef struct SF_STMT {
     SF_COLUMN_DESC *desc;
     void *stmt_attrs;
     sf_bool is_dml;
+
+    /**
+     * User realloc function used in snowflake_fetch
+     */
+    void *(*user_realloc_func)(void*, size_t);
+
     SF_CHUNK_DOWNLOADER *chunk_downloader;
     SF_PUT_GET_RESPONSE *put_get_response;
 } SF_STMT;
@@ -577,7 +583,7 @@ snowflake_stmt_set_attr(SF_STMT *sfstmt, SF_STMT_ATTRIBUTE type,
  * @return 0 if success, otherwise an errno is returned.
  */
 SF_STATUS STDCALL
-snowflake_stmt_get_attr(SF_STMT *sfstmt, SF_STMT_ATTRIBUTE type, void *value);
+snowflake_stmt_get_attr(SF_STMT *sfstmt, SF_STMT_ATTRIBUTE type, void **value);
 
 /**
  * Executes a statement.

--- a/lib/client.c
+++ b/lib/client.c
@@ -1407,10 +1407,9 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
                         break;
                     default:
                         slen = strlen(raw_result->valuestring);
-                        log_debug("slen: %llu, buflen: %llu:%llu, realloc: %p",
-                                     (unsigned long)slen,
+                        log_debug("slen: %llu, maxbuflen: %llu, realloc func: %p",
+                                     slen,
                                      result->max_length,
-                                     result->len,
                                      (void*)sfstmt->user_realloc_func);
                         result->len = slen;
                         if (sfstmt->user_realloc_func != NULL &&

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ SET(TESTS_C
         test_timestamp_ltz
         test_timestamp_tz
         test_timezone
+        test_adjust_fetch_data
         )
 
 SET(TESTS_CXX

--- a/tests/data/.gitignore
+++ b/tests/data/.gitignore
@@ -1,0 +1,1 @@
+test_parallel_upload

--- a/tests/test_adjust_fetch_data.c
+++ b/tests/test_adjust_fetch_data.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing, Inc. All rights reserved.
+ */
+#include <string.h>
+#include "utils/test_setup.h"
+
+/**
+ * Test SF_STMT_USER_REALLOC_FUNC, which reallocates a larger memory
+ * in case the given memory size is not large enough.
+ * @param unused
+ */
+void test_select_long_data_with_small_initial_buffer(void **unused) {
+    SF_CONNECT *sf = setup_snowflake_connection();
+    SF_STATUS status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sf->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    /* query */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+
+    // realloc function is used to allocate a new memory when the given buffer
+    // size is not large enough to fit.
+    snowflake_stmt_set_attr(sfstmt, SF_STMT_USER_REALLOC_FUNC, realloc);
+
+    status = snowflake_query(sfstmt, "select randstr(100,random()) from table(generator(rowcount=>2))", 0);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    size_t init_size = 10;
+    SF_BIND_OUTPUT c1 = {
+        .idx = 1,
+        .c_type = SF_C_TYPE_STRING,
+        .value = calloc(1, init_size),
+        .len = init_size,
+        .max_length = init_size
+    };
+    snowflake_bind_result(sfstmt, &c1);
+    assert_int_equal(snowflake_num_rows(sfstmt), 2);
+
+    int counter = 0;
+    while ((status = snowflake_fetch(sfstmt)) == SF_STATUS_SUCCESS) {
+        assert_int_equal(strlen(c1.value), 100);
+        ++counter;
+    }
+    if (status != SF_STATUS_EOF) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_EOF);
+    free(c1.value);
+    snowflake_stmt_term(sfstmt);
+    snowflake_term(sf);
+}
+
+int main(void) {
+    initialize_test(SF_BOOLEAN_FALSE);
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_select_long_data_with_small_initial_buffer),
+    };
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    snowflake_global_term();
+    return ret;
+}


### PR DESCRIPTION
This is an enhancement for PDO for Snowflake to fix:

https://github.com/snowflakedb/pdo_snowflake/issues/148

The problem is if multiple columns use STRING data type, and you fetch data, the size of buffers are allocated to the number of columns multiplied by 16MB, too much memory consumption.
It is due to the C API design, which enforces the applications to provider buffer before fetching data.

The fix is have `snowflake_fetch` function reallocate the memory if the given maximum buffer size is not large enough and return the new pointer. It is achieved by the statement attribute `SF_STMT_USER_REALLOC_FUNC` that is called.