### PR TITLE
Fix Visual Studio level 3 compiler warnings

### DIFF
--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -80,12 +80,12 @@ void Snowflake::Client::FileMetadataInitializer::populateSrcLocUploadMetadata(
     if (!(fdd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) )
     {
       std::string fileFullPath = std::string(fdd.cFileName);
-      unsigned long dirSep = sourceLocation.find_last_of(PATH_SEP);
+      size_t dirSep = sourceLocation.find_last_of(PATH_SEP);
       std::string dirPath = sourceLocation.substr(0, dirSep + 1);
       LARGE_INTEGER fileSize;
       fileSize.LowPart = fdd.nFileSizeLow;
       fileSize.HighPart = fdd.nFileSizeHigh;
-      initFileMetadata(dirPath, (char *)fdd.cFileName, fileSize.QuadPart);
+      initFileMetadata(dirPath, (char *)fdd.cFileName, (long)fileSize.QuadPart);
     }
   } while (FindNextFile(hFind, &fdd) != 0);
 
@@ -216,7 +216,7 @@ void Snowflake::Client::FileMetadataInitializer::initEncryptionMetadata(
   fileMetadata->encryptionMetadata.cipherStreamSize = (long long int)
     ((fileMetadata->srcFileToUploadSize + encryptionBlockSize) /
     encryptionBlockSize * encryptionBlockSize);
-  fileMetadata->destFileSize = fileMetadata->encryptionMetadata.cipherStreamSize;
+  fileMetadata->destFileSize = (long)(fileMetadata->encryptionMetadata.cipherStreamSize);
 }
 
 Snowflake::Client::RemoteStorageRequestOutcome
@@ -227,7 +227,7 @@ populateSrcLocDownloadMetadata(std::string &sourceLocation,
                                EncryptionMaterial *encMat)
 {
   std::string fullPath = *remoteLocation + sourceLocation;
-  unsigned long dirSep = fullPath.find_last_of('/');
+  size_t dirSep = fullPath.find_last_of('/');
   std::string dstFileName = fullPath.substr(dirSep + 1);
 
   FileMetadata fileMetadata;

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -170,7 +170,7 @@ void Snowflake::Client::FileTransferAgent::uploadFilesInParallel(std::string *co
   Snowflake::Client::Util::ThreadPool tp((unsigned int)response.parallel);
   for (size_t i=0; i<m_smallFilesMeta.size(); i++)
   {
-    unsigned int resultIndex = i + m_largeFilesMeta.size();
+    size_t resultIndex = i + m_largeFilesMeta.size();
     FileMetadata * metadata = &m_smallFilesMeta[i];
     m_executionResults->SetFileMetadata(&m_smallFilesMeta[i], resultIndex);
     metadata->overWrite = response.overwrite;
@@ -222,7 +222,7 @@ void Snowflake::Client::FileTransferAgent::renewToken(std::string *command)
 RemoteStorageRequestOutcome Snowflake::Client::FileTransferAgent::uploadSingleFile(
   IStorageClient *client,
   FileMetadata *fileMetadata,
-  unsigned int resultIndex)
+  size_t resultIndex)
 {
   // compress if required
   if (fileMetadata->requireCompress)
@@ -364,7 +364,7 @@ void Snowflake::Client::FileTransferAgent::downloadFilesInParallel(std::string *
   Snowflake::Client::Util::ThreadPool tp((unsigned int)response.parallel);
   for (size_t i=0; i<m_smallFilesMeta.size(); i++)
   {
-    unsigned int resultIndex = i + m_largeFilesMeta.size();
+    size_t resultIndex = i + m_largeFilesMeta.size();
     FileMetadata * metadata = &m_smallFilesMeta[i];
     m_executionResults->SetFileMetadata(&m_smallFilesMeta[i], resultIndex);
     tp.AddJob([metadata, resultIndex, command, this]()->void {
@@ -393,7 +393,7 @@ void Snowflake::Client::FileTransferAgent::downloadFilesInParallel(std::string *
 RemoteStorageRequestOutcome Snowflake::Client::FileTransferAgent::downloadSingleFile(
   IStorageClient *client,
   FileMetadata *fileMetadata,
-  unsigned int resultIndex)
+  size_t resultIndex)
 {
    fileMetadata->destPath = std::string(response.localLocation) + PATH_SEP +
     fileMetadata->destFileName;

--- a/cpp/FileTransferAgent.hpp
+++ b/cpp/FileTransferAgent.hpp
@@ -23,7 +23,7 @@ namespace Client
 
 class IStorageClient;
 
-struct FileTransferExecutionResult;
+class FileTransferExecutionResult;
 
 /**
  * This is the main class to external component (c api or ODBC)
@@ -63,7 +63,7 @@ private:
    * Upload single file.
    */
   RemoteStorageRequestOutcome uploadSingleFile(IStorageClient *client,
-    FileMetadata *fileMetadata, unsigned int resultIndex);
+    FileMetadata *fileMetadata, size_t resultIndex);
 
   /**
    * Given file name, calculate sha256 message digest. The digest is
@@ -93,7 +93,7 @@ private:
    * Download single file.
    */
   RemoteStorageRequestOutcome downloadSingleFile(IStorageClient *client,
-                                                 FileMetadata *fileMetadata, unsigned int resultIndex);
+                                                 FileMetadata *fileMetadata, size_t resultIndex);
 
   /**
    * compress source file into a temporary file if required by

--- a/cpp/FileTransferExecutionResult.cpp
+++ b/cpp/FileTransferExecutionResult.cpp
@@ -49,7 +49,7 @@ enum GET_COLUMN
 
 FileTransferExecutionResult::FileTransferExecutionResult(
   CommandType commandType,
-  unsigned int resultEntryNum) :
+  size_t resultEntryNum) :
   m_commandType(commandType),
   m_resultEntryNum(resultEntryNum),
   m_currentIndex(-1)
@@ -67,7 +67,7 @@ FileTransferExecutionResult::~FileTransferExecutionResult()
 bool FileTransferExecutionResult::next()
 {
   m_currentIndex ++;
-  return m_currentIndex < m_resultEntryNum;
+  return (unsigned int)m_currentIndex < m_resultEntryNum;
 }
 
 const char* FileTransferExecutionResult::fromOutcomeToStr(
@@ -104,7 +104,7 @@ unsigned int FileTransferExecutionResult::getColumnSize()
   }
 }
 
-const char * FileTransferExecutionResult::getColumnName(int columnIndex)
+const char * FileTransferExecutionResult::getColumnName(unsigned int columnIndex)
 {
   if (columnIndex < getColumnSize())
   {
@@ -125,12 +125,12 @@ const char * FileTransferExecutionResult::getColumnName(int columnIndex)
   }
 }
 
-int FileTransferExecutionResult::getResultSize()
+size_t FileTransferExecutionResult::getResultSize()
 {
   return m_resultEntryNum;
 }
 
-void FileTransferExecutionResult::getColumnAsString(int columnIndex,
+void FileTransferExecutionResult::getColumnAsString(unsigned int columnIndex,
                                                     std::string & value)
 {
   if (columnIndex < getColumnSize())

--- a/cpp/FileTransferExecutionResult.hpp
+++ b/cpp/FileTransferExecutionResult.hpp
@@ -26,29 +26,29 @@ class FileTransferExecutionResult : public ITransferResult
 {
 public:
   FileTransferExecutionResult(CommandType commandType,
-                              unsigned int resultEntryNum);
+                              size_t resultEntryNum);
 
   ~FileTransferExecutionResult();
 
-  void SetTransferOutCome(RemoteStorageRequestOutcome outcome, unsigned int index)
+  void SetTransferOutCome(RemoteStorageRequestOutcome outcome, size_t index)
   {
     m_outcomes[index] = outcome;
   }
 
-  void SetFileMetadata(FileMetadata *fileMetadata, unsigned int index)
+  void SetFileMetadata(FileMetadata *fileMetadata, size_t index)
   {
     m_fileMetadatas[index] = fileMetadata;
   }
 
   bool next();
 
-  int getResultSize();
+  size_t getResultSize();
 
   unsigned int getColumnSize();
 
-  const char * getColumnName(int columnIndex);
+  const char * getColumnName(unsigned int columnIndex);
 
-  void getColumnAsString(int columnIndex, std::string &value);
+  void getColumnAsString(unsigned int columnIndex, std::string &value);
 
   CommandType getCommandType();
 
@@ -65,7 +65,7 @@ private:
   RemoteStorageRequestOutcome * m_outcomes;
 
   /// result size
-  unsigned int m_resultEntryNum;
+  size_t m_resultEntryNum;
 
   /// current index already consumed
   int m_currentIndex;

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -385,7 +385,7 @@ RemoteStorageRequestOutcome SnowflakeS3Client::doMultiPartDownload(
 
   std::string bucket, key;
   extractBucketAndKey(&fileMetadata->srcFileName, bucket, key);
-  int partNum = (int)(fileMetadata->srcFileSize / DATA_SIZE_THRESHOLD) + 1;
+  unsigned int partNum = (unsigned int)(fileMetadata->srcFileSize / DATA_SIZE_THRESHOLD) + 1;
   CXX_LOG_DEBUG("Construct get object request: bucket: %s, key: %s, ",
                bucket.c_str(), key.c_str());
 
@@ -507,7 +507,7 @@ RemoteStorageRequestOutcome SnowflakeS3Client::GetRemoteFileMetadata(
 
   if (outcome.IsSuccess())
   {
-    fileMetadata->srcFileSize = outcome.GetResult().GetContentLength();
+    fileMetadata->srcFileSize = (long)outcome.GetResult().GetContentLength();
     CXX_LOG_INFO("Remote file %s content length: %ld.",
                   key.c_str(), fileMetadata->srcFileSize);
 

--- a/cpp/SnowflakeTransferException.cpp
+++ b/cpp/SnowflakeTransferException.cpp
@@ -25,10 +25,14 @@ Snowflake::Client::SnowflakeTransferException::SnowflakeTransferException(
 {
   const char * msgFmt = errorMsgFmts[(int)transferError];
   va_list args;
+#if defined(__APPLE__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvarargs"
+#endif
   va_start (args, transferError);
+#if defined(__APPLE__)
 #pragma clang diagnostic pop
+#endif
   sb_vsnprintf(m_msg, sizeof(m_msg), sizeof(m_msg) - 1, msgFmt, args);
   va_end(args);
 }

--- a/cpp/crypto/CipherContext.cpp
+++ b/cpp/crypto/CipherContext.cpp
@@ -247,7 +247,7 @@ size_t CipherContext::next(void *const out,
 
   // Continue current operation.
   auto &impl = *m_pimpl;
-  bool success = false;
+  int success = 0;
   int nbBytesOut;
   switch (impl.op)
   {
@@ -257,7 +257,7 @@ size_t CipherContext::next(void *const out,
                                   static_cast<unsigned char *>(out),
                                   &nbBytesOut,
                                   static_cast<const unsigned char *>(in),
-                                  len);
+                                  (int)len);
       break;
 
     case CryptoOperation::DECRYPT:
@@ -265,7 +265,7 @@ size_t CipherContext::next(void *const out,
                                   static_cast<unsigned char *>(out),
                                   &nbBytesOut,
                                   static_cast<const unsigned char *>(in),
-                                  len);
+                                  (int)len);
       break;
 
     default:
@@ -303,7 +303,7 @@ size_t CipherContext::finalize(void *const out)
 
   // Finalize current operation.
   auto &impl = *m_pimpl;
-  bool success;
+  int success;
   int nbBytesOut;
   switch (impl.op)
   {

--- a/cpp/crypto/CipherStreamBuf.cpp
+++ b/cpp/crypto/CipherStreamBuf.cpp
@@ -56,7 +56,7 @@ int CipherStreamBuf::underflow()
     ::std::streamsize bytesRead = m_streambuf->sgetn(m_srcBuffer,
                                                      m_blockSize);
 
-    m_readReachEnds = bytesRead < m_blockSize;
+    m_readReachEnds = (size_t)bytesRead < m_blockSize;
     size_t nextSize = m_cipherCtx.next(m_resultBuffer, m_srcBuffer,
                                 (size_t) bytesRead);
 
@@ -89,7 +89,7 @@ int CipherStreamBuf::overflow(int_type ch)
 
     std::streamsize written = m_streambuf->sputn(m_resultBuffer,
                                                  nextSize + finalSize);
-    if (written < nextSize)
+    if ((size_t)written < nextSize)
     {
       return traits_type::eof();
     }

--- a/cpp/jwt/Signer.cpp
+++ b/cpp/jwt/Signer.cpp
@@ -51,6 +51,7 @@ std::string AlgorithmTypeMapper::toString(AlgorithmType type)
     case AlgorithmType::ES512:
       return ES_512;
     case AlgorithmType::UNKNOWN:
+    default:
       return unknown;
   }
 }

--- a/cpp/util/Base64.hpp
+++ b/cpp/util/Base64.hpp
@@ -161,7 +161,7 @@ struct Base64 final
     ReverseIndex(const char index_size, const char *index) noexcept
     {
         std::memset(data, 0xFF, sizeof(data));
-        for (size_t i = 0; i < index_size; ++i)
+        for (unsigned char i = 0; i < index_size; ++i)
             data[static_cast<unsigned char>(index[i])] = i;
     }
 

--- a/cpp/util/ByteArrayStreamBuf.cpp
+++ b/cpp/util/ByteArrayStreamBuf.cpp
@@ -39,7 +39,7 @@ Snowflake::Client::Util::StreamSplitter::StreamSplitter(
   m_currentPartIndex(-1)
 {
   _critical_section_init(&streamMutex);
-  for (int i=0; i<numOfBuffer; i++)
+  for (unsigned int i=0; i<numOfBuffer; i++)
   {
     buffers.push_back(new ByteArrayStreamBuf(partMaxSize));
   }
@@ -53,7 +53,7 @@ Snowflake::Client::Util::StreamSplitter::FillAndGetBuf(
   ByteArrayStreamBuf * buf = buffers[bufIndex];
   memset(buf->getDataBuffer(), 0, m_partMaxSize);
   m_inputStream->read(buf->getDataBuffer(), m_partMaxSize);
-  buf->updateSize(m_inputStream->gcount());
+  buf->updateSize((long)m_inputStream->gcount());
   m_currentPartIndex ++;
   partIndex = m_currentPartIndex;
   _critical_section_unlock(&streamMutex);
@@ -72,7 +72,7 @@ Snowflake::Client::Util::StreamSplitter::~StreamSplitter()
 unsigned int Snowflake::Client::Util::StreamSplitter::getTotalParts(
   long long int streamSize)
 {
-  return streamSize/m_partMaxSize + 1;
+  return (unsigned int)(streamSize/m_partMaxSize + 1);
 }
 
 Snowflake::Client::Util::StreamAppender::StreamAppender(

--- a/cpp/util/CompressionUtil.cpp
+++ b/cpp/util/CompressionUtil.cpp
@@ -14,7 +14,7 @@
 #ifdef _WIN32
 #  include <fcntl.h>
 #  include <io.h>
-#  define SET_BINARY_MODE(file) setmode(fileno(file), O_BINARY)
+#  define SET_BINARY_MODE(file) _setmode(_fileno(file), O_BINARY)
 #else
 #  define SET_BINARY_MODE(file)
 #endif
@@ -45,7 +45,7 @@ int Snowflake::Client::Util::CompressionUtil::compressWithGzip(FILE *source,
   /* compress until end of file */
   do
   {
-    strm.avail_in = fread(in, 1, CHUNK, source);
+    strm.avail_in = (unsigned int)fread(in, 1, CHUNK, source);
     if (ferror(source))
     {
       (void) deflateEnd(&strm);
@@ -109,7 +109,7 @@ int Snowflake::Client::Util::CompressionUtil::decompressWithGzip(FILE *source,
 
   /* decompress until deflate stream ends or end of file */
   do {
-    strm.avail_in = fread(in, 1, CHUNK, source);
+    strm.avail_in = (unsigned int)fread(in, 1, CHUNK, source);
     if (ferror(source)) {
       (void)inflateEnd(&strm);
       return Z_ERRNO;

--- a/include/snowflake/ITransferResult.hpp
+++ b/include/snowflake/ITransferResult.hpp
@@ -34,7 +34,7 @@ public:
   /**
    * @return result size, a.k.a number of file that has been transferred
    */
-  virtual int getResultSize() = 0;
+  virtual size_t getResultSize() = 0;
 
   /**
    * @return number of column
@@ -44,12 +44,12 @@ public:
   /**
    * @return column name given a column index, index starts from 0
    */
-  virtual const char * getColumnName(int columnIndex) = 0;
+  virtual const char * getColumnName(unsigned int columnIndex) = 0;
 
   /**
    * @return column value as string
    */
-  virtual void getColumnAsString(int columnIndex, std::string & value) = 0;
+  virtual void getColumnAsString(unsigned int columnIndex, std::string & value) = 0;
 
   /**
    * @return command type (upload or download) for file transfer

--- a/lib/chunk_downloader.c
+++ b/lib/chunk_downloader.c
@@ -166,7 +166,7 @@ cleanup:
 
 sf_bool STDCALL create_chunk_headers(struct SF_CHUNK_DOWNLOADER *chunk_downloader, cJSON *json_headers) {
     sf_bool ret = SF_BOOLEAN_FALSE;
-    int header_field_size;
+    size_t header_field_size;
     size_t i;
     cJSON *item = NULL;
     char *header_item = NULL;

--- a/lib/client.c
+++ b/lib/client.c
@@ -1443,7 +1443,6 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
     clear_snowflake_error(&sfstmt->error);
     SF_STATUS ret = SF_STATUS_ERROR_GENERAL;
     sf_bool get_chunk_success = SF_BOOLEAN_TRUE;
-    int64 i;
     uint64 index;
     if (sfstmt->cur_row != NULL) {
         snowflake_cJSON_Delete(sfstmt->cur_row);
@@ -2058,7 +2057,7 @@ SF_STATUS STDCALL snowflake_stmt_set_attr(
     clear_snowflake_error(&sfstmt->error);
     switch(type) {
         case SF_STMT_USER_REALLOC_FUNC:
-            sfstmt->user_realloc_func = value;
+            sfstmt->user_realloc_func = (void*(*)(void*, size_t))value;
             break;
         default:
             SET_SNOWFLAKE_ERROR(

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -7,7 +7,7 @@
 #include "snowflake/platform.h"
 
 // Basic hashing function. Works well for memory addresses
-#define sf_ptr_hash(p, t) (((unsigned long) (p) >> 3) & (sizeof (t)/sizeof ((t)[0]) - 1))
+#define sf_ptr_hash(p, t) (((unsigned long) ((unsigned long long)p) >> 3) & (sizeof (t)/sizeof ((t)[0]) - 1))
 #define SF_ALLOC_MAP_SIZE 2048
 
 static SF_MUTEX_HANDLE allocation_lock;


### PR DESCRIPTION
1. Add check for correct platform before compiler-specific pragmas.
`cpp/SnowflakeTransferException.cpp`
2. Remove deprecated alias setmode and use  _setmode instead.
 `cpp/util/CompressionUtil.cpp`
3. Make various type casts/changes.