### PR TITLE
ODBC driver throws error with SOURCE_COMPRESSION = GZIP

### DIFF
--- a/cpp/FileCompressionType.cpp
+++ b/cpp/FileCompressionType.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <ios>
 #include <cstring>
+#include <snowflake/platform.h>
 #include "FileCompressionType.hpp"
 
 using Snowflake::Client::FileCompressionType;
@@ -204,7 +205,7 @@ const FileCompressionType *FileCompressionType::lookUpByName(const char *name)
 {
   for (size_t i=0; i<types.size(); i++)
   {
-    if (!strncmp(name, (const char*)(types.at(i)->m_name), sizeof(types.at(i)->m_name)))
+    if (!sf_strncasecmp(name, (const char*)(types.at(i)->m_name), sizeof(types.at(i)->m_name)))
     {
       return types.at(i);
     }

--- a/tests/test_simple_put.cpp
+++ b/tests/test_simple_put.cpp
@@ -223,6 +223,12 @@ void test_simple_put_gzip(void **unused)
   test_simple_put_core("small_file.csv.gz", "gzip", true);
 }
 
+void test_simple_put_gzip_caseInsensitive(void **unused)
+{
+  //AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP
+  test_simple_put_core("small_file.csv.gz", "GziP", false);
+}
+
 void test_simple_put_zero_byte(void **unused)
 {
   test_simple_put_core("zero_byte.csv", "auto", true, false);
@@ -371,6 +377,7 @@ int main(void) {
     cmocka_unit_test_teardown(test_simple_put_auto_detect_gzip, teardown),
     cmocka_unit_test_teardown(test_simple_put_no_compress, teardown),
     cmocka_unit_test_teardown(test_simple_put_gzip, teardown),
+    cmocka_unit_test_teardown(test_simple_put_gzip_caseInsensitive, teardown),
     cmocka_unit_test_teardown(test_simple_put_zero_byte, teardown),
     cmocka_unit_test_teardown(test_simple_put_one_byte, teardown),
     cmocka_unit_test_teardown(test_simple_put_skip, teardown),


### PR DESCRIPTION
We need case insensitive comparison here. 