### PR TITLE
Fixed PUT/GET Detection

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -1857,6 +1857,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
         }
     } else {
         log_trace("Connection failed");
+        goto cleanup;
     }
 
     // Everything went well if we got to this point

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -137,37 +137,37 @@ cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
 
     //Create Client Environment JSON blob
     client_env = snowflake_cJSON_CreateObject();
-  snowflake_cJSON_AddStringToObject(client_env, "APPLICATION", application);
-  snowflake_cJSON_AddStringToObject(client_env, "OS", sf_os_name());
+    snowflake_cJSON_AddStringToObject(client_env, "APPLICATION", application);
+    snowflake_cJSON_AddStringToObject(client_env, "OS", sf_os_name());
     sf_os_version(os_version);
-  snowflake_cJSON_AddStringToObject(client_env, "OS_VERSION", os_version);
+    snowflake_cJSON_AddStringToObject(client_env, "OS_VERSION", os_version);
 
     session_parameters = snowflake_cJSON_CreateObject();
-  snowflake_cJSON_AddStringToObject(
-    session_parameters,
-    "AUTOCOMMIT",
-    autocommit == SF_BOOLEAN_TRUE ? SF_BOOLEAN_INTERNAL_TRUE_STR
-                                  : SF_BOOLEAN_INTERNAL_FALSE_STR);
+    snowflake_cJSON_AddStringToObject(
+        session_parameters,
+        "AUTOCOMMIT",
+        autocommit == SF_BOOLEAN_TRUE ? SF_BOOLEAN_INTERNAL_TRUE_STR
+                                      : SF_BOOLEAN_INTERNAL_FALSE_STR);
 
-  snowflake_cJSON_AddStringToObject(session_parameters, "TIMEZONE", timezone);
+    snowflake_cJSON_AddStringToObject(session_parameters, "TIMEZONE", timezone);
 
     //Create Request Data JSON blob
     data = snowflake_cJSON_CreateObject();
-  snowflake_cJSON_AddStringToObject(data, "CLIENT_APP_ID", int_app_name);
-  snowflake_cJSON_AddStringToObject(data, "CLIENT_APP_VERSION", int_app_version);
-  snowflake_cJSON_AddStringToObject(data, "ACCOUNT_NAME", sf->account);
-  snowflake_cJSON_AddStringToObject(data, "LOGIN_NAME", sf->user);
+    snowflake_cJSON_AddStringToObject(data, "CLIENT_APP_ID", int_app_name);
+    snowflake_cJSON_AddStringToObject(data, "CLIENT_APP_VERSION", int_app_version);
+    snowflake_cJSON_AddStringToObject(data, "ACCOUNT_NAME", sf->account);
+    snowflake_cJSON_AddStringToObject(data, "LOGIN_NAME", sf->user);
     // Add password if one exists
     if (sf->password && *(sf->password)) {
-      snowflake_cJSON_AddStringToObject(data, "PASSWORD", sf->password);
+        snowflake_cJSON_AddStringToObject(data, "PASSWORD", sf->password);
     }
-  snowflake_cJSON_AddItemToObject(data, "CLIENT_ENVIRONMENT", client_env);
-  snowflake_cJSON_AddItemToObject(data, "SESSION_PARAMETERS",
+    snowflake_cJSON_AddItemToObject(data, "CLIENT_ENVIRONMENT", client_env);
+    snowflake_cJSON_AddItemToObject(data, "SESSION_PARAMETERS",
                                   session_parameters);
 
     //Create body
     body = snowflake_cJSON_CreateObject();
-  snowflake_cJSON_AddItemToObject(body, "data", data);
+    snowflake_cJSON_AddItemToObject(body, "data", data);
 
 
     return body;
@@ -177,12 +177,13 @@ cJSON *STDCALL create_query_json_body(const char *sql_text, int64 sequence_id, c
     cJSON *body;
     // Create body
     body = snowflake_cJSON_CreateObject();
-  snowflake_cJSON_AddStringToObject(body, "sqlText", sql_text);
-  snowflake_cJSON_AddBoolToObject(body, "asyncExec", SF_BOOLEAN_FALSE);
-  snowflake_cJSON_AddNumberToObject(body, "sequenceId", (double) sequence_id);
+    snowflake_cJSON_AddStringToObject(body, "sqlText", sql_text);
+    snowflake_cJSON_AddBoolToObject(body, "asyncExec", SF_BOOLEAN_FALSE);
+    snowflake_cJSON_AddNumberToObject(body, "sequenceId", (double) sequence_id);
+    snowflake_cJSON_AddNumberToObject(body, "querySubmissionTime", (double) time(NULL) * 1000);
     if (request_id)
     {
-      snowflake_cJSON_AddStringToObject(body, "requestId", request_id);
+        snowflake_cJSON_AddStringToObject(body, "requestId", request_id);
     }
     return body;
 }
@@ -191,8 +192,8 @@ cJSON *STDCALL create_renew_session_json_body(const char *old_token) {
     cJSON *body;
     // Create body
     body = snowflake_cJSON_CreateObject();
-  snowflake_cJSON_AddStringToObject(body, "oldSessionToken", old_token);
-  snowflake_cJSON_AddStringToObject(body, "requestType", REQUEST_TYPE_RENEW);
+    snowflake_cJSON_AddStringToObject(body, "oldSessionToken", old_token);
+    snowflake_cJSON_AddStringToObject(body, "requestType", REQUEST_TYPE_RENEW);
 
     return body;
 }

--- a/lib/platform.c
+++ b/lib/platform.c
@@ -365,7 +365,7 @@ sf_bool STDCALL _is_put_get_command(char *sql_text) {
     regex_t put_get_regex;
     // On MacOS seems \s to match white space character did not work. Change to '[ ]' for now
     //TODO maybe regex compilation should be moved to static variable so that no recompilation needed
-    regcomp(&put_get_regex, "^([ ]*\\/*.*\\/*[ ]*)*(put|get)[ ]+",
+    regcomp(&put_get_regex, "^([ ]*\\/\\*.*\\*\\/[ ]*)*([ ]*)*(put|get)[ ]+",
             REG_ICASE | REG_EXTENDED);
 
     int res;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ SET(TESTS_C
         test_timestamp_tz
         test_timezone
         test_adjust_fetch_data
+        test_issue_76
         )
 
 SET(TESTS_CXX

--- a/tests/test_issue_76.c
+++ b/tests/test_issue_76.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017-2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <string.h>
+#include "utils/test_setup.h"
+
+void test_issue_76(void **unused) {
+    SF_CONNECT *sf = setup_snowflake_connection();
+    SF_STATUS status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sf->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    /* query */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    status = snowflake_prepare(sfstmt, "CREATE OR REPLACE TABLE obfuscated_table_name (daily_input number(38,6))", 0);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+
+    status = snowflake_execute(sfstmt);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+    assert_int_equal(1, sfstmt->total_fieldcount);
+
+    snowflake_stmt_term(sfstmt);
+    snowflake_term(sf);
+}
+
+int main(void) {
+    initialize_test(SF_BOOLEAN_FALSE);
+    const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_issue_76),
+    };
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    snowflake_global_term();
+    return ret;
+}


### PR DESCRIPTION
Changed the regex string that does PUT/GET detection to reduce the number of false positives (queries that are labeled as PUT/GET queries but are not). Also fixed an issue where a query error would not get propagated to the user. Fixed some whitespace issues in connection.c