### PR TITLE
Build with user specified version of GCC/GXX

### DIFF
--- a/scripts/_init.sh
+++ b/scripts/_init.sh
@@ -16,25 +16,27 @@ else
     CMAKE="$(which cmake)"
 fi
 
-if [[ "$(which gcc49)" ]]; then
-    GCC="$(which gcc49)"
-    GXX="$(which g++49)"
-elif [[ "$(which gcc-4.9)" ]]; then
-    GCC="$(which gcc-4.9)"
-    GXX="$(which g++-4.9)"
-elif [[ "$(which gcc52)" ]]; then
-    GCC="$(which gcc52)"
-    GXX="$(which g++52)"
-elif [[ "$(which gcc62)" ]]; then
-    GCC="$(which gcc62)"
-    GXX="$(which g++62)"
-elif [[ "$(which gcc72)" ]]; then
-    GCC="$(which gcc72)"
-    GXX="$(which g++72)"
-else
-    # Default to system
-    GCC="$(which gcc)"
-    GXX="$(which g++)"
+if [[ -z "$GCC" || -z "$GXX" ]]; then
+    if [[ "$(which gcc49)" ]]; then
+        GCC="$(which gcc49)"
+        GXX="$(which g++49)"
+    elif [[ "$(which gcc-4.9)" ]]; then
+        GCC="$(which gcc-4.9)"
+        GXX="$(which g++-4.9)"
+    elif [[ "$(which gcc52)" ]]; then
+        GCC="$(which gcc52)"
+        GXX="$(which g++52)"
+    elif [[ "$(which gcc62)" ]]; then
+        GCC="$(which gcc62)"
+        GXX="$(which g++62)"
+    elif [[ "$(which gcc72)" ]]; then
+        GCC="$(which gcc72)"
+        GXX="$(which g++72)"
+    else
+        # Default to system
+        GCC="$(which gcc)"
+        GXX="$(which g++)"
+    fi
 fi
 
 if [[ "$PLATFORM" == "darwin" ]]; then

--- a/scripts/build_curl.sh
+++ b/scripts/build_curl.sh
@@ -53,7 +53,7 @@ cd $LIBCURL_SOURCE_DIR
 echo "Building Curl with OpenSSL"
 if [[ "$PLATFORM" == "linux" ]]; then
     # Linux 64 bit
-    export CC=gcc52
+    export CC="${GCC:-gcc52}"
     export CFLAGS=-pthread # required to build with gcc52 or OpenSSL check will fail
     PKG_CONFIG="pkg-config -static" LIBS="-ldl" ./configure ${curl_configure_opts[@]}
     make > /dev/null

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -31,7 +31,7 @@ fi
 cd $OPENSSL_SOURCE_DIR
 if [[ "$PLATFORM" == "linux" ]]; then
     # Linux 64 bit
-    export CC=gcc52
+    export CC="${GCC:-gcc52}"
     make distclean clean &> /dev/null || true
     ./Configure linux-x86_64 "${openssl_config_opts[@]}"
     make depend > /dev/null


### PR DESCRIPTION
Updated build scripts to take in a user specified version of GCC/GXX and to make sure that curl and openssl use the same version of GXX/GXX that the other libraries use.