### PR TITLE
Add simba.ini info to oob

### DIFF
--- a/deps/oob-1.0.2/jsonutil.c
+++ b/deps/oob-1.0.2/jsonutil.c
@@ -23,6 +23,7 @@ static struct logDetails oobevent = {{0}, {0}, {0}, {0}, 0, 0};
 
 cJSON* dsn = NULL;
 
+// stores simba.snowflake.ini key value pairs
 cJSON* simba = NULL;
 
 void setdeployment(const char* host);

--- a/deps/oob-1.0.2/jsonutil.c
+++ b/deps/oob-1.0.2/jsonutil.c
@@ -522,4 +522,6 @@ static void freeAll(void)
   memset(connectionInfo.sqlstate,0, 64);
   oobevent.errorCode = 0;
   oobevent.urgent = 0;
+  dsn = NULL;
+  simba = NULL;
 }

--- a/deps/oob-1.0.2/jsonutil.c
+++ b/deps/oob-1.0.2/jsonutil.c
@@ -23,6 +23,8 @@ static struct logDetails oobevent = {{0}, {0}, {0}, {0}, 0, 0};
 
 cJSON* dsn = NULL;
 
+cJSON* simba = NULL;
+
 void setdeployment(const char* host);
 
 int sendOOBevent(char* event);
@@ -220,6 +222,7 @@ char* prepareOOBevent(oobOcspData* ocspevent)
   cJSON_AddItemToObject(list, "Value", vals);
 
   cJSON_AddItemToObject(vals, "DSN", dsn);
+  cJSON_AddItemToObject(vals, "Simba", simba);
 
   if(ocspevent && ocspevent->sfc_peer_host[0] != 0 ) {
     key = cJSON_CreateString(ocspevent->sfc_peer_host);
@@ -418,6 +421,15 @@ void setOOBDsnInfo(KeyValuePair kvPair[], int num) {
         if (!strcasecmp(kvPair[i].key, "server")) {
             setdeployment(kvPair[i].val);
         }
+    }
+    return;
+}
+
+void setOOBSimbaInfo(KeyValuePair kvPair[], int num) {
+    simba = cJSON_CreateObject();
+    for (int i = 0; i < num; ++i) {
+        cJSON* val = cJSON_CreateString(kvPair[i].val);
+        cJSON_AddItemToObject(simba, kvPair[i].key, val);
     }
     return;
 }

--- a/deps/oob-1.0.2/jsonutil.h
+++ b/deps/oob-1.0.2/jsonutil.h
@@ -58,6 +58,8 @@ void setoobConnectioninfo(const char* host,
 
 void setOOBDsnInfo(KeyValuePair kvPair[], int num);
 
+void setOOBSimbaInfo(KeyValuePair kvPair[], int num);
+
 extern char* getOOBDeployment();
 
 extern void getCabundle(char* cabundle, int maxlen);

--- a/deps/oob-1.0.2/oobtelemetry.h
+++ b/deps/oob-1.0.2/oobtelemetry.h
@@ -36,6 +36,7 @@ extern void setoobConnectioninfo(const char* host,
 
 extern void setOOBDsnInfo(KeyValuePair kvPair[], int num);
 
+// setOOBSimbaInfo takes in an array of key value pairs containing the simba.snowflake.ini and adds it to OOB telemetry
 extern void setOOBSimbaInfo(KeyValuePair kvPair[], int num);
 
 #ifdef __cplusplus

--- a/deps/oob-1.0.2/oobtelemetry.h
+++ b/deps/oob-1.0.2/oobtelemetry.h
@@ -36,6 +36,8 @@ extern void setoobConnectioninfo(const char* host,
 
 extern void setOOBDsnInfo(KeyValuePair kvPair[], int num);
 
+extern void setOOBSimbaInfo(KeyValuePair kvPair[], int num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_unit_oob.cpp
+++ b/tests/test_unit_oob.cpp
@@ -41,7 +41,7 @@ typedef struct {
 typedef struct {
     const char *key;
     const char *val;
-} SF_KEY_VAL;
+} SF_PAIR;
 
 void test_oob(void **) {
     int evnt = 0;
@@ -181,7 +181,7 @@ void test_dsn(void **) {
 
     const std::vector<std::string> SF_SENSITIVE_KEYS = std::vector<std::string>{"UID", "PWD", "TOKEN", "PASSCODE", "PRIV_KEY_FILE_PWD"};
 
-    SF_KEY_VAL dsnParameters[] = {
+    SF_PAIR dsnParameters[] = {
             {"SERVER", "snowflake.local.snowflakecomputing.com"},
             {"PORT", "443"},
             {"ACCOUNT", "testaccount"},
@@ -196,7 +196,7 @@ void test_dsn(void **) {
             {"SSL", "1"},
     };
 
-    int count = sizeof(dsnParameters)/sizeof(SF_KEY_VAL);
+    int count = sizeof(dsnParameters)/sizeof(SF_PAIR);
     struct KeyValuePair* kvPairs = (struct KeyValuePair*) malloc(sizeof(struct KeyValuePair)*count);
 
     for (int i = 0; i < count; ++i) {
@@ -224,7 +224,7 @@ void test_dsn(void **) {
     char *oobevent = prepareOOBevent(nullptr);
 
     std::string payload = std::string(oobevent);
-    for (int evnt = 0; evnt < sizeof(dsnParameters)/sizeof(SF_KEY_VAL); ++evnt) {
+    for (int evnt = 0; evnt < sizeof(dsnParameters)/sizeof(SF_PAIR); ++evnt) {
         int idx = payload.find(dsnParameters[evnt].key);
         assert_int_not_equal(idx, std::string::npos);
         idx += strlen(dsnParameters[evnt].key)+strlen("\":");
@@ -255,7 +255,7 @@ void test_dsn(void **) {
 void test_simba(void **) {
     std::string CABundlePath = getCABundleFile();
 
-    SF_KEY_VAL simbaParameters[] = {
+    SF_PAIR simbaParameters[] = {
             {"DriverManagerEncoding","UTF-16"},
             {"DriverLocale", "en-US"},
             {"ErrorMessagesPath", "/home/debugger/snowflake-odbc/ErrorMessages"},
@@ -267,7 +267,7 @@ void test_simba(void **) {
             {"CABundleFile", "/home/debugger/snowflake-odbc/Dependencies/CABundle/cacert.pem"},
     };
 
-    int count = sizeof(simbaParameters)/sizeof(SF_KEY_VAL);
+    int count = sizeof(simbaParameters)/sizeof(SF_PAIR);
     struct KeyValuePair* kvPairs = (struct KeyValuePair*) malloc(sizeof(struct KeyValuePair)*count);
 
     for (int i = 0; i < count; ++i) {
@@ -290,7 +290,7 @@ void test_simba(void **) {
     char *oobevent = prepareOOBevent(nullptr);
 
     std::string payload = std::string(oobevent);
-    for (int i = 0; i < sizeof(simbaParameters)/sizeof(SF_KEY_VAL); ++i) {
+    for (int i = 0; i < sizeof(simbaParameters)/sizeof(SF_PAIR); ++i) {
         int idx = payload.find(simbaParameters[i].key);
         assert_int_not_equal(idx, std::string::npos);
         idx += strlen(simbaParameters[i].key)+strlen("\":");

--- a/tests/test_unit_oob.cpp
+++ b/tests/test_unit_oob.cpp
@@ -274,8 +274,7 @@ void test_simba(void **) {
         kvPairs[i] = KeyValuePair{simbaParameters[i].key, simbaParameters[i].val};
     }
     setOOBSimbaInfo(kvPairs, count);
-    KeyValuePair dsnInfo[] = {{"server", "snowflake.local.snowflakecomputing.com"}};
-    setOOBDsnInfo(dsnInfo, 1);
+    setoobConnectioninfo("snowflake.local.snowflakecomputing.com","","","","","","","","","",0);
 
     char connStr[] = "/session/v1/login-request?requestId=c4d53986-ee7a-4f01-9fac-2604653e9c41&request_guid=abbab0e5-5c77-4102-9d29-d44efde6a050&databaseName=testdb&schemaName=testschema&warehouse=regress";
     char url[1024] = {0};


### PR DESCRIPTION
Sample payload:

`[{
		"Created_On":	"2020-07-14 02:49:50",
		"Name":	"SimbaIniConfig",
		"SchemaVersion":	1,
		"Tags":	{
			"UUID":	"2648fde6-9193-42b3-9c6b-4788c70c0383",
			"connectionString":	"snowflake.local.snowflakecomputing.com:443:/session/v1/login-request?requestId=c4d53986-ee7a-4f01-9fac-2604653e9c41&request_guid=abbab0e5-5c77-4102-9d29-d44efde6a050&databaseName=testdb&schemaName=testschema&warehouse=regress",
			"ctx_account":	"sfctest0",
			"ctx_port":	"443",
			"ctx_protocol":	"https",
			"ctx_user":	"snowman",
			"driver":	"ODBC",
			"version":	"99.0.0",
			"hostOs":	"Linux",
			"telemetryServerDeployment":	"dev"
		},
		"Type":	"Log",
		"UUID":	"2648fde6-9193-42b3-9c6b-4788c70c0383",
		"Urgent":	false,
		"Value":	{
			"DSN":	{
				"server":	"snowflake.local.snowflakecomputing.com"
			},
			"Simba":	{
				"DriverManagerEncoding":	"UTF-16",
				"DriverLocale":	"en-US",
				"ErrorMessagesPath":	"/home/debugger/snowflake-odbc/ErrorMessages",
				"LogNamespace":	"",
				"LogPath":	"/tmp",
				"ODBCInstLib":	"libodbcinst.so",
				"CURLVerboseMode":	"true",
				"LogLevel":	"6",
				"CABundleFile":	"/home/debugger/snowflake-odbc/Dependencies/CABundle/cacert.pem"
			},
			"request":	"snowflake.local.snowflakecomputing.com:443:/session/v1/login-request?requestId=c4d53986-ee7a-4f01-9fac-2604653e9c41&request_guid=abbab0e5-5c77-4102-9d29-d44efde6a050&databaseName=testdb&schemaName=testschema&warehouse=regress"`