### PR TITLE
Fix MSFT security issues

### DIFF
--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -38,18 +38,18 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo, unsigned int pa
   char caBundleFile[MAX_PATH] ={0};
   if(transferConfig && transferConfig->caBundleFile) {
       int len = std::min((int)strlen(transferConfig->caBundleFile), MAX_PATH - 1);
-      strncpy(caBundleFile, transferConfig->caBundleFile, len);
+      sb_strncpy(caBundleFile, sizeof(caBundleFile), transferConfig->caBundleFile, len);
       caBundleFile[len]=0;
       CXX_LOG_TRACE("ca bundle file from TransferConfig *%s*", caBundleFile);
   }
   else if( caBundleFile[0] == 0 ) {
-      snowflake_global_get_attribute(SF_GLOBAL_CA_BUNDLE_FILE, caBundleFile);
+      snowflake_global_get_attribute(SF_GLOBAL_CA_BUNDLE_FILE, caBundleFile, sizeof(caBundleFile));
       CXX_LOG_TRACE("ca bundle file from SF_GLOBAL_CA_BUNDLE_FILE *%s*", caBundleFile);
   }
 if( caBundleFile[0] == 0 ) {
       const char* capath = std::getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
       int len = std::min((int)strlen(capath), MAX_PATH - 1);
-      strncpy(caBundleFile, capath, len);
+      sb_strncpy(caBundleFile, sizeof(caBundleFile), capath, len);
       caBundleFile[len]=0;
       CXX_LOG_TRACE("ca bundle file from SNOWFLAKE_TEST_CA_BUNDLE_FILE *%s*", caBundleFile);
   }
@@ -157,7 +157,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::doMultiPartUpload(FileMetadata
 std::string buildEncryptionMetadataJSON(std::string iv64, std::string enkek64)
 {
   char buf[512];
-  sprintf(buf,"{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\", \"KeyWrappingMetadata\":{\"EncryptionLibrary\":\"Java 5.3.0\"}}", enkek64.c_str(), iv64.c_str());
+  sb_sprintf(buf, sizeof(buf), "{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\", \"KeyWrappingMetadata\":{\"EncryptionLibrary\":\"Java 5.3.0\"}}", enkek64.c_str(), iv64.c_str());
 
   return std::string(buf);
 }

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -60,8 +60,8 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo, unsigned int parallel
   }
   else
   {
-    char caBundleFile[200] = {0};
-    snowflake_global_get_attribute(SF_GLOBAL_CA_BUNDLE_FILE, caBundleFile);
+    char caBundleFile[MAX_PATH + 1] = {0};
+    snowflake_global_get_attribute(SF_GLOBAL_CA_BUNDLE_FILE, caBundleFile, sizeof(caBundleFile));
     caFile = Aws::String(caBundleFile);
   }
 

--- a/cpp/SnowflakeTransferException.cpp
+++ b/cpp/SnowflakeTransferException.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include "snowflake/SnowflakeTransferException.hpp"
+#include "snowflake/Simba_CRTFunctionSafe.h"
 
 // keep same order as entries in enum TransferError, so that error message can
 // be matched correspondingly
@@ -28,7 +29,7 @@ Snowflake::Client::SnowflakeTransferException::SnowflakeTransferException(
 #pragma clang diagnostic ignored "-Wvarargs"
   va_start (args, transferError);
 #pragma clang diagnostic pop
-  vsprintf(m_msg, msgFmt, args);
+  sb_vsnprintf(m_msg, sizeof(m_msg), sizeof(m_msg) - 1, msgFmt, args);
   va_end(args);
 }
 

--- a/cpp/crypto/CryptoTypes.hpp
+++ b/cpp/crypto/CryptoTypes.hpp
@@ -6,6 +6,7 @@
 #define SNOWFLAKECLIENT_CRYPTOTYPES_HPP
 
 #include <cstring>
+#include "snowflake/Simba_CRTFunctionSafe.h"
 
 namespace Snowflake
 {
@@ -73,7 +74,7 @@ struct CryptoKey final
   inline CryptoKey(const CryptoKey &other) : CryptoKey()
   {
     nbBits = other.nbBits;
-    std::memcpy(data, other.data, sizeof(data));
+    sb_memcpy(data, sizeof(data), other.data, sizeof(data));
   }
 
   inline ~CryptoKey() noexcept

--- a/cpp/crypto/Cryptor.cpp
+++ b/cpp/crypto/Cryptor.cpp
@@ -66,7 +66,7 @@ static void getRandomBytesFromFile(char *const out,
   for (size_t i = 0; i < steps; ++i)
   {
     const T rdv = rd();
-    memcpy(outT, &rdv, STEP);
+    sb_memcpy(outT, nbBytes - (outT-out), &rdv, STEP);
     outT += STEP;
   }
 
@@ -75,7 +75,7 @@ static void getRandomBytesFromFile(char *const out,
   if (rem)
   {
     const T remVal = rd();
-    memcpy(outT, &remVal, rem);
+    sb_memcpy(outT, nbBytes - (outT - out), &remVal, rem);
   }
 }
 

--- a/cpp/util/Base64.hpp
+++ b/cpp/util/Base64.hpp
@@ -161,7 +161,7 @@ struct Base64 final
     ReverseIndex(const char index_size, const char *index) noexcept
     {
         std::memset(data, 0xFF, sizeof(data));
-        for (size_t i = 0; i < INDEX_SIZE; ++i)
+        for (size_t i = 0; i < index_size; ++i)
             data[static_cast<unsigned char>(index[i])] = i;
     }
 

--- a/include/snowflake/Simba_CRTFunctionSafe.h
+++ b/include/snowflake/Simba_CRTFunctionSafe.h
@@ -1,0 +1,337 @@
+// =================================================================================================
+///  @file Simba_CRTFunctionSafe.h
+///
+///  C Run-Time library functions' definitions for cross platform use.
+///
+///  Copyright (C) 2019 Simba Technologies Incorporated.
+// =================================================================================================
+
+#ifndef _SIMBA_CRTFUNCTIONSAFE_H_
+#define _SIMBA_CRTFUNCTIONSAFE_H_
+
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#if defined(WIN32) || defined(_WIN64)   // For Windows
+
+    /// @brief Copy a string.
+    /// 
+    /// @param out_dest         Destination string buffer. (NOT OWN)
+    /// @param in_destSize      Size of the destination string buffer.
+    /// @param in_src           Null-terminated source string buffer. (NOT OWN)
+    /// 
+    /// @return The destination string; NULL if an error occurred. (NOT OWN)
+    inline char* sb_strcpy(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src)
+    {
+        if (0 == strcpy_s(out_dest, in_destSize, in_src))
+        {
+            return out_dest;
+        }
+        return NULL;
+    }
+
+    /// @brief Copy characters of one string to another.
+    ///
+    /// @param out_dest         Destination string. (NOT OWN)
+    /// @param in_destSize      The size of the destination string, in characters. 
+    /// @param in_src           Source string. (NOT OWN)
+    /// @param in_sizeToCopy    Number of characters to be copied.
+    /// 
+    /// @return The destination string; NULL if a truncation or error occurred. (NOT OWN)
+    inline char* sb_strncpy(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src,
+        size_t in_sizeToCopy)
+    {
+        if (0 == strncpy_s(out_dest, in_destSize, in_src, in_sizeToCopy))
+        {
+            return out_dest;
+        }
+        return NULL;
+    }
+
+    /// @brief Append to a string.
+    /// 
+    /// @param out_dest         Destination string to append to. (NOT OWN)
+    /// @param in_destSize      Size of the destination string buffer.
+    /// @param in_src           Null-terminated source string buffer. (NOT OWN)
+    /// 
+    /// @return The destination string; NULL if an error occurred. (NOT OWN)
+    inline char* sb_strcat(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src)
+    {
+        if (0 == strcat_s(out_dest, in_destSize, in_src))
+        {
+            return out_dest;
+        }
+        return NULL;
+    }
+
+    /// @brief Append characters of one string to another.
+    ///
+    /// @param out_dest         Destination string to append to. (NOT OWN)
+    /// @param in_destSize      The size of the destination string buffer, in characters. 
+    /// @param in_src           Source string. (NOT OWN)
+    /// @param in_sizeToCopy    Number of characters to be copied.
+    /// 
+    /// @return The destination string; NULL if a truncation or error occurred. (NOT OWN)
+    inline char* sb_strncat(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src,
+        size_t in_sizeToCopy)
+    {
+        if (0 == strncpy_s(out_dest, in_destSize, in_src, in_sizeToCopy))
+        {
+            return out_dest;
+        }
+        return NULL;
+    }
+
+    /// @brief Copy bytes between buffers. 
+    /// 
+    /// @param out_dest         Destination buffer. (NOT OWN)
+    /// @param in_destSize      Size of the destination buffer. 
+    /// @param in_src           Buffer to copy from. (NOT OWN)
+    /// @param in_sizeToCopy    Number of bytes to copy.
+    /// 
+    /// @return A pointer to destination; NULL if an error occurred. (NOT OWN)
+    inline void* sb_memcpy(
+        void* out_dest,
+        size_t in_destSize,
+        const void* in_src,
+        size_t in_sizeToCopy)
+    {
+        if (0 == memcpy_s(out_dest, in_destSize, in_src, in_sizeToCopy))
+        {
+            return out_dest;
+        }
+        return NULL;
+    }
+
+    /// @brief Write formatted output using a pointer to a list of arguments.
+    /// 
+    /// Note: To ensure that there is room for the terminating null, be sure that in_sizeToWrite is 
+    /// strictly less than in_sizeOfBuffer.
+    /// 
+    /// @param out_buffer       Storage location for output. (NOT OWN)
+    /// @param in_sizeOfBuffer  Size of buffer in characters. 
+    /// @param in_sizeToWrite   Maximum number of characters to write (not including the 
+    ///                         terminating null).
+    /// @param in_format        Format control string. (NOT OWN)
+    /// @param in_argPtr        Pointer to list of arguments.
+    /// 
+    /// @return The number of bytes written to the buffer, not counting the terminating null 
+    /// character; -1 if the truncation or error occurred.
+    inline int sb_vsnprintf(
+        char* out_buffer,
+        size_t in_sizeOfBuffer,
+        size_t in_sizeToWrite,
+        const char* in_format,
+        va_list in_argPtr)
+    {
+        if (in_sizeToWrite >= in_sizeOfBuffer) return -1;
+
+        return _vsnprintf_s(out_buffer, in_sizeOfBuffer, _TRUNCATE, in_format, in_argPtr);
+    }
+
+    /// @brief Write formatted data to a string. 
+    /// 
+    /// @param out_buffer       Storage location for output. (NOT OWN)
+    /// @param in_sizeOfBuffer  Size of buffer in characters. 
+    /// @param in_format        Format control string. (NOT OWN)
+    /// @param ...              Optional arguments for printf style conversions.
+    /// 
+    /// @return The number of bytes written to the buffer, not counting the terminating null 
+    /// character; -1 if an error occurred.
+    inline int sb_sprintf(
+        char* out_buffer,
+        size_t in_sizeOfBuffer,
+        const char* in_format,
+        ...)
+    {
+        if (!in_sizeOfBuffer) return -1;
+
+        va_list formatParams;
+        va_start(formatParams, in_format);
+        int bytesWritten = sb_vsnprintf(out_buffer, in_sizeOfBuffer, in_sizeOfBuffer - 1, in_format, formatParams);
+        va_end(formatParams);
+
+        return bytesWritten;
+    }
+
+    /// @brief Reads formatted data from a string. 
+    /// 
+    /// Note: A buffer size parameter is required when you use the type field characters 
+    /// c, C, s, S, or string control sets that are enclosed in []. 
+    ///
+    /// @param in_buffer        Stored data. (NOT OWN)
+    /// @param in_format        Format control string. (NOT OWN)
+    /// @param ...              Optional arguments.
+    /// 
+    /// @return The number of fields that are successfully converted and assigned;
+    /// -1 if an error occurred.
+    inline int sb_sscanf(
+        const char* in_buffer,
+        const char* in_format,
+        ...)
+    {
+        va_list formatParams;
+        va_start(formatParams, in_format);
+        int ret = vsscanf_s(in_buffer, in_format, formatParams);
+        va_end(formatParams);
+
+        return ret;
+    }
+
+#else   // For all other platforms except Windows
+
+    /// @brief Copy a string.
+    /// 
+    /// @param out_dest         Destination string buffer. (NOT OWN)
+    /// @param in_destSize      Size of the destination string buffer.
+    /// @param in_src           Null-terminated source string buffer. (NOT OWN)
+    /// 
+    /// @return The destination string; NULL if an error occurred. (NOT OWN)
+    inline char* sb_strcpy(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src)
+    {
+        return strcpy(out_dest, in_src);
+    }
+
+    /// @brief Copy characters of one string to another.
+    ///
+    /// @param out_dest         Destination string. (NOT OWN)
+    /// @param in_destSize      The size of the destination string, in characters. 
+    /// @param in_src           Source string. (NOT OWN)
+    /// @param in_sizeToCopy    Number of characters to be copied.
+    /// 
+    /// @return The destination string; NULL if a truncation or error occurred. (NOT OWN)
+    inline char* sb_strncpy(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src,
+        size_t in_sizeToCopy)
+    {
+        return strncpy(out_dest, in_src, in_sizeToCopy);
+    }
+
+    /// @brief Append to a string.
+    /// 
+    /// @param out_dest         Destination string to append to. (NOT OWN)
+    /// @param in_destSize      Size of the destination string buffer.
+    /// @param in_src           Null-terminated source string buffer. (NOT OWN)
+    /// 
+    /// @return The destination string; NULL if an error occurred. (NOT OWN)
+    inline char* sb_strcat(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src)
+    {
+        return strcat(out_dest, in_src);
+    }
+
+    /// @brief Append characters of one string to another.
+    ///
+    /// @param out_dest         Destination string to append to. (NOT OWN)
+    /// @param in_destSize      The size of the destination string buffer, in characters. 
+    /// @param in_src           Source string. (NOT OWN)
+    /// @param in_sizeToCopy    Number of characters to be copied.
+    /// 
+    /// @return The destination string; NULL if a truncation or error occurred. (NOT OWN)
+    inline char* sb_strncat(
+        char* out_dest,
+        size_t in_destSize,
+        const char* in_src,
+        size_t in_sizeToCopy)
+    {
+        return strncat(out_dest, in_src, in_sizeToCopy);
+    }
+
+    /// @brief Copy bytes between buffers. 
+    /// 
+    /// @param out_dest         Destination buffer. (NOT OWN)
+    /// @param in_destSize      Size of the destination buffer. 
+    /// @param in_src           Buffer to copy from. (NOT OWN)
+    /// @param in_sizeToCopy    Number of bytes to copy.
+    /// 
+    /// @return A pointer to destination; NULL if an error occurred. (NOT OWN)
+    inline void* sb_memcpy(
+        void* out_dest,
+        size_t in_destSize,
+        const void* in_src,
+        size_t in_sizeToCopy)
+    {
+        return memcpy(out_dest, in_src, in_sizeToCopy);
+    }
+
+    /// @brief Write formatted output using a pointer to a list of arguments.
+    /// 
+    /// Note: To ensure that there is room for the terminating null, be sure that in_sizeToWrite is 
+    /// strictly less than in_sizeOfBuffer.
+    /// 
+    /// @param out_buffer       Storage location for output. (NOT OWN)
+    /// @param in_sizeOfBuffer  Size of buffer in characters. 
+    /// @param in_sizeToWrite   Maximum number of characters to write (not including the 
+    ///                         terminating null).
+    /// @param in_format        Format control string. (NOT OWN)
+    /// @param in_argPtr        Pointer to list of arguments.
+    /// 
+    /// @return The number of bytes written to the buffer, not counting the terminating null 
+    /// character; -1 if the truncation or error occurred.
+    inline int sb_vsnprintf(
+        char* out_buffer,
+        size_t in_sizeOfBuffer,
+        size_t in_sizeToWrite,
+        const char* in_format,
+        va_list in_argPtr)
+    {
+        // vsnprintf takes the size including terminating null while in_sizeToWrite does not
+        // include terminating null.
+        if (in_sizeToWrite >= in_sizeOfBuffer) return -1;
+
+        int ret = vsnprintf(out_buffer, in_sizeToWrite + 1, in_format, in_argPtr);
+        if ((ret < 0) || ((size_t)ret > in_sizeToWrite)) return -1;
+
+        return ret;
+    }
+
+    /// @brief Write formatted data to a string. 
+    /// 
+    /// @param out_buffer       Storage location for output. (NOT OWN)
+    /// @param in_sizeOfBuffer  Size of buffer in characters. 
+    /// @param in_format        Format control string. (NOT OWN)
+    /// @param ...	            Optional arguments for printf style conversions.
+    /// 
+    /// @return The number of bytes written to the buffer, not counting the terminating null 
+    /// character; -1 if an error occurred.
+    inline int sb_sprintf(
+        char* out_buffer,
+        size_t in_sizeOfBuffer,
+        const char* in_format,
+        ...)
+    {
+        va_list formatParams;
+        va_start(formatParams, in_format);
+        int bytesWritten = sb_vsnprintf(out_buffer, in_sizeOfBuffer, in_sizeOfBuffer - 1, in_format, formatParams);
+        va_end(formatParams);
+
+        return bytesWritten;
+    }
+
+#define sb_sscanf sscanf
+
+#endif
+
+#endif

--- a/include/snowflake/Simba_CRTFunctionSafe.h
+++ b/include/snowflake/Simba_CRTFunctionSafe.h
@@ -90,7 +90,7 @@
         const char* in_src,
         size_t in_sizeToCopy)
     {
-        if (0 == strncpy_s(out_dest, in_destSize, in_src, in_sizeToCopy))
+        if (0 == strncat_s(out_dest, in_destSize, in_src, in_sizeToCopy))
         {
             return out_dest;
         }

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -415,11 +415,12 @@ SF_STATUS STDCALL snowflake_global_set_attribute(
 /**
  * Get a global attribute
  * @param type a value of SF_GLOBAL_ATTRIBUTE
- * @param value a pointer to value
+ * @param value a pointer to value buffer
+ * @param buffer size
  * @return 0 if successful, errno otherise.
  */
 SF_STATUS STDCALL snowflake_global_get_attribute(
-    SF_GLOBAL_ATTRIBUTE type, void *value);
+    SF_GLOBAL_ATTRIBUTE type, void *value, size_t size);
 
 /**
  * Initializes a SNOWFLAKE connection context

--- a/include/snowflake/platform.h
+++ b/include/snowflake/platform.h
@@ -45,6 +45,8 @@ typedef pthread_mutex_t SF_MUTEX_HANDLE;
 
 #endif
 
+#include "Simba_CRTFunctionSafe.h"
+
 struct tm *STDCALL sf_gmtime(const time_t *timep, struct tm *result);
 
 struct tm *STDCALL sf_localtime(const time_t *timep, struct tm *result);
@@ -108,7 +110,7 @@ int STDCALL _mutex_term(SF_MUTEX_HANDLE *lock);
 
 const char *STDCALL sf_os_name();
 
-void STDCALL sf_os_version(char *ret);
+void STDCALL sf_os_version(char *ret, size_t size);
 
 int STDCALL sf_strncasecmp(const char *s1, const char *s2, size_t n);
 

--- a/lib/cJSON.h
+++ b/lib/cJSON.h
@@ -28,10 +28,60 @@ extern "C"
 {
 #endif
 
+#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#define __WINDOWS__
+#endif
+
+#ifdef __WINDOWS__
+
+/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 3 define options:
+
+CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
+CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
+CJSON_IMPORT_SYMBOLS - Define this if you want to dllimport symbol
+
+For *nix builds that support visibility attribute, you can define similar behavior by
+
+setting default visibility to hidden by adding
+-fvisibility=hidden (for gcc)
+or
+-xldscope=hidden (for sun cc)
+to CFLAGS
+
+then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJSON_EXPORT_SYMBOLS does
+
+*/
+
+#define CJSON_CDECL __cdecl
+#define CJSON_STDCALL __stdcall
+
+/* export symbols by default, this is necessary for copy pasting the C and header file */
+#if !defined(CJSON_HIDE_SYMBOLS) && !defined(CJSON_IMPORT_SYMBOLS) && !defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_EXPORT_SYMBOLS
+#endif
+
+#if defined(CJSON_HIDE_SYMBOLS)
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
+#elif defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllexport) type CJSON_STDCALL
+#elif defined(CJSON_IMPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllimport) type CJSON_STDCALL
+#endif
+#else /* !__WINDOWS__ */
+#define CJSON_CDECL
+#define CJSON_STDCALL
+
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
+#define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
+#else
+#define CJSON_PUBLIC(type) type
+#endif
+#endif
+
 /* project version */
 #define CJSON_VERSION_MAJOR 1
-#define CJSON_VERSION_MINOR 6
-#define CJSON_VERSION_PATCH 0
+#define CJSON_VERSION_MINOR 7
+#define CJSON_VERSION_PATCH 12
 
 #include <stddef.h>
 
@@ -63,7 +113,7 @@ typedef struct cJSON
 
     /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
     char *valuestring;
-    /* writing to valueint is DEPRECATED, use snowflake_cJSON_SetNumberValue instead */
+    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
     int valueint;
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
@@ -74,54 +124,12 @@ typedef struct cJSON
 
 typedef struct cJSON_Hooks
 {
-      void *(*malloc_fn)(size_t sz);
-      void (*free_fn)(void *ptr);
+      /* malloc/free are CDECL on Windows regardless of the default calling convention of the compiler, so ensure the hooks allow passing those functions directly. */
+      void *(CJSON_CDECL *malloc_fn)(size_t sz);
+      void (CJSON_CDECL *free_fn)(void *ptr);
 } cJSON_Hooks;
 
 typedef int cJSON_bool;
-
-#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
-#define __WINDOWS__
-#endif
-#ifdef __WINDOWS__
-
-/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 2 define options:
-
-CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
-CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
-CJSON_IMPORT_SYMBOLS - Define this if you want to dllimport symbol
-
-For *nix builds that support visibility attribute, you can define similar behavior by
-
-setting default visibility to hidden by adding
--fvisibility=hidden (for gcc)
-or
--xldscope=hidden (for sun cc)
-to CFLAGS
-
-then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJSON_EXPORT_SYMBOLS does
-
-*/
-
-/* export symbols by default, this is necessary for copy pasting the C and header file */
-#if !defined(CJSON_HIDE_SYMBOLS) && !defined(CJSON_IMPORT_SYMBOLS) && !defined(CJSON_EXPORT_SYMBOLS)
-#define CJSON_EXPORT_SYMBOLS
-#endif
-
-#if defined(CJSON_HIDE_SYMBOLS)
-#define CJSON_PUBLIC(type)   type __stdcall
-#elif defined(CJSON_EXPORT_SYMBOLS)
-#define CJSON_PUBLIC(type)   __declspec(dllexport) type __stdcall
-#elif defined(CJSON_IMPORT_SYMBOLS)
-#define CJSON_PUBLIC(type)   __declspec(dllimport) type __stdcall
-#endif
-#else /* !WIN32 */
-#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
-#define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
-#else
-#define CJSON_PUBLIC(type) type
-#endif
-#endif
 
 /* Limits how deeply nested arrays/objects can be before cJSON rejects to parse them.
  * This is to prevent stack overflows. */
@@ -133,7 +141,7 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 CJSON_PUBLIC(const char*) snowflake_cJSON_Version(void);
 
 /* Supply malloc, realloc and free functions to cJSON */
-CJSON_PUBLIC(void) snowflake_cJSON_InitHooks(cJSON_Hooks *hooks);
+CJSON_PUBLIC(void) snowflake_cJSON_InitHooks(cJSON_Hooks* hooks);
 
 /* Memory Management: the caller is always responsible to free the results from all variants of snowflake_cJSON_Parse (with snowflake_cJSON_Delete) and snowflake_cJSON_Print (with stdlib free, cJSON_Hooks.free_fn, or snowflake_cJSON_free as appropriate). The exception is snowflake_cJSON_PrintPreallocated, where the caller has full responsibility of the buffer. */
 /* Supply a block of JSON, and this returns a cJSON object you can interrogate. */
@@ -149,44 +157,38 @@ CJSON_PUBLIC(char *) snowflake_cJSON_Print(const cJSON *item);
 /* Render a cJSON entity to text for transfer/storage without any formatting. */
 CJSON_PUBLIC(char *) snowflake_cJSON_PrintUnformatted(const cJSON *item);
 /* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
-CJSON_PUBLIC(char *) snowflake_cJSON_PrintBuffered(const cJSON *item,
-                                                   int prebuffer,
-                                                   cJSON_bool fmt);
+CJSON_PUBLIC(char *) snowflake_cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt);
 /* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
 /* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_PrintPreallocated(cJSON *item,
-                                                           char *buffer,
-                                                           const int length,
-                                                           const cJSON_bool format);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
 /* Delete a cJSON entity and all subentities. */
-CJSON_PUBLIC(void) snowflake_cJSON_Delete(cJSON *c);
+CJSON_PUBLIC(void) snowflake_cJSON_Delete(cJSON *item);
 
 /* Returns the number of items in an array (or object). */
 CJSON_PUBLIC(int) snowflake_cJSON_GetArraySize(const cJSON *array);
-/* Retrieve item number "item" from array "array". Returns NULL if unsuccessful. */
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_GetArrayItem(const cJSON *array,
-                                                   int index);
+/* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_GetArrayItem(const cJSON *array, int index);
 /* Get item "string" from object. Case insensitive. */
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_GetObjectItem(const cJSON *const object,
-                                                    const char *const string);
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_GetObjectItemCaseSensitive(
-  const cJSON *const object, const char *const string);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_HasObjectItem(const cJSON *object,
-                                                       const char *string);
-/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when snowflake_cJSON_Parse() succeeds. */
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_HasObjectItem(const cJSON *object, const char *string);
+/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when snowflake_cJSON_Parse() returns 0. 0 when snowflake_cJSON_Parse() succeeds. */
 CJSON_PUBLIC(const char *) snowflake_cJSON_GetErrorPtr(void);
 
+/* Check if the item is a string and return its valuestring */
+CJSON_PUBLIC(char *) snowflake_cJSON_GetStringValue(cJSON *item);
+
 /* These functions check the type of an item */
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsInvalid(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsFalse(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsTrue(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsBool(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsNull(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsNumber(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsString(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsArray(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsObject(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsRaw(const cJSON *const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsInvalid(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsFalse(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsTrue(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsBool(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsNull(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsNumber(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsString(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsArray(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsObject(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsRaw(const cJSON * const item);
 
 /* These calls create a cJSON item of the appropriate type. */
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateNull(void);
@@ -200,91 +202,77 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateRaw(const char *raw);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateArray(void);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateObject(void);
 
+/* Create a string where valuestring references a string so
+ * it will not be freed by snowflake_cJSON_Delete */
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateStringReference(const char *string);
+/* Create an object/array that only references it's elements so
+ * they will not be freed by snowflake_cJSON_Delete */
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateObjectReference(const cJSON *child);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateArrayReference(const cJSON *child);
+
 /* These utilities create an Array of count items. */
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateIntArray(const int *numbers,
-                                                     int count);
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateFloatArray(const float *numbers,
-                                                       int count);
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateDoubleArray(const double *numbers,
-                                                        int count);
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateStringArray(const char **strings,
-                                                        int count);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateIntArray(const int *numbers, int count);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateFloatArray(const float *numbers, int count);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateDoubleArray(const double *numbers, int count);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateStringArray(const char **strings, int count);
 
 /* Append item to the specified array/object. */
 CJSON_PUBLIC(void) snowflake_cJSON_AddItemToArray(cJSON *array, cJSON *item);
-CJSON_PUBLIC(void) snowflake_cJSON_AddItemToObject(cJSON *object,
-                                                   const char *string,
-                                                   cJSON *item);
+CJSON_PUBLIC(void) snowflake_cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
 /* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
- * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
+ * WARNING: When this function was used, make sure to always check that (item->type & snowflake_cJSON_StringIsConst) is zero before
  * writing to `item->string` */
-CJSON_PUBLIC(void) snowflake_cJSON_AddItemToObjectCS(cJSON *object,
-                                                     const char *string,
-                                                     cJSON *item);
+CJSON_PUBLIC(void) snowflake_cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
 /* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
-CJSON_PUBLIC(void) snowflake_cJSON_AddItemReferenceToArray(cJSON *array,
-                                                           cJSON *item);
-CJSON_PUBLIC(void) snowflake_cJSON_AddItemReferenceToObject(cJSON *object,
-                                                            const char *string,
-                                                            cJSON *item);
+CJSON_PUBLIC(void) snowflake_cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(void) snowflake_cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
 
-/* Remove/Detatch items from Arrays/Objects. */
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemViaPointer(cJSON *parent,
-                                                           cJSON *const item);
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromArray(cJSON *array,
-                                                          int which);
+/* Remove/Detach items from Arrays/Objects. */
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromArray(cJSON *array, int which);
 CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromArray(cJSON *array, int which);
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObject(cJSON *object,
-                                                           const char *string);
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(
-  cJSON *object, const char *string);
-CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object,
-                                                        const char *string);
-CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObjectCaseSensitive(
-  cJSON *object, const char *string);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string);
+CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string);
 
 /* Update array items. */
-CJSON_PUBLIC(void) snowflake_cJSON_InsertItemInArray(cJSON *array, int which,
-                                                     cJSON *newitem); /* Shifts pre-existing items to the right. */
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_ReplaceItemViaPointer(
-  cJSON *const parent, cJSON *const item, cJSON *replacement);
-CJSON_PUBLIC(void) snowflake_cJSON_ReplaceItemInArray(cJSON *array, int which,
-                                                      cJSON *newitem);
-CJSON_PUBLIC(void) snowflake_cJSON_ReplaceItemInObject(cJSON *object,
-                                                       const char *string,
-                                                       cJSON *newitem);
-CJSON_PUBLIC(void) snowflake_cJSON_ReplaceItemInObjectCaseSensitive(
-  cJSON *object, const char *string, cJSON *newitem);
+CJSON_PUBLIC(void) snowflake_cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem); /* Shifts pre-existing items to the right. */
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement);
+CJSON_PUBLIC(void) snowflake_cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
+CJSON_PUBLIC(void) snowflake_cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *newitem);
+CJSON_PUBLIC(void) snowflake_cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object,const char *string,cJSON *newitem);
 
 /* Duplicate a cJSON item */
-CJSON_PUBLIC(cJSON *) snowflake_cJSON_Duplicate(const cJSON *item,
-                                                cJSON_bool recurse);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_Duplicate(const cJSON *item, cJSON_bool recurse);
 /* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
 need to be released. With recurse!=0, it will duplicate any children connected to the item.
 The item->next and ->prev pointers are always zero on return from Duplicate. */
 /* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
  * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
-CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_Compare(const cJSON *const a,
-                                                 const cJSON *const b,
-                                                 const cJSON_bool case_sensitive);
+CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
 
-
+/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings */
+/* The input pointer json cannot point to a read-only address area, such as a string constant, 
+ * but should point to a readable and writable adress area. */
 CJSON_PUBLIC(void) snowflake_cJSON_Minify(char *json);
 
-/* Macros for creating things quickly. */
-#define snowflake_cJSON_AddNullToObject(object,name) snowflake_cJSON_AddItemToObject(object, name, snowflake_cJSON_CreateNull())
-#define snowflake_cJSON_AddTrueToObject(object,name) snowflake_cJSON_AddItemToObject(object, name, snowflake_cJSON_CreateTrue())
-#define snowflake_cJSON_AddFalseToObject(object,name) snowflake_cJSON_AddItemToObject(object, name, snowflake_cJSON_CreateFalse())
-#define snowflake_cJSON_AddBoolToObject(object,name,b) snowflake_cJSON_AddItemToObject(object, name, snowflake_cJSON_CreateBool(b))
-#define snowflake_cJSON_AddNumberToObject(object,name,n) snowflake_cJSON_AddItemToObject(object, name, snowflake_cJSON_CreateNumber(n))
-#define snowflake_cJSON_AddStringToObject(object,name,s) snowflake_cJSON_AddItemToObject(object, name, snowflake_cJSON_CreateString(s))
-#define snowflake_cJSON_AddRawToObject(object,name,s) snowflake_cJSON_AddItemToObject(object, name, snowflake_cJSON_CreateRaw(s))
+/* Helper functions for creating and adding items to an object at the same time.
+ * They return the added item or NULL on failure. */
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddNullToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddTrueToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddFalseToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddArrayToObject(cJSON * const object, const char * const name);
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
 #define snowflake_cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
 /* helper for the snowflake_cJSON_SetNumberValue macro */
-CJSON_PUBLIC(double) snowflake_cJSON_SetNumberHelper(cJSON *object,
-                                                     double number);
+CJSON_PUBLIC(double) snowflake_cJSON_SetNumberHelper(cJSON *object, double number);
 #define snowflake_cJSON_SetNumberValue(object, number) ((object != NULL) ? snowflake_cJSON_SetNumberHelper(object, (double)number) : (number))
 
 /* Macro for iterating over an array or object */

--- a/lib/client_int.h
+++ b/lib/client_int.h
@@ -15,6 +15,7 @@
 #define HEADER_ACCEPT_TYPE_APPLICATION_SNOWFLAKE "accept: application/snowflake"
 #define HEADER_ACCEPT_TYPE_APPLICATION_JSON "accept: application/json"
 #define HEADER_C_API_USER_AGENT_FORMAT "User-Agent: %s/%s (%s_%s) %s/%lu"
+#define HEADER_C_API_USER_AGENT_MAX_LEN 256
 #define HEADER_DIRECT_QUERY_TOKEN_FORMAT "Authorization: %s"
 #define HEADER_SERVICE_NAME_FORMAT "X-Snowflake-Service: %s"
 

--- a/lib/error.c
+++ b/lib/error.c
@@ -34,7 +34,7 @@ void STDCALL set_snowflake_error(SF_ERROR_STRUCT *error,
     }
 
     error->error_code = error_code;
-    strncpy(error->sfqid, sfqid, SF_UUID4_LEN);
+    sb_strncpy(error->sfqid, SF_UUID4_LEN, sfqid, SF_UUID4_LEN);
     // Null terminate
     if (error->sfqid[SF_UUID4_LEN - 1] != '\0') {
         error->sfqid[SF_UUID4_LEN - 1] = '\0';
@@ -42,7 +42,7 @@ void STDCALL set_snowflake_error(SF_ERROR_STRUCT *error,
 
     if (sqlstate != NULL) {
         /* set SQLState if specified */
-        strncpy(error->sqlstate, sqlstate, sizeof(error->sqlstate));
+        sb_strncpy(error->sqlstate, sizeof(error->sqlstate), sqlstate, sizeof(error->sqlstate));
         error->sqlstate[sizeof(error->sqlstate) - 1] = '\0';
     }
 
@@ -54,7 +54,7 @@ void STDCALL set_snowflake_error(SF_ERROR_STRUCT *error,
     /* allocate new memory */
     error->msg = SF_CALLOC(msglen + 1, sizeof(char));
     if (error->msg != NULL) {
-        strncpy(error->msg, msg, msglen);
+        sb_strncpy(error->msg, msglen + 1, msg, msglen);
         error->msg[msglen] = '\0';
         error->is_shared_msg = SF_BOOLEAN_FALSE;
     } else {
@@ -63,7 +63,7 @@ void STDCALL set_snowflake_error(SF_ERROR_STRUCT *error,
         size_t len =
           msglen > sizeof(_shared_msg) ? sizeof(_shared_msg) : msglen;
         memset(_shared_msg, 0, sizeof(_shared_msg));
-        strncpy(_shared_msg, msg, len);
+        sb_strncpy(_shared_msg, sizeof(_shared_msg), msg, len);
         _shared_msg[sizeof(_shared_msg) - 1] = '\0';
         _mutex_unlock(&mutex_shared_msg);
 
@@ -84,7 +84,7 @@ void STDCALL clear_snowflake_error(SF_ERROR_STRUCT *error) {
         /* Error already set and msg is not on shared mem */
         SF_FREE(error->msg);
     }
-    strcpy(error->sqlstate, SF_SQLSTATE_NO_ERROR);
+    sb_strcpy(error->sqlstate, sizeof(error->sqlstate), SF_SQLSTATE_NO_ERROR);
     error->error_code = SF_STATUS_SUCCESS;
     error->msg = NULL;
     error->file = NULL;

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -284,7 +284,7 @@ sf_bool STDCALL http_perform(CURL *curl,
             buffer.buffer = (char *) SF_CALLOC(1,
                                                2); // Don't forget null terminator
             buffer.size = 1;
-            strncpy(buffer.buffer, "[", 2);
+            sb_strncpy(buffer.buffer, 2, "[", 2);
         }
 
         // Be optimistic
@@ -296,11 +296,11 @@ sf_bool STDCALL http_perform(CURL *curl,
         if (res != CURLE_OK) {
             char msg[1024];
             if (res == CURLE_SSL_CACERT_BADFILE) {
-                snprintf(msg, sizeof(msg), "curl_easy_perform() failed. err: %s, CA Cert file: %s",
+                sb_sprintf(msg, sizeof(msg), "curl_easy_perform() failed. err: %s, CA Cert file: %s",
                     curl_easy_strerror(res), CA_BUNDLE_FILE ? CA_BUNDLE_FILE : "Not Specified");
             }
             else {
-                snprintf(msg, sizeof(msg), "curl_easy_perform() failed: %s", curl_easy_strerror(res));
+                sb_sprintf(msg, sizeof(msg), "curl_easy_perform() failed: %s", curl_easy_strerror(res));
             }
             msg[sizeof(msg)-1] = (char)0;
             log_error(msg);
@@ -338,7 +338,7 @@ sf_bool STDCALL http_perform(CURL *curl,
         if (chunk_downloader) {
             buffer.buffer = (char *) SF_REALLOC(buffer.buffer, buffer.size +
                                                                2); // 1 byte for closing bracket, 1 for null terminator
-            memcpy(&buffer.buffer[buffer.size], "]", 1);
+            sb_memcpy(&buffer.buffer[buffer.size], 1, "]", 1);
             buffer.size += 1;
             // Set null terminator
             buffer.buffer[buffer.size] = '\0';

--- a/lib/results.c
+++ b/lib/results.c
@@ -192,37 +192,36 @@ char *value_to_string(void *value, size_t len, SF_C_TYPE c_type) {
     if (value == NULL) {
         return NULL;
     }
+
+    // The buffer size for fixed length data types.
+    // Not necessarily to be exact length of the actual data, to avoid memory fragmentation.
+    size = 64;
+
     // TODO turn cases into macro and check to see if ret if null
     switch (c_type) {
         case SF_C_TYPE_INT8:
-            size = (size_t) snprintf( NULL, 0, "%d", *(int8 *) value) + 1;
             ret = (char *) SF_CALLOC(1, size);
-            snprintf(ret, size, "%d", *(int8 *) value);
+            sb_sprintf(ret, size, "%d", *(int8 *) value);
             return ret;
         case SF_C_TYPE_UINT8:
-            size = (size_t) snprintf( NULL, 0, "%u", *(uint8 *) value) + 1;
             ret = (char *) SF_CALLOC(1, size);
-            snprintf(ret, size, "%u", *(uint8 *) value);
+            sb_sprintf(ret, size, "%u", *(uint8 *) value);
             return ret;
         case SF_C_TYPE_INT64:
-            size = (size_t) snprintf( NULL, 0, "%lld", *(int64 *) value) + 1;
             ret = (char *) SF_CALLOC(1, size);
-            snprintf(ret, size, "%lld", *(int64 *) value);
+            sb_sprintf(ret, size, "%lld", *(int64 *) value);
             return ret;
         case SF_C_TYPE_UINT64:
-            size = (size_t) snprintf( NULL, 0, "%llu", *(uint64 *) value) + 1;
             ret = (char *) SF_CALLOC(1, size);
-            snprintf(ret, size, "%llu", *(uint64 *) value);
+            sb_sprintf(ret, size, "%llu", *(uint64 *) value);
             return ret;
         case SF_C_TYPE_FLOAT64:
-            size = (size_t) snprintf( NULL, 0, "%f", *(float64 *) value) + 1;
             ret = (char *) SF_CALLOC(1, size);
-            snprintf(ret, size, "%f", *(float64 *) value);
+            sb_sprintf(ret, size, "%f", *(float64 *) value);
             return ret;
         case SF_C_TYPE_BOOLEAN:
-            size = *(sf_bool*)value != (sf_bool)0 ? sizeof(SF_BOOLEAN_INTERNAL_TRUE_STR) : sizeof(SF_BOOLEAN_INTERNAL_FALSE_STR);
             ret = (char*) SF_CALLOC(1, size + 1);
-            strncpy(ret, *(sf_bool*)value != (sf_bool)0 ? SF_BOOLEAN_INTERNAL_TRUE_STR : SF_BOOLEAN_INTERNAL_FALSE_STR, size + 1);
+            sb_strncpy(ret, size + 1, *(sf_bool*)value != (sf_bool)0 ? SF_BOOLEAN_INTERNAL_TRUE_STR : SF_BOOLEAN_INTERNAL_FALSE_STR, size + 1);
             return ret;
         case SF_C_TYPE_BINARY:
             size = (size_t)len * 2 + 1;
@@ -233,7 +232,7 @@ char *value_to_string(void *value, size_t len, SF_C_TYPE c_type) {
         case SF_C_TYPE_STRING:
             size = (size_t)len + 1;
             ret = (char *) SF_CALLOC(1, size);
-            strncpy(ret, (const char *) value, size);
+            sb_strncpy(ret, size, (const char *) value, size);
             return ret;
         case SF_C_TYPE_TIMESTAMP:
             // TODO Add timestamp case


### PR DESCRIPTION
1. SLSL-166-1-1: Out of Date Third Party Components. Update cJSON.
2. SLSL-166-1-2: General Use of Unsafe Functions Banned Under Microsoft SDL
3. SLSL-166-1-10: Authenticator OS Command Injection
4. SLSL-166-1-20: Base64 Decoder Minor Error