### PR TITLE
SNOW-163154 Fixes auto compression guess

### DIFF
--- a/cpp/FileCompressionType.cpp
+++ b/cpp/FileCompressionType.cpp
@@ -189,10 +189,14 @@ const FileCompressionType *FileCompressionType::
     // https://github.com/madler/brotli/blob/master/br-format-v3.txt
     if (types.at(i) == &FileCompressionType::BROTLI)
     {
-      std::string file_ext = fileFullPath.substr(fileFullPath.find_last_of('.'));
-      if (!strcmp(file_ext.c_str(), types.at(i)->getFileExtension()))
+      auto pos = fileFullPath.find_last_of('.');
+      if( pos != std::string::npos) 
       {
-        return types.at(i);
+        std::string file_ext = fileFullPath.substr(pos);
+        if (!strcmp(file_ext.c_str(), types.at(i)->getFileExtension())) 
+        {
+          return types.at(i);
+        }
       }
     }
   }

--- a/tests/test_unit_file_type_detect.cpp
+++ b/tests/test_unit_file_type_detect.cpp
@@ -65,6 +65,11 @@ void test_detect_orc(void **unused)
   test_file_type_detect_core(&FileCompressionType::ORC, "TestOrcFile.test1.orc");
 }
 
+void test_detect_noextension(void **unused)
+{
+  test_file_type_detect_core(&FileCompressionType::NONE, "small_file");
+}
+
 int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_detect_gzip),
@@ -76,6 +81,7 @@ int main(void) {
     cmocka_unit_test(test_detect_brotli),
     cmocka_unit_test(test_detect_parquet),
     cmocka_unit_test(test_detect_orc),
+    cmocka_unit_test(test_detect_noextension),
   };
   int ret = cmocka_run_group_tests(tests, NULL, NULL);
   return ret;


### PR DESCRIPTION
When a file with no extension is uploaded, the driver tries to guess the file type compression and fails. 

This fixes the type and returns unknown so we handle it as a normal file.