### PR TITLE
Remove constructor of EncryptionMaterial

### DIFF
--- a/cpp/StatementPutGet.cpp
+++ b/cpp/StatementPutGet.cpp
@@ -28,7 +28,8 @@ bool StatementPutGet::parsePutGetCommand(std::string *sql,
     ->source_compression;
 
   cJSON *src = (cJSON *) response->src_list;
-  for (int i = 0; i < snowflake_cJSON_GetArraySize(src); i++)
+  int src_size = snowflake_cJSON_GetArraySize(src);
+  for (int i = 0; i < src_size; i++)
   {
     cJSON *val = snowflake_cJSON_GetArrayItem(src, i);
     putGetParseResponse->srcLocations.emplace_back(val->valuestring);
@@ -46,7 +47,8 @@ bool StatementPutGet::parsePutGetCommand(std::string *sql,
   {
     putGetParseResponse->command = CommandType::DOWNLOAD;
     cJSON *enc_mat_array_get = (cJSON *) response->enc_mat_get;
-    for (int i=0; i< snowflake_cJSON_GetArraySize(enc_mat_array_get); i++)
+    int enc_mat_array_size = snowflake_cJSON_GetArraySize(enc_mat_array_get);
+    for (int i = 0; i < enc_mat_array_size; i++)
     {
       cJSON * enc_mat = snowflake_cJSON_GetArrayItem(enc_mat_array_get, i);
       putGetParseResponse->encryptionMaterials.emplace_back(

--- a/include/snowflake/PutGetParseResponse.hpp
+++ b/include/snowflake/PutGetParseResponse.hpp
@@ -18,8 +18,8 @@ namespace Client
 struct EncryptionMaterial
 {
   EncryptionMaterial(char * queryStageMasterKey_,
-                   char * queryId_,
-                   long long smkId_)
+                     char * queryId_,
+                     long long smkId_)
   {
     this->queryStageMasterKey = std::string(queryStageMasterKey_);
     this->queryId = std::string(queryId_);

--- a/include/snowflake/PutGetParseResponse.hpp
+++ b/include/snowflake/PutGetParseResponse.hpp
@@ -17,6 +17,14 @@ namespace Client
 
 struct EncryptionMaterial
 {
+  EncryptionMaterial(char * queryStageMasterKey_,
+                   char * queryId_,
+                   long long smkId_)
+  {
+    this->queryStageMasterKey = std::string(queryStageMasterKey_);
+    this->queryId = std::string(queryId_);
+    this->smkId = smkId_;
+  }
   /// master key to encrypt file key
   std::string queryStageMasterKey;
 

--- a/include/snowflake/PutGetParseResponse.hpp
+++ b/include/snowflake/PutGetParseResponse.hpp
@@ -17,15 +17,6 @@ namespace Client
 
 struct EncryptionMaterial
 {
-  EncryptionMaterial(char * queryStageMasterKey,
-                     char * queryId,
-                     long long smkId)
-  {
-    this->queryStageMasterKey = std::string(queryStageMasterKey);
-    this->queryId = std::string(queryId);
-    this->smkId = smkId;
-  }
-
   /// master key to encrypt file key
   std::string queryStageMasterKey;
 


### PR DESCRIPTION
The parameter passed into the struct has the same name as member variable and caused a lot of warning thrown on the ODBC since it uses stricter compile flag. It would be a good chance to meet up with higher standard during the Simba upgrade this time.

Since the constructor seems to not being used anywhere, I just throw it away.