### PR TITLE
Proxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,19 +109,21 @@ set (SOURCE_FILES_PUT_GET
         cpp/StorageClientFactory.hpp
         cpp/StorageClientFactory.cpp
         cpp/RemoteStorageRequestOutcome.hpp
-        cpp/crypto/CryptoTypes.hpp
         cpp/util/Base64.hpp
         cpp/util/Base64.cpp
         cpp/util/ByteArrayStreamBuf.cpp
         cpp/util/ByteArrayStreamBuf.hpp
         cpp/util/CompressionUtil.cpp
         cpp/util/CompressionUtil.hpp
+        cpp/util/Proxy.hpp
+        cpp/util/Proxy.cpp
         cpp/util/ThreadPool.hpp
+        cpp/util/SnowflakeCommon.hpp
+        cpp/crypto/CryptoTypes.hpp
         cpp/crypto/Cryptor.hpp
         cpp/crypto/CipherContext.hpp
         cpp/crypto/CipherContext.cpp
         cpp/crypto/Cryptor.cpp
-        cpp/util/SnowflakeCommon.hpp
         cpp/crypto/CipherStreamBuf.cpp
         cpp/crypto/CipherStreamBuf.hpp
         cpp/crypto/HashContext.cpp

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -77,7 +77,8 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo, unsigned int parallel
   // Set Proxy
   if (!proxy.getMachine().empty()) {
     clientConfiguration.proxyHost = Aws::String(proxy.getMachine());
-    clientConfiguration.proxyScheme = !proxy.getScheme().compare("http") ? Aws::Http::Scheme::HTTP : Aws::Http::Scheme::HTTPS;
+    clientConfiguration.proxyScheme = proxy.getScheme() == Snowflake::Client::Util::Proxy::Protocol::HTTPS ?
+      Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
   }
   if (!proxy.getUser().empty() && !proxy.getPwd().empty()) {
     clientConfiguration.proxyUserName = proxy.getUser();

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -534,19 +534,21 @@ RemoteStorageRequestOutcome SnowflakeS3Client::GetRemoteFileMetadata(
 void SnowflakeS3Client::decomposeProxyToParts(
   Aws::String &user, Aws::String &pwd, Aws::String &machine, unsigned &port, Aws::Http::Scheme &scheme)
 {
-  std::string proxy;
+  std::string proxy, protocol;
   std::size_t found, pos;
+  bool scheme_set = false;
 
   // Get proxy string and set scheme
   if (std::getenv("all_proxy")) {
     proxy = std::getenv("all_proxy");
-    scheme = Aws::Http::Scheme::HTTPS;
   } else if (std::getenv("https_proxy")) {
     proxy = std::getenv("https_proxy");
     scheme = Aws::Http::Scheme::HTTPS;
+    scheme_set = true;
   } else if (std::getenv("http_proxy")) {
     proxy = std::getenv("http_proxy");
     scheme = Aws::Http::Scheme::HTTP;
+    scheme_set = true;
   } else {
     return;
   }
@@ -556,6 +558,10 @@ void SnowflakeS3Client::decomposeProxyToParts(
   found = proxy.find("://");
   if (found != std::string::npos) {
     // constant value for '://'
+    if (!scheme_set) {
+      protocol = proxy.substr(pos, found - pos);
+      scheme = protocol.compare("https") == 0 ? Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
+    }
     pos = found + 3;
   }
 

--- a/cpp/SnowflakeS3Client.hpp
+++ b/cpp/SnowflakeS3Client.hpp
@@ -155,6 +155,9 @@ private:
   void uploadParts(MultiUploadCtx * uploadCtx);
 
   RemoteStorageRequestOutcome handleError(const Aws::Client::AWSError<Aws::S3::S3Errors> &error);
+
+  void decomposeProxyToParts(Aws::String &user, Aws::String &pwd, Aws::String &machine,
+                             unsigned &port, Aws::Http::Scheme &scheme);
 };
 }
 }

--- a/cpp/SnowflakeS3Client.hpp
+++ b/cpp/SnowflakeS3Client.hpp
@@ -155,9 +155,6 @@ private:
   void uploadParts(MultiUploadCtx * uploadCtx);
 
   RemoteStorageRequestOutcome handleError(const Aws::Client::AWSError<Aws::S3::S3Errors> &error);
-
-  void decomposeProxyToParts(Aws::String &user, Aws::String &pwd, Aws::String &machine,
-                             unsigned &port, Aws::Http::Scheme &scheme);
 };
 }
 }

--- a/cpp/util/Proxy.cpp
+++ b/cpp/util/Proxy.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include "Proxy.hpp"
+
+Snowflake::Client::Util::Proxy::Proxy(const std::string &proxy_str)
+{
+    stringToProxyParts(proxy_str);
+}
+
+Snowflake::Client::Util::Proxy::Proxy(std::string &user, std::string &pwd,
+  std::string &machine, unsigned port, std::string &scheme) :
+  m_user(user), m_pwd(pwd), m_machine(machine), m_port(port), m_scheme(scheme) {}
+
+
+void Snowflake::Client::Util::Proxy::stringToProxyParts(const std::string &proxy)
+{
+    std::string protocol;
+    std::size_t found, pos;
+
+    // Proxy is in the form: "[protocol://][user:password@]machine[:port]"
+    pos = 0;
+    found = proxy.find("://");
+    if (found != std::string::npos) {
+        // constant value for '://'
+        protocol = proxy.substr(pos, found - pos);
+        m_scheme = protocol;
+        pos = found + 3;
+    }
+
+    found = proxy.find('@', pos);
+    // If username and password exist, set them
+    if (found != std::string::npos) {
+        size_t colon_pos = proxy.find(':', pos);
+        m_user = std::string(proxy.substr(pos, colon_pos - pos));
+        pos = colon_pos + 1;
+        m_pwd = std::string(proxy.substr(pos, found - pos));
+        pos = found + 1;
+    }
+
+    found = proxy.find(':', pos);
+    if (found != std::string::npos) {
+        // port exists, set machine and port
+        m_machine = std::string(proxy.substr(pos, found - pos));
+        pos = found + 1;
+        m_port = (unsigned int) strtoul(proxy.substr(pos, (proxy.length()) - pos).c_str(), nullptr, 10);
+    } else {
+        // just set machine
+        m_machine = std::string(proxy.substr(pos, (proxy.length() - 1) - pos));
+    }
+}
+
+void Snowflake::Client::Util::Proxy::clearPwd() {
+    m_pwd.clear();
+}
+
+void Snowflake::Client::Util::Proxy::setProxyFromEnv() {
+    std::string proxy;
+
+    // Get proxy string and set scheme
+    if (std::getenv("all_proxy")) {
+        proxy = std::getenv("all_proxy");
+    } else if (std::getenv("https_proxy")) {
+        proxy = std::getenv("https_proxy");
+    } else if (std::getenv("http_proxy")) {
+        proxy = std::getenv("http_proxy");
+    } else {
+        return;
+    }
+
+    stringToProxyParts(proxy);
+}

--- a/cpp/util/Proxy.cpp
+++ b/cpp/util/Proxy.cpp
@@ -19,6 +19,11 @@ void Snowflake::Client::Util::Proxy::stringToProxyParts(const std::string &proxy
     std::string protocol;
     std::size_t found, pos;
 
+    // Return on an empty input proxy string
+    if (proxy.empty()) {
+        return;
+    }
+
     // Proxy is in the form: "[protocol://][user:password@]machine[:port]"
     pos = 0;
     found = proxy.find("://");
@@ -47,7 +52,7 @@ void Snowflake::Client::Util::Proxy::stringToProxyParts(const std::string &proxy
         m_port = (unsigned int) strtoul(proxy.substr(pos, (proxy.length()) - pos).c_str(), nullptr, 10);
     } else {
         // just set machine
-        m_machine = std::string(proxy.substr(pos, (proxy.length() - 1) - pos));
+        m_machine = std::string(proxy.substr(pos, (proxy.length()) - pos));
     }
 }
 

--- a/cpp/util/Proxy.cpp
+++ b/cpp/util/Proxy.cpp
@@ -10,8 +10,8 @@ Snowflake::Client::Util::Proxy::Proxy(const std::string &proxy_str)
 }
 
 Snowflake::Client::Util::Proxy::Proxy(std::string &user, std::string &pwd,
-  std::string &machine, unsigned port, std::string &scheme) :
-  m_user(user), m_pwd(pwd), m_machine(machine), m_port(port), m_scheme(scheme) {}
+  std::string &machine, unsigned port, Snowflake::Client::Util::Proxy::Protocol scheme) :
+  m_user(user), m_pwd(pwd), m_machine(machine), m_port(port), m_protocol(scheme) {}
 
 
 void Snowflake::Client::Util::Proxy::stringToProxyParts(const std::string &proxy)
@@ -30,8 +30,15 @@ void Snowflake::Client::Util::Proxy::stringToProxyParts(const std::string &proxy
     if (found != std::string::npos) {
         // constant value for '://'
         protocol = proxy.substr(pos, found - pos);
-        m_scheme = protocol;
+        m_protocol = !protocol.compare("http") ? Snowflake::Client::Util::Proxy::Protocol::HTTP :
+                                               Snowflake::Client::Util::Proxy::Protocol::HTTPS;
+        // Set port with default value based on protocol and update
+        // below if user specifies port in proxy string
+        m_port = m_protocol == Snowflake::Client::Util::Proxy::Protocol::HTTP ? 80 : 443;
         pos = found + 3;
+    } else {
+        m_protocol = Snowflake::Client::Util::Proxy::Protocol::HTTP;
+        m_port = 80;
     }
 
     found = proxy.find('@', pos);

--- a/cpp/util/Proxy.hpp
+++ b/cpp/util/Proxy.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKECLIENT_PROXY_HPP
+#define SNOWFLAKECLIENT_PROXY_HPP
+
+#include <cstddef>
+#include <string>
+
+namespace Snowflake
+{
+namespace Client
+{
+namespace Util
+{
+class Proxy
+{
+public:
+    Proxy() = default;
+
+    Proxy(const std::string &proxy_str);
+
+    Proxy(std::string &user, std::string &pwd, std::string &machine, unsigned port, std::string &scheme);
+
+    ~Proxy() = default;
+
+    inline const std::string& getUser()
+    {
+        return this->m_user;
+    }
+
+    inline const std::string& getPwd()
+    {
+        return this->m_pwd;
+    }
+
+    inline const std::string& getMachine()
+    {
+        return this->m_machine;
+    }
+
+    inline unsigned getPort()
+    {
+        return this->m_port;
+    }
+
+    inline const std::string& getScheme()
+    {
+        return this->m_scheme;
+    }
+
+    void clearPwd();
+
+    void setProxyFromEnv();
+
+private:
+    std::string m_user;
+    std::string m_pwd;
+    std::string m_machine;
+    unsigned m_port = 0;
+    std::string m_scheme;
+
+    void stringToProxyParts(const std::string &proxy);
+};
+}
+}
+}
+
+#endif //SNOWFLAKECLIENT_PROXY_HPP

--- a/cpp/util/Proxy.hpp
+++ b/cpp/util/Proxy.hpp
@@ -17,11 +17,13 @@ namespace Util
 class Proxy
 {
 public:
+    enum Protocol {NONE, HTTP, HTTPS};
+
     Proxy() = default;
 
     Proxy(const std::string &proxy_str);
 
-    Proxy(std::string &user, std::string &pwd, std::string &machine, unsigned port, std::string &scheme);
+    Proxy(std::string &user, std::string &pwd, std::string &machine, unsigned port, Protocol scheme);
 
     ~Proxy() = default;
 
@@ -45,9 +47,9 @@ public:
         return this->m_port;
     }
 
-    inline const std::string& getScheme()
+    inline Protocol getScheme()
     {
-        return this->m_scheme;
+        return this->m_protocol;
     }
 
     void clearPwd();
@@ -59,7 +61,7 @@ private:
     std::string m_pwd;
     std::string m_machine;
     unsigned m_port = 0;
-    std::string m_scheme;
+    Protocol m_protocol = Protocol::NONE;
 
     void stringToProxyParts(const std::string &proxy);
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,8 +47,9 @@ SET(TESTS_CXX
         test_unit_file_type_detect
         test_unit_stream_splitter
         test_unit_thread_pool
-        test_unit_base64)
-        #test_cpp_select1)
+        test_unit_base64
+        #test_cpp_select1
+        test_unit_proxy)
 
 SET(TESTS_PERF
         test_perf_string_reads_and_writes

--- a/tests/test_unit_proxy.cpp
+++ b/tests/test_unit_proxy.cpp
@@ -2,50 +2,51 @@
  * Copyright (c) 2018 Snowflake Computing, Inc. All rights reserved.
  */
 
+#include <cassert>
 #include "util/Proxy.hpp"
 #include "utils/test_setup.h"
 #include "utils/TestSetup.hpp"
 
 typedef ::Snowflake::Client::Util::Proxy Proxy;
 
-void test_proxy_parts_equality(const char *proxy_str, const char *user, const char *pwd, const char *machine, unsigned port, const char *scheme) {
+void test_proxy_parts_equality(const char *proxy_str, const char *user, const char *pwd, const char *machine, unsigned port, Proxy::Protocol scheme) {
     Proxy proxy(proxy_str);
 
     assert_string_equal(proxy.getUser().c_str(), user);
     assert_string_equal(proxy.getPwd().c_str(), pwd);
     assert_string_equal(proxy.getMachine().c_str(), machine);
     assert_int_equal(proxy.getPort(), port);
-    assert_string_equal(proxy.getScheme().c_str(), scheme);
+    assert(proxy.getScheme() == scheme);
 }
 
 void test_proxy_machine_only(void **unused)
 {
-    test_proxy_parts_equality("localhost", "", "", "localhost", 0, "");
+    test_proxy_parts_equality("localhost", "", "", "localhost", 80, Proxy::Protocol::HTTP);
 }
 
 void test_proxy_machine_and_port(void **unused)
 {
-    test_proxy_parts_equality("localhost:8081", "", "", "localhost", 8081, "");
+    test_proxy_parts_equality("localhost:8081", "", "", "localhost", 8081, Proxy::Protocol::HTTP);
 }
 
 void test_proxy_machine_and_scheme(void **unused)
 {
-    test_proxy_parts_equality("https://localhost", "", "", "localhost", 0, "https");
+    test_proxy_parts_equality("https://localhost", "", "", "localhost", 443, Proxy::Protocol::HTTPS);
 }
 
 void test_proxy_machine_port_scheme(void **unused)
 {
-    test_proxy_parts_equality("http://localhost:5050", "", "", "localhost", 5050, "http");
+    test_proxy_parts_equality("http://localhost:5050", "", "", "localhost", 5050, Proxy::Protocol::HTTP);
 }
 
 void test_proxy_all(void **unused)
 {
-    test_proxy_parts_equality("https://someuser:somepwd@somewhere.com:5050", "someuser", "somepwd", "somewhere.com", 5050, "https");
+    test_proxy_parts_equality("https://someuser:somepwd@somewhere.com:5050", "someuser", "somepwd", "somewhere.com", 5050, Proxy::Protocol::HTTPS);
 }
 
 void test_proxy_empty(void **unused)
 {
-    test_proxy_parts_equality("", "", "", "", 0, "");
+    test_proxy_parts_equality("", "", "", "", 0, Proxy::Protocol::NONE);
 }
 
 int main(void) {

--- a/tests/test_unit_proxy.cpp
+++ b/tests/test_unit_proxy.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include "util/Proxy.hpp"
+#include "utils/test_setup.h"
+#include "utils/TestSetup.hpp"
+
+typedef ::Snowflake::Client::Util::Proxy Proxy;
+
+void test_proxy_parts_equality(const char *proxy_str, const char *user, const char *pwd, const char *machine, unsigned port, const char *scheme) {
+    Proxy proxy(proxy_str);
+
+    assert_string_equal(proxy.getUser().c_str(), user);
+    assert_string_equal(proxy.getPwd().c_str(), pwd);
+    assert_string_equal(proxy.getMachine().c_str(), machine);
+    assert_int_equal(proxy.getPort(), port);
+    assert_string_equal(proxy.getScheme().c_str(), scheme);
+}
+
+void test_proxy_machine_only(void **unused)
+{
+    test_proxy_parts_equality("localhost", "", "", "localhost", 0, "");
+}
+
+void test_proxy_machine_and_port(void **unused)
+{
+    test_proxy_parts_equality("localhost:8081", "", "", "localhost", 8081, "");
+}
+
+void test_proxy_machine_and_scheme(void **unused)
+{
+    test_proxy_parts_equality("https://localhost", "", "", "localhost", 0, "https");
+}
+
+void test_proxy_machine_port_scheme(void **unused)
+{
+    test_proxy_parts_equality("http://localhost:5050", "", "", "localhost", 5050, "http");
+}
+
+void test_proxy_all(void **unused)
+{
+    test_proxy_parts_equality("https://someuser:somepwd@somewhere.com:5050", "someuser", "somepwd", "somewhere.com", 5050, "https");
+}
+
+void test_proxy_empty(void **unused)
+{
+    test_proxy_parts_equality("", "", "", "", 0, "");
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_proxy_machine_only),
+    cmocka_unit_test(test_proxy_machine_and_port),
+    cmocka_unit_test(test_proxy_machine_and_scheme),
+    cmocka_unit_test(test_proxy_machine_port_scheme),
+    cmocka_unit_test(test_proxy_all),
+    cmocka_unit_test(test_proxy_empty),
+  };
+  int ret = cmocka_run_group_tests(tests, NULL, NULL);
+  return ret;
+}


### PR DESCRIPTION
Added code to enable proxy support for PUT/GET commands. The code reads the value from the env vars (all_proxy, http_proxy, https_proxy) and sets the appropriate configuration fields in AWS API.