### PR TITLE
Handling timestamps with zerp precision

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -907,12 +907,11 @@ SF_STATUS STDCALL snowflake_timestamp_from_parts(SF_TIMESTAMP *ts, int32 nanosec
  * @param str
  * @param timezone
  * @param scale
- * @param precision
  * @param ts_type
  * @return
  */
 SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const char *str, const char *timezone,
-                                                         int32 scale, int32 precision, SF_DB_TYPE ts_type);
+                                                         int32 scale, SF_DB_TYPE ts_type);
 
 /**
  *

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -907,11 +907,12 @@ SF_STATUS STDCALL snowflake_timestamp_from_parts(SF_TIMESTAMP *ts, int32 nanosec
  * @param str
  * @param timezone
  * @param scale
+ * @param precision
  * @param ts_type
  * @return
  */
 SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const char *str, const char *timezone,
-                                                         int32 scale, SF_DB_TYPE ts_type);
+                                                         int32 scale, int32 precision, SF_DB_TYPE ts_type);
 
 /**
  *

--- a/lib/client.c
+++ b/lib/client.c
@@ -2544,6 +2544,7 @@ SF_STATUS STDCALL snowflake_column_as_timestamp(SF_STMT *sfstmt, int idx, SF_TIM
                                                       column->valuestring,
                                                       sfstmt->connection->timezone,
                                                       (int32) sfstmt->desc[idx - 1].scale,
+                                                      (int32) sfstmt->desc[idx - 1].precision,
                                                       db_type);
     } else {
         return SF_STATUS_ERROR_CONVERSION_FAILURE;
@@ -2682,6 +2683,7 @@ SF_STATUS STDCALL snowflake_column_as_str(SF_STMT *sfstmt, int idx, char **value
                                                         column->valuestring,
                                                         sfstmt->connection->timezone,
                                                         (int32) sfstmt->desc[idx - 1].scale,
+                                                        (int32) sfstmt->desc[idx - 1].precision,
                                                         sfstmt->desc[idx - 1].type)) {
                 SET_SNOWFLAKE_STMT_ERROR(&sfstmt->error,
                                          SF_STATUS_ERROR_CONVERSION_FAILURE,
@@ -2860,7 +2862,7 @@ SF_STATUS STDCALL snowflake_timestamp_from_parts(SF_TIMESTAMP *ts, int32 nanosec
 }
 
 SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const char *str, const char *timezone,
-                                                         int32 scale, SF_DB_TYPE ts_type) {
+                                                         int32 scale, int32 precision, SF_DB_TYPE ts_type) {
     if (!ts) {
         return SF_STATUS_ERROR_NULL_POINTER;
     }
@@ -2879,21 +2881,25 @@ SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const
     ts->ts_type = ts_type;
     ts->tzoffset = 0;
 
-    /* Search for a decimal point */
-    char *ptr = strchr(str, (int) '.');
+    /* Search for a decimal point if precision > 0
+     * When precision == 0, str will look like e.g. "1593586800 2040"*/
+    const char *ptr = precision > 0 ? strchr(str, (int) '.') : str;
     // No decimal point exists for date types
     if (ptr == NULL && ts->ts_type != SF_DB_TYPE_DATE) {
         ret = SF_STATUS_ERROR_GENERAL;
         goto cleanup;
     }
+
     sec = strtoll(str, NULL, 10);
 
     if (ts->ts_type == SF_DB_TYPE_DATE) {
         sec = sec * SECONDS_IN_AN_HOUR;
     } else {
+        if (precision > 0) {
+          nsec = strtoll(ptr + 1, NULL, 10);
+        }
         /* Search for a space for TIMESTAMP_TZ */
         char *sptr = strchr(ptr + 1, (int) ' ');
-        nsec = strtoll(ptr + 1, NULL, 10);
         if (sptr != NULL) {
             /* TIMESTAMP_TZ */
             nsec = strtoll(ptr + 1, NULL, 10);

--- a/lib/client.c
+++ b/lib/client.c
@@ -2544,7 +2544,6 @@ SF_STATUS STDCALL snowflake_column_as_timestamp(SF_STMT *sfstmt, int idx, SF_TIM
                                                       column->valuestring,
                                                       sfstmt->connection->timezone,
                                                       (int32) sfstmt->desc[idx - 1].scale,
-                                                      (int32) sfstmt->desc[idx - 1].precision,
                                                       db_type);
     } else {
         return SF_STATUS_ERROR_CONVERSION_FAILURE;
@@ -2683,7 +2682,6 @@ SF_STATUS STDCALL snowflake_column_as_str(SF_STMT *sfstmt, int idx, char **value
                                                         column->valuestring,
                                                         sfstmt->connection->timezone,
                                                         (int32) sfstmt->desc[idx - 1].scale,
-                                                        (int32) sfstmt->desc[idx - 1].precision,
                                                         sfstmt->desc[idx - 1].type)) {
                 SET_SNOWFLAKE_STMT_ERROR(&sfstmt->error,
                                          SF_STATUS_ERROR_CONVERSION_FAILURE,
@@ -2862,7 +2860,7 @@ SF_STATUS STDCALL snowflake_timestamp_from_parts(SF_TIMESTAMP *ts, int32 nanosec
 }
 
 SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const char *str, const char *timezone,
-                                                         int32 scale, int32 precision, SF_DB_TYPE ts_type) {
+                                                         int32 scale, SF_DB_TYPE ts_type) {
     if (!ts) {
         return SF_STATUS_ERROR_NULL_POINTER;
     }
@@ -2881,9 +2879,9 @@ SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const
     ts->ts_type = ts_type;
     ts->tzoffset = 0;
 
-    /* Search for a decimal point if precision > 0
-     * When precision == 0, str will look like e.g. "1593586800 2040"*/
-    const char *ptr = precision > 0 ? strchr(str, (int) '.') : str;
+    /* Search for a decimal point if scale > 0
+     * When scale == 0, str will look like e.g. "1593586800 2040"*/
+    const char *ptr = scale > 0 ? strchr(str, (int) '.') : str;
     // No decimal point exists for date types
     if (ptr == NULL && ts->ts_type != SF_DB_TYPE_DATE) {
         ret = SF_STATUS_ERROR_GENERAL;
@@ -2895,14 +2893,13 @@ SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const
     if (ts->ts_type == SF_DB_TYPE_DATE) {
         sec = sec * SECONDS_IN_AN_HOUR;
     } else {
-        if (precision > 0) {
+        if (scale > 0) {
           nsec = strtoll(ptr + 1, NULL, 10);
         }
         /* Search for a space for TIMESTAMP_TZ */
         char *sptr = strchr(ptr + 1, (int) ' ');
         if (sptr != NULL) {
             /* TIMESTAMP_TZ */
-            nsec = strtoll(ptr + 1, NULL, 10);
             tzoffset = strtoll(sptr + 1, NULL, 10) - TIMEZONE_OFFSET_RANGE;
         }
     }

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -277,7 +277,14 @@ sf_bool STDCALL create_header(SF_CONNECT *sf, SF_HEADER *header, SF_ERROR_STRUCT
                                header->use_application_json_accept_type ?
                                HEADER_ACCEPT_TYPE_APPLICATION_JSON :
                                HEADER_ACCEPT_TYPE_APPLICATION_SNOWFLAKE);
-    header->header = curl_slist_append(header->header, SF_HEADER_USER_AGENT);
+
+    if (SF_HEADER_USER_AGENT != NULL){
+      header->header = curl_slist_append(header->header, SF_HEADER_USER_AGENT);
+    }
+    else
+    {
+      log_trace("SF_HEADER_USER_AGENT is null");
+    }
 
     log_trace("Created header");
 
@@ -590,8 +597,7 @@ char * STDCALL encode_url(CURL *curl,
 
 
     encoded_url_size += extraUrlParams ?
-                        num_args > 0 ? strlen(extraUrlParams) + strlen(URL_PARAM_DELIM) : strlen(extraUrlParams)
-                                       : 0;
+                        strlen(extraUrlParams) + strlen(URL_PARAM_DELIM) : 0;
 
     encoded_url = (char *) SF_CALLOC(1, encoded_url_size);
     if (!encoded_url) {
@@ -621,11 +627,8 @@ char * STDCALL encode_url(CURL *curl,
     // sure extraUrlParams is correct)
     if (extraUrlParams && !is_string_empty(extraUrlParams))
     {
-        if (num_args)
-        {
-            sb_strncat(encoded_url, encoded_url_size, URL_PARAM_DELIM, 1);
-        }
-        sb_strncat(encoded_url, encoded_url_size, extraUrlParams, strlen(extraUrlParams));
+      strncat(encoded_url, URL_PARAM_DELIM, 1);
+      strncat(encoded_url, extraUrlParams, strlen(extraUrlParams));
     }
 
     log_debug("URL: %s", encoded_url);

--- a/tests/test_timestamp_ltz.c
+++ b/tests/test_timestamp_ltz.c
@@ -3,6 +3,7 @@
  */
 #include <string.h>
 #include "utils/test_setup.h"
+#include "../lib/connection.h"
 
 
 typedef struct test_case_to_string {
@@ -14,152 +15,174 @@ typedef struct test_case_to_string {
 
 #define USER_TZ "America/New_York"
 
-void test_timestamp_ltz(void** unused) {
-    TEST_CASE_TO_STRING test_cases[] = {
+void test_timestamp_ltz_helper(sf_bool useZeroPrecision)
+{
+
+  TEST_CASE_TO_STRING test_cases[] = {
 #ifndef _WIN32
-      {.c1in = 1, .c2in = "2014-05-03 13:56:46.123 -04:00", .c2out = "2014-05-03 13:56:46.12300"},
-      {.c1in = 2, .c2in = "1969-11-21 05:17:23.0123 -05:00", .c2out = "1969-11-21 05:17:23.01230"},
-      {.c1in = 3, .c2in = "1960-01-01 00:00:00.0000", .c2out = "1960-01-01 00:00:00.00000"},
+          {.c1in = 1, .c2in = "2014-05-03 13:56:46.123 -04:00", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+                                                                         ? "2014-05-03 13:56:46"
+                                                                         : "2014-05-03 13:56:46.12300"},
+          {.c1in = 2, .c2in = "1969-11-21 05:17:23.0123 -05:00", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+                                                                          ? "1969-11-21 05:17:23"
+                                                                          : "1969-11-21 05:17:23.01230"},
+          {.c1in = 3, .c2in = "1960-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+                                                                   ? "1960-01-01 00:00:00"
+                                                                   : "1960-01-01 00:00:00.00000"},
 #ifndef __APPLE__
-      // Must run the tests High Sierra (10.13) or newer OS.
-      {.c1in = 4, .c2in = "1500-01-01 00:00:00.0000", .c2out = "1500-01-01 00:00:00.00000"},
-      // High Sierra (10.13) fixed the calendar issue before 1600, yet the output is slightly different from Linux.
-      // {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = "0001-01-01 00:00:00.00000"},
-      {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = "1-01-01 00:00:00.00000"},
+          // Must run the tests High Sierra (10.13) or newer OS.
+          {.c1in = 4, .c2in = "1500-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+                                                                   ? "1500-01-01 00:00:00"
+                                                                   : "1500-01-01 00:00:00.00000"},
+          // High Sierra (10.13) fixed the calendar issue before 1600, yet the output is slightly different from Linux.
+          // {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = "0001-01-01 00:00:00.00000"},
+          {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+                                                                   ? "1-01-01 00:00:00"
+                                                                   : "1-01-01 00:00:00.00000"},
 #endif // __APPLE__
-      {.c1in = 6, .c2in = "9999-01-01 00:00:00.0000", .c2out = "9999-01-01 00:00:00.00000"},
-      {.c1in = 7, .c2in = "99999-12-31 23:59:59.9999", .c2out = "", .error_code=100035},
+          {.c1in = 6, .c2in = "9999-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+                                                                   ? "9999-01-01 00:00:00"
+                                                                   : "9999-01-01 00:00:00.00000"},
+          {.c1in = 7, .c2in = "99999-12-31 23:59:59.9999", .c2out = "", .error_code=100035},
 #endif // _WIN32
-      {.c1in = 8, .c2in = NULL, .c2out = NULL},
-      /* // none of the platform supports this
-      {.c1in = 9, .c2in = "9999-12-31 23:59:59.9999", .c2out = "9999-12-31 23:59:59.99990 -05:00"},
-       */
-    };
-    /* The client application must set the session parameter TIMEZONE
-     * to the local timezone.
-     * You could set the environment variable TZ but won't impact the result.
-     */
-    SF_CONNECT *sf = setup_snowflake_connection_with_autocommit(
-      USER_TZ, SF_BOOLEAN_TRUE);
+          {.c1in = 8, .c2in = NULL, .c2out = NULL},
+          /* // none of the platform supports this
+          {.c1in = 9, .c2in = "9999-12-31 23:59:59.9999", .c2out = "9999-12-31 23:59:59.99990 -05:00"},
+           */
+  };
 
-    SF_STATUS status = snowflake_connect(sf);
+
+  /* The client application must set the session parameter TIMEZONE
+   * to the local timezone.
+   * You could set the environment variable TZ but won't impact the result.
+   */
+  SF_CONNECT *sf = setup_snowflake_connection_with_autocommit(
+          USER_TZ, SF_BOOLEAN_TRUE);
+
+  SF_STATUS status = snowflake_connect(sf);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sf->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+
+  /* Create a statement once and reused */
+  SF_STMT *sfstmt = snowflake_stmt(sf);
+  status = snowflake_query(
+          sfstmt,
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "create or replace table t (c1 int, c2 timestamp_ltz(0))"
+          : "create or replace table t (c1 int, c2 timestamp_ltz(5))",
+          0
+  );
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sfstmt->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+
+  /* insert data */
+  status = snowflake_prepare(
+          sfstmt,
+          "insert into t(c1,c2) values(?,?)",
+          0);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sfstmt->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+
+  size_t i;
+  size_t len;
+  int no_error_test_cases = 0;
+  for (i = 0, len = sizeof(test_cases) / sizeof(TEST_CASE_TO_STRING);
+       i < len; i++) {
+    TEST_CASE_TO_STRING v = test_cases[i];
+    SF_BIND_INPUT ic1;
+    ic1.idx = 1;
+    ic1.name = NULL;
+    ic1.c_type = SF_C_TYPE_INT64;
+    ic1.value = (void *) &v.c1in;
+    ic1.len = sizeof(v.c1in);
+    status = snowflake_bind_param(sfstmt, &ic1);
     if (status != SF_STATUS_SUCCESS) {
-        dump_error(&(sf->error));
+      dump_error(&(sfstmt->error));
     }
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
-    /* Create a statement once and reused */
-    SF_STMT *sfstmt = snowflake_stmt(sf);
-    status = snowflake_query(
-      sfstmt,
-      "create or replace table t (c1 int, c2 timestamp_ltz(5))",
-      0
-    );
+    SF_BIND_INPUT ic2;
+    ic2.idx = 2;
+    ic2.name = NULL;
+    ic2.c_type = SF_C_TYPE_STRING;
+    ic2.value = (void *) v.c2in;
+    ic2.len = v.c2in != NULL ? strlen(v.c2in) : 0;
+    status = snowflake_bind_param(sfstmt, &ic2);
     if (status != SF_STATUS_SUCCESS) {
-        dump_error(&(sfstmt->error));
+      dump_error(&(sfstmt->error));
     }
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
-    /* insert data */
-    status = snowflake_prepare(
-      sfstmt,
-      "insert into t(c1,c2) values(?,?)",
-      0);
-    if (status != SF_STATUS_SUCCESS) {
-        dump_error(&(sfstmt->error));
+    status = snowflake_execute(sfstmt);
+    if (v.error_code != SF_STATUS_SUCCESS) {
+      // expecting failure
+      SF_ERROR_STRUCT *error = snowflake_stmt_error(sfstmt);
+      assert_int_equal(error->error_code, v.error_code);
+    } else {
+      // expecting success
+      assert_int_equal(status, SF_STATUS_SUCCESS);
+      ++no_error_test_cases;
     }
+  }
+
+  /* query */
+  status = snowflake_query(sfstmt, "select * from t order by 1", 0);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sfstmt->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+
+  char *c2buf = NULL;
+  size_t c2buf_len = 0;
+  size_t c2buf_max_size = 0;
+  sf_bool is_null;
+  assert_int_equal(snowflake_num_rows(sfstmt), no_error_test_cases);
+
+  int counter = 0;
+  while ((status = snowflake_fetch(sfstmt)) == SF_STATUS_SUCCESS) {
+    TEST_CASE_TO_STRING v;
+    do {
+      memcpy(&v, &test_cases[counter++], sizeof(TEST_CASE_TO_STRING));
+    }
+    while (v.error_code != (SF_STATUS)0);
     assert_int_equal(status, SF_STATUS_SUCCESS);
-    
-    size_t i;
-    size_t len;
-    int no_error_test_cases = 0;
-    for (i = 0, len = sizeof(test_cases) / sizeof(TEST_CASE_TO_STRING);
-         i < len; i++) {
-        TEST_CASE_TO_STRING v = test_cases[i];
-        SF_BIND_INPUT ic1;
-        ic1.idx = 1;
-        ic1.name = NULL;
-        ic1.c_type = SF_C_TYPE_INT64;
-        ic1.value = (void *) &v.c1in;
-        ic1.len = sizeof(v.c1in);
-        status = snowflake_bind_param(sfstmt, &ic1);
-        if (status != SF_STATUS_SUCCESS) {
-            dump_error(&(sfstmt->error));
-        }
-        assert_int_equal(status, SF_STATUS_SUCCESS);
-
-        SF_BIND_INPUT ic2;
-        ic2.idx = 2;
-        ic2.name = NULL;
-        ic2.c_type = SF_C_TYPE_STRING;
-        ic2.value = (void *) v.c2in;
-        ic2.len = v.c2in != NULL ? strlen(v.c2in) : 0;
-        status = snowflake_bind_param(sfstmt, &ic2);
-        if (status != SF_STATUS_SUCCESS) {
-            dump_error(&(sfstmt->error));
-        }
-        assert_int_equal(status, SF_STATUS_SUCCESS);
-
-        status = snowflake_execute(sfstmt);
-        if (v.error_code != SF_STATUS_SUCCESS) {
-            // expecting failure
-            SF_ERROR_STRUCT *error = snowflake_stmt_error(sfstmt);
-            assert_int_equal(error->error_code, v.error_code);
-        } else {
-            // expecting success
-            assert_int_equal(status, SF_STATUS_SUCCESS);
-            ++no_error_test_cases;
-        }
+    if (v.c2out == NULL) {
+      // expecting NULL
+      snowflake_column_is_null(sfstmt, 2, &is_null);
+      assert_true(is_null);
+    } else {
+      // expecting not null
+      snowflake_column_as_str(sfstmt, 2, &c2buf, &c2buf_len, &c2buf_max_size);
+      assert_string_equal(v.c2out, c2buf);
     }
+  }
+  if (status != SF_STATUS_EOF) {
+    dump_error(&(sfstmt->error));
+  }
+  assert_int_equal(status, SF_STATUS_EOF);
 
-    /* query */
-    status = snowflake_query(sfstmt, "select * from t order by 1", 0);
-    if (status != SF_STATUS_SUCCESS) {
-        dump_error(&(sfstmt->error));
-    }
-    assert_int_equal(status, SF_STATUS_SUCCESS);
+  status = snowflake_query(sfstmt, "drop table if exists t", 0);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sfstmt->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
 
-    char *c2buf = NULL;
-    size_t c2buf_len = 0;
-    size_t c2buf_max_size = 0;
-    sf_bool is_null;
-    assert_int_equal(snowflake_num_rows(sfstmt), no_error_test_cases);
-
-    int counter = 0;
-    while ((status = snowflake_fetch(sfstmt)) == SF_STATUS_SUCCESS) {
-        TEST_CASE_TO_STRING v;
-        do {
-            memcpy(&v, &test_cases[counter++], sizeof(TEST_CASE_TO_STRING));
-        }
-        while (v.error_code != (SF_STATUS)0);
-        assert_int_equal(status, SF_STATUS_SUCCESS);
-        if (v.c2out == NULL) {
-            // expecting NULL
-            snowflake_column_is_null(sfstmt, 2, &is_null);
-            assert_true(is_null);
-        } else {
-            // expecting not null
-            snowflake_column_as_str(sfstmt, 2, &c2buf, &c2buf_len, &c2buf_max_size);
-            assert_string_equal(v.c2out, c2buf);
-        }
-    }
-    if (status != SF_STATUS_EOF) {
-        dump_error(&(sfstmt->error));
-    }
-    assert_int_equal(status, SF_STATUS_EOF);
-
-    status = snowflake_query(sfstmt, "drop table if exists t", 0);
-    if (status != SF_STATUS_SUCCESS) {
-        dump_error(&(sfstmt->error));
-    }
-    assert_int_equal(status, SF_STATUS_SUCCESS);
-
-    free(c2buf);
-    c2buf = NULL;
-    snowflake_stmt_term(sfstmt);
-    snowflake_term(sf);
+  free(c2buf);
+  c2buf = NULL;
+  snowflake_stmt_term(sfstmt);
+  snowflake_term(sf);
 }
 
+void test_timestamp_ltz(void** unused) {
+  test_timestamp_ltz_helper(SF_BOOLEAN_TRUE);
+  test_timestamp_ltz_helper(SF_BOOLEAN_FALSE);
+}
 
 int main(void) {
     initialize_test(SF_BOOLEAN_FALSE);

--- a/tests/test_timestamp_tz.c
+++ b/tests/test_timestamp_tz.c
@@ -16,31 +16,51 @@ typedef struct test_case_to_string {
 
 #define USER_TZ "America/New_York"
 
-void test_timestamp_tz(void **unused) {
-    TEST_CASE_TO_STRING test_cases[] = {
+void test_timestamp_tz_helper(sf_bool useZeroPrecision){
+  TEST_CASE_TO_STRING test_cases[] = {
 #ifndef _WIN32
-      {.c1in = 1, .c2in = "2014-05-03 13:56:46.123 +09:00", .c2out = "2014-05-03 13:56:46.12300 +09:00"},
-      {.c1in = 2, .c2in = "1969-11-21 05:17:23.0123 -01:00", .c2out = "1969-11-21 05:17:23.01230 -01:00"},
-      {.c1in = 3, .c2in = "1960-01-01 00:00:00.0000", .c2out = "1960-01-01 00:00:00.00000 -05:00"},
-      // timestamp before 1600 doesn't work properly.
-      {.c1in = 4, .c2in = "1500-01-01 00:00:00.0000", .c2out = "1500-01-01 00:00:02.00000 -04:56"},
+          {.c1in = 1, .c2in = "2014-05-03 13:56:46.123 +09:00", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "2014-05-03 13:56:46 +09:00" : "2014-05-03 13:56:46.12300 +09:00"},
+          {.c1in = 2, .c2in = "1969-11-21 05:17:23.0123 -01:00", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "1969-11-21 05:17:23 -01:00" : "1969-11-21 05:17:23.01230 -01:00"},
+          {.c1in = 3, .c2in = "1960-01-01 00:00:00.0000", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "1960-01-01 00:00:00 -05:00" : "1960-01-01 00:00:00.00000 -05:00"},
+          // timestamp before 1600 doesn't work properly.
+          {.c1in = 4, .c2in = "1500-01-01 00:00:00.0000", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "1500-01-01 00:00:02 -04:56" : "1500-01-01 00:00:02.00000 -04:56"},
 #ifdef __APPLE__
-      {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = "0001-01-01 00:00:02.00000 -04:56"},
+          {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE ?
+          "0001-01-01 00:00:02 -04:56" : "0001-01-01 00:00:02.00000 -04:56"},
 #else
-      {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = "1-01-01 00:00:02.00000 -04:56"},
+          {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE ? "1-01-01 00:00:02 -04:56"
+                                              : "1-01-01 00:00:02.00000 -04:56"},
 #endif // __APPLE__
-      {.c1in = 6, .c2in = "9999-01-01 00:00:00.0000", .c2out = "9999-01-01 00:00:00.00000 -05:00"},
-      {.c1in = 7, .c2in = "99999-12-31 23:59:59.9999", .c2out = "", .error_code=100035},
-      {.c1in = 8, .c2in = NULL, .c2out = NULL},
-      {.c1in = 9, .c2in = "2030-07-16 09:01:12.0987 +04:30", .c2out = "2030-07-16 09:01:12.09870 +04:30"},
-      {.c1in = 10, .c2in = "1804-10-23 13:08:48.8765 +04:30", .c2out = "1804-10-23 13:08:48.87650 +04:30"},
-      {.c1in = 11, .c2in = "1969-11-21 08:19:34.123 -02:30", .c2out = "1969-11-21 08:19:34.12300 -02:30"},
+          {.c1in = 6, .c2in = "9999-01-01 00:00:00.0000", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "9999-01-01 00:00:00 -05:00" : "9999-01-01 00:00:00.00000 -05:00"},
+          {.c1in = 7, .c2in = "99999-12-31 23:59:59.9999", .c2out = "", .error_code=100035},
+          {.c1in = 8, .c2in = NULL, .c2out = NULL},
+          {.c1in = 9, .c2in = "2030-07-16 09:01:12.0987 +04:30", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "2030-07-16 09:01:12 +04:30" : "2030-07-16 09:01:12.09870 +04:30"},
+          {.c1in = 10, .c2in = "1804-10-23 13:08:48.8765 +04:30", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "1804-10-23 13:08:48 +04:30" : "1804-10-23 13:08:48.87650 +04:30"},
+          {.c1in = 11, .c2in = "1969-11-21 08:19:34.123 -02:30", .c2out =
+          useZeroPrecision == SF_BOOLEAN_TRUE
+          ? "1969-11-21 08:19:34 -02:30" : "1969-11-21 08:19:34.12300 -02:30"},
 #endif // _WIN32
-      {.c1in = 12, .c2in = NULL, .c2out = NULL},
-      /*
-      {.c1in = 11, .c2in = "9999-12-31 23:59:59.9999", .c2out = "9999-12-31 23:59:59.99990 -05:00"},
-       */
-    };
+          {.c1in = 12, .c2in = NULL, .c2out = NULL},
+          /*
+          {.c1in = 11, .c2in = "9999-12-31 23:59:59.9999", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE ? "9999-12-31 23:59:59.99990 -05:00"},
+           */
+  };
     SF_CONNECT *sf = setup_snowflake_connection_with_autocommit(
       USER_TZ, SF_BOOLEAN_TRUE); // set the session timezone
 
@@ -54,7 +74,9 @@ void test_timestamp_tz(void **unused) {
     SF_STMT *sfstmt = snowflake_stmt(sf);
     status = snowflake_query(
       sfstmt,
-      "create or replace table t (c1 int, c2 timestamp_tz(5))",
+      useZeroPrecision == SF_BOOLEAN_TRUE
+      ? "create or replace table t (c1 int, c2 timestamp_tz(0))"
+      : "create or replace table t (c1 int, c2 timestamp_tz(5))",
       0
     );
     if (status != SF_STATUS_SUCCESS) {
@@ -162,6 +184,10 @@ void test_timestamp_tz(void **unused) {
     snowflake_term(sf);
 }
 
+void test_timestamp_tz(void** unused) {
+  test_timestamp_tz_helper(SF_BOOLEAN_TRUE);
+  test_timestamp_tz_helper(SF_BOOLEAN_FALSE);
+}
 
 int main(void) {
     initialize_test(SF_BOOLEAN_FALSE);


### PR DESCRIPTION
The current implementation is not dealing with TSs with precision 0 and considers them as malformed.
closing #221 