### PR TITLE
Fix a Base64 Decode bug

### DIFF
--- a/cpp/util/Base64.cpp
+++ b/cpp/util/Base64.cpp
@@ -47,7 +47,7 @@ std::vector<char> Base64::decodeURLNoPadding(const std::string &text)
   // Base 64 decode text
   size_t decode_len = Client::Util::Base64::decodedLength(in_text.length());
   std::vector<char> decoded(decode_len);
-  decode_len = Client::Util::Base64::decodeUrl(in_text.c_str(), in_text.length(), decoded.data());
+  decode_len = decodeUrl(in_text.c_str(), in_text.length(), decoded.data());
 
   if (decode_len == static_cast<size_t >(-1L))
   {
@@ -72,7 +72,7 @@ std::vector<char> Base64::decodePadding(const std::string &text)
   // Base 64 decode text
   size_t decode_len = Client::Util::Base64::decodedLength(text.length());
   std::vector<char> decoded(decode_len);
-  decode_len = Client::Util::Base64::decodeUrl(text.c_str(), text.length(), decoded.data());
+  decode_len = decode(text.c_str(), text.length(), decoded.data());
 
   if (decode_len == static_cast<size_t >(-1L))
   {

--- a/tests/test_unit_base64.cpp
+++ b/tests/test_unit_base64.cpp
@@ -150,11 +150,6 @@ private:
   }
 };
 
-inline std::string removePadding(const std::string &origin)
-{
-
-}
-
 static std::shared_ptr<Base64TestcaseI> testcasesPadding[] = {
   std::make_shared<Base64TestcaseStr>("eoqwiroiqnweropiqnweorinqwoepir",
                                       "ZW9xd2lyb2lxbndlcm9waXFud2VvcmlucXdvZXBpcg=="),

--- a/tests/test_unit_base64.cpp
+++ b/tests/test_unit_base64.cpp
@@ -22,7 +22,24 @@ struct Base64TestcaseI
   virtual size_t getEncodeLen() = 0;
   virtual const void *getDecode() = 0;
   virtual size_t getDecodeLen() = 0;
+
+  virtual std::vector<char> getDecodeVec() = 0;
+
+  virtual std::string getEncodeStr() = 0;
+
+  virtual std::string getEncodeStrNoPadding() = 0;
 };
+
+static std::string truncatePadding(const std::string &origin)
+{
+  if (origin.length() == 0)
+  {
+    return origin;
+  }
+  size_t end = origin.length() - 1;
+  while (origin[end] == '=') end--;
+  return std::string(origin.begin(), origin.begin() + end + 1);
+}
 
 /**
  * Implementation of Base64 test case using string as representation
@@ -47,6 +64,21 @@ struct Base64TestcaseStr : Base64TestcaseI
   inline size_t getDecodeLen()
   {
     return decode_.length();
+  }
+
+  inline std::vector<char> getDecodeVec()
+  {
+    return std::vector<char>(decode_.begin(), decode_.end());
+  }
+
+  inline std::string getEncodeStr()
+  {
+    return encode_;
+  }
+
+  inline std::string getEncodeStrNoPadding()
+  {
+    return truncatePadding(encode_);
   }
 
   Base64TestcaseStr(std::string decode, std::string encode) :
@@ -80,6 +112,21 @@ struct Base64TestcaseFile : Base64TestcaseI
     return decode_.size();
   }
 
+  inline std::vector<char> getDecodeVec()
+  {
+    return decode_;
+  }
+
+  inline std::string getEncodeStr()
+  {
+    return std::string(encode_.begin(), encode_.end());
+  }
+
+  inline std::string getEncodeStrNoPadding()
+  {
+    return truncatePadding(std::string(encode_.begin(), encode_.end()));
+  }
+
   Base64TestcaseFile(std::string decode_file_name, std::string encode_file_name) {
     decode_ = readAllBytes(decode_file_name);
     encode_ = readAllBytes(encode_file_name);
@@ -103,6 +150,21 @@ private:
   }
 };
 
+inline std::string removePadding(const std::string &origin)
+{
+
+}
+
+static std::shared_ptr<Base64TestcaseI> testcasesPadding[] = {
+  std::make_shared<Base64TestcaseStr>("eoqwiroiqnweropiqnweorinqwoepir",
+                                      "ZW9xd2lyb2lxbndlcm9waXFud2VvcmlucXdvZXBpcg=="),
+  std::make_shared<Base64TestcaseStr>("32421bjbsaf", "MzI0MjFiamJzYWY="),
+  std::make_shared<Base64TestcaseStr>("nfainwerq", "bmZhaW53ZXJx"),
+  std::make_shared<Base64TestcaseStr>("Snowflake is fxxkin great!!!", "U25vd2ZsYWtlIGlzIGZ4eGtpbiBncmVhdCEhIQ=="),
+  std::make_shared<Base64TestcaseStr>("asdfwerqewrsfasxc2312saDSFADF", "YXNkZndlcnFld3JzZmFzeGMyMzEyc2FEU0ZBREY="),
+  std::make_shared<Base64TestcaseFile>("decode", "encode"),
+};
+
 /**
  * Test the encode/decode function of base 64 
  * @param unused
@@ -111,16 +173,8 @@ void test_base64_coding(void **unused)
 {
   char result[1024];
 
-  std::shared_ptr<Base64TestcaseI> testcases[] = {
-    std::make_shared<Base64TestcaseStr>("eoqwiroiqnweropiqnweorinqwoepir", "ZW9xd2lyb2lxbndlcm9waXFud2VvcmlucXdvZXBpcg=="),
-    std::make_shared<Base64TestcaseStr>("32421bjbsaf", "MzI0MjFiamJzYWY="),
-    std::make_shared<Base64TestcaseStr>("nfainwerq", "bmZhaW53ZXJx"),
-    std::make_shared<Base64TestcaseStr>("Snowflake is fxxkin great!!!", "U25vd2ZsYWtlIGlzIGZ4eGtpbiBncmVhdCEhIQ=="),
-    std::make_shared<Base64TestcaseStr>("asdfwerqewrsfasxc2312saDSFADF", "YXNkZndlcnFld3JzZmFzeGMyMzEyc2FEU0ZBREY="),
-    std::make_shared<Base64TestcaseFile>("decode", "encode"),
-  };
-
-  for (auto &testcase : testcases) {
+  for (auto &testcase : testcasesPadding)
+  {
     const void *encode = testcase->getEncode();
     size_t encode_len = testcase->getEncodeLen();
     const void *decode = testcase->getDecode();
@@ -139,6 +193,57 @@ void test_base64_coding(void **unused)
 }
 
 /**
+ * Test the encode/decode cpp style function of base 64
+ * @param unused
+ */
+void test_base64_cpp_coding(void **)
+{
+  for (auto &testcase : testcasesPadding)
+  {
+    auto encodeExpect = testcase->getEncodeStr();
+    auto decodeExpect = testcase->getDecodeVec();
+
+    auto encodeActual = Base64::encodePadding(decodeExpect);
+    auto decodeActual = Base64::decodePadding(encodeExpect);
+
+    assert_string_equal(encodeActual.c_str(), encodeExpect.c_str());
+    assert_int_equal(decodeActual.size(), decodeExpect.size());
+    assert_memory_equal(decodeActual.data(), decodeExpect.data(), decodeActual.size());
+  }
+}
+
+static std::shared_ptr<Base64TestcaseI> testcasesURLPadding[] = {
+  std::make_shared<Base64TestcaseStr>("eoqwiroiqnweropiqnweorinqwoepir",
+                                      "ZW9xd2lyb2lxbndlcm9waXFud2VvcmlucXdvZXBpcg=="),
+  std::make_shared<Base64TestcaseStr>("32421bjbsaf", "MzI0MjFiamJzYWY="),
+  std::make_shared<Base64TestcaseStr>("nfainwerq", "bmZhaW53ZXJx"),
+  std::make_shared<Base64TestcaseStr>("Snowflake is fxxkin great!!!", "U25vd2ZsYWtlIGlzIGZ4eGtpbiBncmVhdCEhIQ=="),
+  std::make_shared<Base64TestcaseStr>("asdfwerqewrsfasxc2312saDSFADF", "YXNkZndlcnFld3JzZmFzeGMyMzEyc2FEU0ZBREY="),
+  std::make_shared<Base64TestcaseFile>("decode", "encode64"),
+};
+
+/**
+ * Test the encode/decode cpp style function of base 64 url with no padding
+ * @param unused
+ */
+void test_base64_url_cpp_coding(void **)
+{
+
+  for (auto &testcase : testcasesURLPadding)
+  {
+    auto encodeExpect = testcase->getEncodeStrNoPadding();
+    auto decodeExpect = testcase->getDecodeVec();
+
+    auto encodeActual = Base64::encodeURLNoPadding(decodeExpect);
+    auto decodeActual = Base64::decodeURLNoPadding(encodeExpect);
+
+    assert_string_equal(encodeActual.c_str(), encodeExpect.c_str());
+    assert_int_equal(decodeActual.size(), decodeExpect.size());
+    assert_memory_equal(decodeActual.data(), decodeExpect.data(), decodeActual.size());
+  }
+}
+
+/**
  * Test the encode/decode function of base 64 url
  * @param unused 
  */
@@ -146,16 +251,8 @@ void test_base64_url_coding(void **unused)
 {
   char result[1024];
 
-  std::shared_ptr<Base64TestcaseI> testcases[] = {
-    std::make_shared<Base64TestcaseStr>("eoqwiroiqnweropiqnweorinqwoepir", "ZW9xd2lyb2lxbndlcm9waXFud2VvcmlucXdvZXBpcg=="),
-    std::make_shared<Base64TestcaseStr>("32421bjbsaf", "MzI0MjFiamJzYWY="),
-    std::make_shared<Base64TestcaseStr>("nfainwerq", "bmZhaW53ZXJx"),
-    std::make_shared<Base64TestcaseStr>("Snowflake is fxxkin great!!!", "U25vd2ZsYWtlIGlzIGZ4eGtpbiBncmVhdCEhIQ=="),
-    std::make_shared<Base64TestcaseStr>("asdfwerqewrsfasxc2312saDSFADF", "YXNkZndlcnFld3JzZmFzeGMyMzEyc2FEU0ZBREY="),
-    std::make_shared<Base64TestcaseFile>("decode", "encode64"),
-  };
-
-  for (auto &testcase : testcases) {
+  for (auto &testcase : testcasesURLPadding)
+  {
     const void *encode = testcase->getEncode();
     size_t encode_len = testcase->getEncodeLen();
     const void *decode = testcase->getDecode();
@@ -176,7 +273,9 @@ void test_base64_url_coding(void **unused)
 int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_base64_coding),
+    cmocka_unit_test(test_base64_cpp_coding),
     cmocka_unit_test(test_base64_url_coding),
+    cmocka_unit_test(test_base64_url_cpp_coding),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
I made a typo on the cpp style Base64 decode method, specifically:
https://github.com/snowflakedb/libsnowflakeclient/compare/jwt?expand=1#diff-a4b11b74cdecb4aa697704b9d3a549b4L75

This PR corrected it and added test cases to verify that.