### PR TITLE
SNOW-170115 ODBC put on windows fails when file paths have forward slash

### DIFF
--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -81,11 +81,17 @@ void Snowflake::Client::FileMetadataInitializer::populateSrcLocUploadMetadata(st
     {
       std::string fileFullPath = std::string(fdd.cFileName);
       size_t dirSep = sourceLocation.find_last_of(PATH_SEP);
-      std::string dirPath = sourceLocation.substr(0, dirSep + 1);
-      LARGE_INTEGER fileSize;
-      fileSize.LowPart = fdd.nFileSizeLow;
-      fileSize.HighPart = fdd.nFileSizeHigh;
-      initUploadFileMetadata(dirPath, (char *)fdd.cFileName, (long)fileSize.QuadPart, putThreshold);
+	  if (dirSep == std::string::npos) 
+	  {
+		  dirSep = sourceLocation.find_last_of(ALTER_PATH_SEP);
+	  }
+	  if (dirSep != std::string::npos) {
+		  std::string dirPath = sourceLocation.substr(0, dirSep + 1);
+		  LARGE_INTEGER fileSize;
+		  fileSize.LowPart = fdd.nFileSizeLow;
+		  fileSize.HighPart = fdd.nFileSizeHigh;
+		  initUploadFileMetadata(dirPath, (char *)fdd.cFileName, (long)fileSize.QuadPart, putThreshold);
+	  }
     }
   } while (FindNextFile(hFind, &fdd) != 0);
 

--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -81,17 +81,18 @@ void Snowflake::Client::FileMetadataInitializer::populateSrcLocUploadMetadata(st
     {
       std::string fileFullPath = std::string(fdd.cFileName);
       size_t dirSep = sourceLocation.find_last_of(PATH_SEP);
-	  if (dirSep == std::string::npos) 
-	  {
-		  dirSep = sourceLocation.find_last_of(ALTER_PATH_SEP);
-	  }
-	  if (dirSep != std::string::npos) {
-		  std::string dirPath = sourceLocation.substr(0, dirSep + 1);
-		  LARGE_INTEGER fileSize;
-		  fileSize.LowPart = fdd.nFileSizeLow;
-		  fileSize.HighPart = fdd.nFileSizeHigh;
-		  initUploadFileMetadata(dirPath, (char *)fdd.cFileName, (long)fileSize.QuadPart, putThreshold);
-	  }
+      if (dirSep == std::string::npos) 
+      {
+        dirSep = sourceLocation.find_last_of(ALTER_PATH_SEP);
+      }
+      if (dirSep != std::string::npos) 
+      {
+        std::string dirPath = sourceLocation.substr(0, dirSep + 1);
+        LARGE_INTEGER fileSize;
+        fileSize.LowPart = fdd.nFileSizeLow;
+        fileSize.HighPart = fdd.nFileSizeHigh;
+        initUploadFileMetadata(dirPath, (char *)fdd.cFileName, (long)fileSize.QuadPart, putThreshold);
+      }
     }
   } while (FindNextFile(hFind, &fdd) != 0);
 

--- a/include/snowflake/platform.h
+++ b/include/snowflake/platform.h
@@ -24,6 +24,7 @@ typedef SRWLOCK SF_RWLOCK_HANDLE;
 typedef HANDLE SF_MUTEX_HANDLE;
 
 #define PATH_SEP '\\'
+#define ALTER_PATH_SEP '/'
 //On windows MAX_PATH is defined as 255
 
 #else

--- a/tests/test_unit_file_metadata_init.cpp
+++ b/tests/test_unit_file_metadata_init.cpp
@@ -70,30 +70,30 @@ std::vector<std::string> getListOfTestFileMatchDir()
 void test_file_pattern_match_core(std::vector<std::string> *expectedFiles,
                                   const char *filePattern)
 {
-	std::vector<std::string> listTestDir = getListOfTestFileMatchDir();
-	for (auto testDir : listTestDir)
-	{
-		std::vector<FileMetadata> smallFileMetadata;
-		std::vector<FileMetadata> largeFileMetadata;
+  std::vector<std::string> listTestDir = getListOfTestFileMatchDir();
+  for (auto testDir : listTestDir)
+  {
+    std::vector<FileMetadata> smallFileMetadata;
+    std::vector<FileMetadata> largeFileMetadata;
 
-		FileMetadataInitializer initializer(smallFileMetadata, largeFileMetadata);
-		initializer.setSourceCompression((char *)"none");
-  
-		std::string fullFilePattern = testDir + filePattern;
-		initializer.populateSrcLocUploadMetadata(fullFilePattern, DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD);
+    FileMetadataInitializer initializer(smallFileMetadata, largeFileMetadata);
+    initializer.setSourceCompression((char *)"none");
 
-		std::unordered_set<std::string> actualFiles;
-		for (auto i = smallFileMetadata.begin(); i != smallFileMetadata.end(); i++) {
-		  actualFiles.insert(i->srcFileName);
-		}
+    std::string fullFilePattern = testDir + filePattern;
+    initializer.populateSrcLocUploadMetadata(fullFilePattern, DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD);
 
-		std::unordered_set<std::string> expectedFilesFull;
-		for (auto i = expectedFiles->begin(); i != expectedFiles->end(); i++) {
-		  std::string expectedFileFull = testDir + *i;
-		  expectedFilesFull.insert(expectedFileFull);
-		}
+    std::unordered_set<std::string> actualFiles;
+    for (auto i = smallFileMetadata.begin(); i != smallFileMetadata.end(); i++) {
+      actualFiles.insert(i->srcFileName);
+    }
 
-		assert_true(expectedFilesFull == actualFiles);
+    std::unordered_set<std::string> expectedFilesFull;
+    for (auto i = expectedFiles->begin(); i != expectedFiles->end(); i++) {
+      std::string expectedFileFull = testDir + *i;
+      expectedFilesFull.insert(expectedFileFull);
+    }
+
+    assert_true(expectedFilesFull == actualFiles);
   }
 }
 

--- a/tests/test_unit_file_metadata_init.cpp
+++ b/tests/test_unit_file_metadata_init.cpp
@@ -14,7 +14,7 @@
 #include <map>
 
 #define FILES_IN_DIR "file1.csv", "file2.csv", "file3.csv", "file4.csv", "file1.gz"
-char tempDir[MAX_PATH+1]={0};
+
 
 typedef ::Snowflake::Client::FileCompressionType FileCompressionType;
 

--- a/tests/test_unit_file_metadata_init.cpp
+++ b/tests/test_unit_file_metadata_init.cpp
@@ -83,12 +83,14 @@ void test_file_pattern_match_core(std::vector<std::string> *expectedFiles,
     initializer.populateSrcLocUploadMetadata(fullFilePattern, DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD);
 
     std::unordered_set<std::string> actualFiles;
-    for (auto i = smallFileMetadata.begin(); i != smallFileMetadata.end(); i++) {
+    for (auto i = smallFileMetadata.begin(); i != smallFileMetadata.end(); i++) 
+    {
       actualFiles.insert(i->srcFileName);
     }
 
     std::unordered_set<std::string> expectedFilesFull;
-    for (auto i = expectedFiles->begin(); i != expectedFiles->end(); i++) {
+    for (auto i = expectedFiles->begin(); i != expectedFiles->end(); i++) 
+    {
       std::string expectedFileFull = testDir + *i;
       expectedFilesFull.insert(expectedFileFull);
     }

--- a/tests/test_unit_file_metadata_init.cpp
+++ b/tests/test_unit_file_metadata_init.cpp
@@ -54,11 +54,10 @@ void replaceStrAll(std::string &stringToReplace,
 std::vector<std::string> getListOfTestFileMatchDir()
 {
   std::vector<std::string> listOfTestDirs; 
-  sf_get_uniq_tmp_dir(tempDir);
-  std::string srcLocation (tempDir);
   #ifdef _WIN32
+  std::string srcLocation = getTestFileMatchDir();
   replaceStrAll(srcLocation,"\\","/");
-  // Directory path is looks like C:/Users/vreddy/App/Temp/adkf-kasdfk-adsfl/
+  // Directory path looks like C:/Users/vreddy/App/Temp/adkf-kasdfk-adsfl/
   // Testing forward slash for put/get support
   listOfTestDirs.push_back(srcLocation);
   #endif
@@ -71,30 +70,30 @@ std::vector<std::string> getListOfTestFileMatchDir()
 void test_file_pattern_match_core(std::vector<std::string> *expectedFiles,
                                   const char *filePattern)
 {
-  std::vector<FileMetadata> smallFileMetadata;
-  std::vector<FileMetadata> largeFileMetadata;
+	std::vector<std::string> listTestDir = getListOfTestFileMatchDir();
+	for (auto testDir : listTestDir)
+	{
+		std::vector<FileMetadata> smallFileMetadata;
+		std::vector<FileMetadata> largeFileMetadata;
 
-  FileMetadataInitializer initializer(smallFileMetadata, largeFileMetadata);
-  initializer.setSourceCompression((char *)"none");
+		FileMetadataInitializer initializer(smallFileMetadata, largeFileMetadata);
+		initializer.setSourceCompression((char *)"none");
   
-  std::vector<std::string> listTestDir = getListOfTestFileMatchDir();
-  for(auto testDir : listTestDir)
-  {
-    std::string fullFilePattern = testDir + filePattern;
-    initializer.populateSrcLocUploadMetadata(fullFilePattern, DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD);
+		std::string fullFilePattern = testDir + filePattern;
+		initializer.populateSrcLocUploadMetadata(fullFilePattern, DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD);
 
-    std::unordered_set<std::string> actualFiles;
-    for (auto i = smallFileMetadata.begin(); i != smallFileMetadata.end(); i++) {
-      actualFiles.insert(i->srcFileName);
-    }
+		std::unordered_set<std::string> actualFiles;
+		for (auto i = smallFileMetadata.begin(); i != smallFileMetadata.end(); i++) {
+		  actualFiles.insert(i->srcFileName);
+		}
 
-    std::unordered_set<std::string> expectedFilesFull;
-    for (auto i = expectedFiles->begin(); i != expectedFiles->end(); i++) {
-      std::string expectedFileFull = testDir + *i;
-      expectedFilesFull.insert(expectedFileFull);
-    }
+		std::unordered_set<std::string> expectedFilesFull;
+		for (auto i = expectedFiles->begin(); i != expectedFiles->end(); i++) {
+		  std::string expectedFileFull = testDir + *i;
+		  expectedFilesFull.insert(expectedFileFull);
+		}
 
-    assert_true(expectedFilesFull == actualFiles);
+		assert_true(expectedFilesFull == actualFiles);
   }
 }
 


### PR DESCRIPTION
On windows file path C:/Users/vreddy/TestData/testput.csv fails to upload.

This fix will address this issue.