### PR TITLE
add BUILD_CLEAN flag

### DIFF
--- a/ci/build/build.sh
+++ b/ci/build/build.sh
@@ -10,7 +10,6 @@ SCRIPTS_DIR=$( cd "$CI_BUILD_DIR/../../scripts" && pwd )
 
 [[ -z "$BUILD_TYPE" ]] && echo "Set BUILD_TYPE: [Debug, Release]" && exit 1
 
-
 source $SCRIPTS_DIR/_init.sh -t $BUILD_TYPE
 source $SCRIPTS_DIR/utils.sh
 init_git_variables
@@ -28,9 +27,10 @@ function download_build_component()
     else
         echo "=== download or build $component_name ==="
         ret="$(check_directory $component_name $build_type)"
-        if [[ "$(check_directory $component_name $build_type)" == "EXIST" ]]; then
+        if [[ "$ret" == "EXIST" ]] && [[ "$BUILD_CLEAN" == "false" ]]; then
             echo "Skip download or build."
         else
+            rm -rf $DEPENDENCY_DIR/$component_name
             if ! aws s3 cp --only-show-errors s3://sfc-dev1-data/dependency/$component_name/$zip_file_name $ARTIFACTS_DIR; then
                 echo "=== build: $component_name ==="
                 "$component_script" -t "$build_type"
@@ -42,7 +42,6 @@ function download_build_component()
                 fi
             else
                 echo "=== download and extract: $component_name"
-                rm -rf $DEPENDENCY_DIR/$component_name
                 pushd $DEPENDENCY_DIR >& /dev/null
                     tar xvfz $ARTIFACTS_DIR/$zip_file_name
                 popd >& /dev/null

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -31,6 +31,7 @@ docker run \
         -e GIT_BRANCH \
         -e GIT_COMMIT \
         -e BUILD_TYPE \
+        -e BUILD_CLEAN \
         -e AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_ACCESS_KEY \
         -e GITHUB_ACTIONS \

--- a/ci/build_win.bat
+++ b/ci/build_win.bat
@@ -72,9 +72,12 @@ goto :EOF
         echo === download or build: %component_name% ===
         call %utils_script% :check_directory %component_name%
         if !ERRORLEVEL! EQU 0 (
-            echo Skip download or build.
-            exit /b 0
+            if "%build_clean%"=="false" (
+                echo Skip download or build.
+                exit /b 0
+            )
         )
+        rd /s /q deps-build\%arcdir%\%vsdir%\%build_type%\%component_name%
         cmd /c aws s3 cp --only-show-errors s3://sfc-dev1-data/dependency/%component_name%/%zip_file_name% %curdir%\artifacts\
         if !ERRORLEVEL! NEQ 0 (
             call %build_script% :build %platform% %build_type% %vs_version% %dynamic_runtime%


### PR DESCRIPTION
I found the local build test doesn't detect inconsistency between dependencies and libsnowflakeclient.
This change is to clean up the dependency's staging area before running the build.

`BUILD_CLEAN` can be set to `false` if the download/build can be skipped for faster dev test iteration optionally.