### PR TITLE
mask logging of sensitive information from AWS SDK

### DIFF
--- a/cpp/logger/SFAwsLogger.cpp
+++ b/cpp/logger/SFAwsLogger.cpp
@@ -10,6 +10,19 @@
 #define AWS_NS "AwsSdk"
 #define AWS_LINE 0
 
+namespace
+{
+  size_t findCaseInsensitive(std::string data, std::string toSearch, size_t pos = 0)
+  {
+    // Convert complete given String to lower case
+    std::transform(data.begin(), data.end(), data.begin(), ::tolower);
+    // Convert complete given Sub String to lower case
+    std::transform(toSearch.begin(), toSearch.end(), toSearch.begin(), ::tolower);
+    // Find sub string in given string
+    return data.find(toSearch, pos);
+  }
+}
+
 Snowflake::Client::SFAwsLogger::SFAwsLogger()
 {}
 
@@ -44,7 +57,19 @@ void Snowflake::Client::SFAwsLogger::LogStream(LogLevel logLevel,
                                                const char *tag,
                                                const Aws::OStringStream &messageStream)
 {
-  this->Log(logLevel, tag, "%s", messageStream.rdbuf()->str().c_str());
+  std::string logStr = messageStream.rdbuf()->str();
+  if ((std::string::npos != findCaseInsensitive(logStr, "token")) ||
+      (std::string::npos != findCaseInsensitive(logStr, "Credential")) ||
+      (std::string::npos != findCaseInsensitive(logStr, "Signature")) ||
+      (std::string::npos != findCaseInsensitive(logStr, "authorization")) ||
+      (std::string::npos != findCaseInsensitive(logStr, "amz-key")) ||
+      (std::string::npos != findCaseInsensitive(logStr, "amz-iv")) ||
+      (std::string::npos != findCaseInsensitive(logStr, "smkId")))
+  {
+    return;
+  }
+
+  this->Log(logLevel, tag, "%s", logStr.c_str());
 }
 
 int Snowflake::Client::SFAwsLogger::toSFLogeLevel(LogLevel logLevel)


### PR DESCRIPTION
This change can fix the test case failure for logging of put/get on GCP.