### PR TITLE
JWT Enhancement - support direct token verification

### DIFF
--- a/cpp/jwt/Jwt.cpp
+++ b/cpp/jwt/Jwt.cpp
@@ -51,21 +51,35 @@ JWTObject::JWTObject(const std::string &input)
   secret_ = remain.substr(pos + 1);
 }
 
-bool JWTObject::verify(EVP_PKEY *key, bool format)
+bool JWTObject::verify(EVP_PKEY *key)
 {
   std::unique_ptr<ISigner> signer{ISigner::buildSigner(header_->getAlgorithmType())};
   std::string msg;
 
   if (signer == nullptr) return false;
 
-  if (format)
-  {
-    msg = header_->serialize() + '.' + claim_set_->serialize();
-  }
-  else
-  {
-    msg = header_->serialize(false) + '.' + claim_set_->serialize(false);
-  }
+  msg = header_->serialize() + '.' + claim_set_->serialize();
+  return signer->verify(key, msg, secret_);
+}
+
+bool JWTObject::verify(EVP_PKEY *key, const char *token)
+{
+  std::unique_ptr<ISigner> signer{ISigner::buildSigner(header_->getAlgorithmType())};
+  std::string msg(token);
+  size_t pos;
+  std::string remain;
+
+  if (signer == nullptr) return false;
+
+  pos = msg.find('.');
+  if (pos == std::string::npos) throw JwtException("Fail to extract header");
+
+  remain = msg.substr(pos + 1);
+  pos = remain.find('.');
+  if (pos == std::string::npos) throw JwtException("Fail to extract token");
+
+  secret_ = remain.substr(pos + 1);
+
   return signer->verify(key, msg, secret_);
 }
 

--- a/cpp/jwt/Jwt.hpp
+++ b/cpp/jwt/Jwt.hpp
@@ -75,10 +75,18 @@ public:
    *       and the secret's value are properly set already unless the object is
    *       parsed from some serialized text
    * @param key
-   * @param format - whether to format msg while verifying signature
    * @return true if the verification pass
    */
-  bool verify(EVP_PKEY *key, bool format);
+  bool verify(EVP_PKEY *key);
+
+  /**
+   * Verify the token directly without parsing it and
+   * serializing from the Header / Claimset in the JWTObject.
+   * @param key - key to verify the signature
+   * @param token - base64 encoded JWT Token
+   * @return
+   */
+  bool verify(EVP_PKEY *key, const char *token);
 
   /**
    * Serialize the JWT token to a string, the secret field would be set

--- a/cpp/jwt/jwtWrapper.cpp
+++ b/cpp/jwt/jwtWrapper.cpp
@@ -130,7 +130,20 @@ const char * CJWT_serialize(CJWT cjwt_obj, EVP_PKEY *key)
 int CJWT_verify(CJWT cjwt_obj, EVP_PKEY *key)
 {
     IJwt *ijwt_obj = static_cast<IJwt *>(cjwt_obj);
-    if ((ijwt_obj->verify(key, false)))
+    if ((ijwt_obj->verify(key)))
+    {
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+int CJWT_verify_token(CJWT cjwt_obj, EVP_PKEY *key, const char *token)
+{
+    IJwt *ijwt_obj = static_cast<IJwt *>(cjwt_obj);
+    if ((ijwt_obj->verify(key, token)))
     {
         return 1;
     }

--- a/include/snowflake/IJwt.hpp
+++ b/include/snowflake/IJwt.hpp
@@ -213,7 +213,16 @@ public:
    * Verify the JWT is valid using the public key
    * @usedBy authenticator
    */
-  virtual bool verify(EVP_PKEY *key, bool format) = 0;
+  virtual bool verify(EVP_PKEY *key) = 0;
+
+  /**
+   * Verify JWT token directly without parsing
+   * header or claimset.
+   * @param key
+   * @param token
+   * @return verification status.
+   */
+  virtual bool verify(EVP_PKEY *key, const char *token) = 0;
 
   /**
    * Setter and getter functions for header and claimset

--- a/include/snowflake/jwtWrapper.h
+++ b/include/snowflake/jwtWrapper.h
@@ -152,6 +152,16 @@ const char *CJWT_serialize(CJWT cjwt_obj, EVP_PKEY *key);
  */
 int CJWT_verify(CJWT c_jwt_token, EVP_PKEY *key);
 
+
+/**
+ * Verify a JWT Token Directly without parsing
+ * @param c_jwt_token
+ * @param key
+ * @param token
+ * @return
+ */
+int CJWT_verify_token(CJWT c_jwt_token, EVP_PKEY *key, const char *token);
+
 /**
  * Set claimset in a iJwt Object
  * @param c_jwt_token

--- a/tests/test_unit_jwt.cpp
+++ b/tests/test_unit_jwt.cpp
@@ -125,7 +125,7 @@ void test_sign_verify(void **)
 
   assert_string_not_equal(result.c_str(), "");
 
-  assert_true(jwt.verify(pub_key.get(), true));
+  assert_true(jwt.verify(pub_key.get()));
 }
 
 int main()


### PR DESCRIPTION
Enhanced JWT to support verification of a base64 encoded JWT Token directly without the need of parsing it into a JWTObject. This bypasses the steps to serialize Header and ClaimSet Objects while signature verification. 