### PR TITLE
SNOW-57187 Parse row metadata from response in libsnowflakeclient

### DIFF
--- a/include/snowflake/Statement.hpp
+++ b/include/snowflake/Statement.hpp
@@ -32,6 +32,8 @@ namespace Snowflake {
 
             SF_COLUMN_DESC *desc();
 
+            SF_ROW_METADATA *rowMetadata();
+
             void prepare(const std::string &command_);
 
             void setAttribute(SF_STMT_ATTRIBUTE type_,

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -313,6 +313,13 @@ typedef struct SF_COLUMN_DESC {
     sf_bool null_ok;
 } SF_COLUMN_DESC;
 
+typedef struct SF_ROW_METADATA {
+    int64 num_rows_inserted;
+    int64 num_rows_updated;
+    int64 num_rows_deleted;
+    int64 num_multi_joined_rows_updated;
+} SF_ROW_METADATA;
+
 /**
  * Chunk downloader context
  */
@@ -343,6 +350,7 @@ typedef struct SF_STMT {
     void *name_list;
     unsigned int params_len;
     SF_COLUMN_DESC *desc;
+    SF_ROW_METADATA *row_metadata;
     void *stmt_attrs;
     sf_bool is_dml;
 

--- a/lib/results.c
+++ b/lib/results.c
@@ -295,3 +295,29 @@ SF_COLUMN_DESC * set_description(const cJSON *rowtype) {
 
     return desc;
 }
+
+SF_ROW_METADATA * set_row_metadata(const cJSON *rowMetadata) {
+    cJSON *column;
+    SF_ROW_METADATA *metadata = NULL;
+    size_t array_size = (size_t) snowflake_cJSON_GetArraySize(rowMetadata);
+    if (rowMetadata == NULL || array_size == 0) {
+        return metadata;
+    }
+    if (array_size == 1) {
+        metadata = (SF_ROW_METADATA *) SF_MALLOC(sizeof(SF_ROW_METADATA));
+        column = snowflake_cJSON_GetArrayItem(rowMetadata, 0);
+        if(json_copy_int(&metadata->num_rows_inserted, column, "numRowsInserted")) {
+          metadata->num_rows_inserted = 0;
+        }
+        if(json_copy_int(&metadata->num_rows_updated, column, "numRowsUpdated")) {
+          metadata->num_rows_updated = 0;
+        }
+        if(json_copy_int(&metadata->num_rows_deleted, column, "numRowsDeleted")) {
+          metadata->num_rows_deleted = 0;
+        }
+        if(json_copy_int(&metadata->num_multi_joined_rows_updated, column, "numDmlDuplicates")) {
+          metadata->num_multi_joined_rows_updated = 0;
+        }
+    }
+    return metadata;
+}

--- a/lib/results.c
+++ b/lib/results.c
@@ -307,16 +307,16 @@ SF_ROW_METADATA * set_row_metadata(const cJSON *rowMetadata) {
         metadata = (SF_ROW_METADATA *) SF_MALLOC(sizeof(SF_ROW_METADATA));
         column = snowflake_cJSON_GetArrayItem(rowMetadata, 0);
         if(json_copy_int(&metadata->num_rows_inserted, column, "numRowsInserted")) {
-          metadata->num_rows_inserted = 0;
+            metadata->num_rows_inserted = 0;
         }
         if(json_copy_int(&metadata->num_rows_updated, column, "numRowsUpdated")) {
-          metadata->num_rows_updated = 0;
+            metadata->num_rows_updated = 0;
         }
         if(json_copy_int(&metadata->num_rows_deleted, column, "numRowsDeleted")) {
-          metadata->num_rows_deleted = 0;
+            metadata->num_rows_deleted = 0;
         }
         if(json_copy_int(&metadata->num_multi_joined_rows_updated, column, "numDmlDuplicates")) {
-          metadata->num_multi_joined_rows_updated = 0;
+            metadata->num_multi_joined_rows_updated = 0;
         }
     }
     return metadata;

--- a/lib/results.h
+++ b/lib/results.h
@@ -18,6 +18,7 @@ SF_C_TYPE snowflake_to_c_type(SF_DB_TYPE type, int64 precision, int64 scale);
 SF_DB_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_DB_TYPE tsmode);
 char *value_to_string(void *value, size_t len, SF_C_TYPE c_type);
 SF_COLUMN_DESC * set_description(const cJSON *rowtype);
+SF_ROW_METADATA * set_row_metadata(const cJSON *rowtype);
 
 #ifdef __cplusplus
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,8 @@ SET(TESTS_C
         test_issue_76
         test_column_fetch
         test_native_timestamp
-        test_row_metadata)
+#        test_row_metadata
+        )
 
 SET(TESTS_CXX
         test_unit_jwt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,8 @@ SET(TESTS_C
         test_adjust_fetch_data
         test_issue_76
         test_column_fetch
-        test_native_timestamp)
+        test_native_timestamp
+        test_row_metadata)
 
 SET(TESTS_CXX
         test_unit_jwt

--- a/tests/test_row_metadata.c
+++ b/tests/test_row_metadata.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018-2019 Snowflake Computing, Inc. All rights reserved.
+ */
+#include <assert.h>
+#include "utils/test_setup.h"
+
+void test_row_metadata(void **unused) {
+    SF_STATUS status;
+    SF_CONNECT *sf = setup_snowflake_connection();
+
+    status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sf->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    /* Create a statement once and reused */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    status = snowflake_query(
+        sfstmt,
+        "create or replace table t (c1 number, c2 number)",
+        0
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+    assert(sfstmt->row_metadata == NULL);
+
+    status = snowflake_query(
+        sfstmt,
+        "insert into t values (1, 2), (3, 4)",
+        0
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    assert(sfstmt->is_dml);
+    assert(sfstmt->row_metadata);
+    assert_int_equal(sfstmt->row_metadata->num_rows_inserted, 2);
+    assert_int_equal(sfstmt->row_metadata->num_rows_updated, 0);
+    assert_int_equal(sfstmt->row_metadata->num_rows_deleted, 0);
+    assert_int_equal(sfstmt->row_metadata->num_multi_joined_rows_updated, 0);
+
+    status = snowflake_query(
+        sfstmt,
+        "update t set c2 = src.c2\n"
+        "  from (select $1 as c1, $2 as c2 from values (1, 10), (1, 5), (2, 6)) src\n"
+        "  where t.c1 = src.c1",
+        0
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    assert(sfstmt->is_dml);
+    assert(sfstmt->row_metadata);
+    assert_int_equal(sfstmt->row_metadata->num_rows_inserted, 0);
+    assert_int_equal(sfstmt->row_metadata->num_rows_updated, 1);
+    assert_int_equal(sfstmt->row_metadata->num_rows_deleted, 0);
+    assert_int_equal(sfstmt->row_metadata->num_multi_joined_rows_updated, 1);
+
+    status = snowflake_query(
+        sfstmt,
+        "delete from t",
+        0
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    assert(sfstmt->is_dml);
+    assert(sfstmt->row_metadata);
+    assert_int_equal(sfstmt->row_metadata->num_rows_inserted, 0);
+    assert_int_equal(sfstmt->row_metadata->num_rows_updated, 0);
+    assert_int_equal(sfstmt->row_metadata->num_rows_deleted, 2);
+    assert_int_equal(sfstmt->row_metadata->num_multi_joined_rows_updated, 0);
+
+    status = snowflake_query(sfstmt, "drop table if exists t", 0);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+    assert(sfstmt->row_metadata == NULL);
+
+    snowflake_stmt_term(sfstmt);
+    snowflake_term(sf);
+}
+
+int main(void) {
+    initialize_test(SF_BOOLEAN_FALSE);
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_row_metadata),
+    };
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    snowflake_global_term();
+    return ret;
+}


### PR DESCRIPTION
Description

The XP change that uses the row metadata parsed here can be found in this PR https://github.com/snowflakedb/snowflake/pull/9493

Note: The enclosed test (test_row_metadata) is commented out because the response changes that were made to GS have not yet been deployed at the time of this PR. The response change should be deployed in 4.28. Once 4.28 is deployed, I will enable the test. The JIRA to track enabling the test is https://snowflakecomputing.atlassian.net/browse/SNOW-180697

Here is a screenshot of the test passing on my local dev environment with the latest GS:
<img width="1358" alt="Screen Shot 2020-08-03 at 5 33 32 PM" src="https://user-images.githubusercontent.com/65570153/89229837-33e7a180-d5b0-11ea-913d-98102db309dc.png">


Testing
A test is enclosed