### PR TITLE
Using time_t instead of int 32 to avoid overflow SNOW-81888

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -933,7 +933,7 @@ SF_STATUS STDCALL snowflake_timestamp_to_string(SF_TIMESTAMP *ts, const char *fm
  * @param epoch_time Pointer to store the number of seconds since the epoch
  * @return 0 if success, otherwise an errno is returned
  */
-SF_STATUS STDCALL snowflake_timestamp_get_epoch_seconds(SF_TIMESTAMP *ts, int32 *epoch_time);
+SF_STATUS STDCALL snowflake_timestamp_get_epoch_seconds(SF_TIMESTAMP *ts, time_t *epoch_time);
 
 /**
  * Extracts the part of the timestamp that contains the number of nanoseconds

--- a/lib/client.c
+++ b/lib/client.c
@@ -3034,15 +3034,16 @@ cleanup:
 
 
 
-SF_STATUS STDCALL snowflake_timestamp_get_epoch_seconds(SF_TIMESTAMP *ts, int32 *epoch_time_ptr) {
+SF_STATUS STDCALL snowflake_timestamp_get_epoch_seconds(SF_TIMESTAMP *ts,
+                                                        time_t *epoch_time_ptr) {
     if (!ts) {
         return SF_STATUS_ERROR_NULL_POINTER;
     }
 
-    int32 epoch_time_local;
+    time_t epoch_time_local;
 
     ts->tm_obj.tm_isdst = -1;
-    epoch_time_local = (int32) mktime(&ts->tm_obj);
+    epoch_time_local = (time_t) mktime(&ts->tm_obj);
     // mktime takes into account tm_gmtoff which is a Linux and OS X ONLY field
 #if defined(__linux__) || defined(__APPLE__)
     epoch_time_local += ts->tm_obj.tm_gmtoff;

--- a/tests/test_column_fetch.c
+++ b/tests/test_column_fetch.c
@@ -743,7 +743,7 @@ void test_column_as_timestamp(void **unused) {
             assert_int_equal(52, snowflake_timestamp_get_seconds(&out[i]));
             assert_int_equal(968746000, snowflake_timestamp_get_nanoseconds(&out[i]));
             assert_int_equal(9, snowflake_timestamp_get_scale(&out[i]));
-            int32 epoch_time = 0;
+            time_t epoch_time = 0;
             snowflake_timestamp_get_epoch_seconds(&out[i], &epoch_time);
             assert_int_equal(1527864052, epoch_time);
         }
@@ -759,7 +759,7 @@ void test_column_as_timestamp(void **unused) {
         assert_int_equal(0, snowflake_timestamp_get_minutes(&out[3]));
         assert_int_equal(0, snowflake_timestamp_get_seconds(&out[3]));
         assert_int_equal(0, snowflake_timestamp_get_nanoseconds(&out[3]));
-        int32 epoch_time = 0;
+        time_t epoch_time = 0;
         snowflake_timestamp_get_epoch_seconds(&out[3], &epoch_time);
         assert_int_equal(0, epoch_time);
 
@@ -865,7 +865,7 @@ void test_column_as_timestamp_windows(void **unused) {
         assert_int_equal(0, snowflake_timestamp_get_minutes(&out[0]));
         assert_int_equal(0, snowflake_timestamp_get_seconds(&out[0]));
         assert_int_equal(0, snowflake_timestamp_get_nanoseconds(&out[0]));
-        int32 epoch_time = 0;
+        time_t epoch_time = 0;
         snowflake_timestamp_get_epoch_seconds(&out[0], &epoch_time);
         assert_int_equal(0, epoch_time);
 


### PR DESCRIPTION
Description
@sfc-gh-kwagner this is change that I did for SNOW-81888 locally quite a while ago (in branch I created for stored proc) but fell through crack to be checked into the main repo