### PR TITLE
SNOW-219403 Add configurable retries for put fails

### DIFF
--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -70,7 +70,8 @@ Snowflake::Client::FileTransferAgent::FileTransferAgent(
   m_transferConfig(transferConfig),
   m_uploadStream(nullptr),
   m_uploadStreamSize(0),
-  m_useDevUrand(false)
+  m_useDevUrand(false),
+  m_maxPutRetries(10)
 {
   _mutex_init(&m_parallelTokRenewMutex);
 }
@@ -403,7 +404,7 @@ RemoteStorageRequestOutcome Snowflake::Client::FileTransferAgent::uploadSingleFi
   CXX_LOG_TRACE("Encryption metadata init done");
 
   RemoteStorageRequestOutcome outcome = RemoteStorageRequestOutcome::SUCCESS;
-  RetryContext putRetryCtx(fileMetadata->srcFileName);
+  RetryContext putRetryCtx(fileMetadata->srcFileName, m_maxPutRetries);
   do
   {
     //Sleeps only when its a retry

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -71,7 +71,7 @@ Snowflake::Client::FileTransferAgent::FileTransferAgent(
   m_uploadStream(nullptr),
   m_uploadStreamSize(0),
   m_useDevUrand(false),
-  m_maxPutRetries(10)
+  m_maxPutRetries(5)
 {
   _mutex_init(&m_parallelTokRenewMutex);
 }

--- a/cpp/FileTransferAgent.hpp
+++ b/cpp/FileTransferAgent.hpp
@@ -38,10 +38,10 @@ constexpr unsigned long MILLI_SECONDS_IN_SECOND = 1000;
 class RetryContext
 {
   public:
-    RetryContext(std::string &fileName):
+    RetryContext(const std::string &fileName, int maxRetries):
     m_retryCount(0),
     m_putFileName(fileName),
-    m_maxRetryCount(10),
+    m_maxRetryCount(maxRetries),
     m_minSleepTimeInMs(3 * MILLI_SECONDS_IN_SECOND), //3 seconds
     m_maxSleepTimeInMs(180 * MILLI_SECONDS_IN_SECOND), //180 seconds is the max sleep time
     m_timeoutInMs(600 * MILLI_SECONDS_IN_SECOND) // timeout 600 seconds.
@@ -170,6 +170,11 @@ public:
     m_useDevUrand = useUrand;
   }
 
+  virtual void setPutMaxRetries(int maxRetries)
+  {
+     m_maxPutRetries = maxRetries;
+  }
+
 private:
   /**
    * Populate file metadata, (Get source file name)
@@ -288,6 +293,8 @@ private:
 
   /// Whether to use /dev/urandom or /dev/random;
   bool m_useDevUrand;
+
+  int m_maxPutRetries;
 };
 }
 }

--- a/include/snowflake/IFileTransferAgent.hpp
+++ b/include/snowflake/IFileTransferAgent.hpp
@@ -62,6 +62,12 @@ public:
    */
   virtual void setRandomDeviceAsUrand(bool useUrand){};
 
+  /**
+   * Set max number of retries for put fails
+   * @param maxRetries: max number of retries.
+   */
+  virtual void setPutMaxRetries(int maxRetries){};
+
 };
 
 }

--- a/tests/test_unit_put_retry.cpp
+++ b/tests/test_unit_put_retry.cpp
@@ -193,6 +193,26 @@ void test_simple_put_retry(void ** unused)
   test_simple_put_retry_core("small_file.csv.gz");
 }
 
+void test_set_max_retry_core()
+{
+  int maxRetries = 2;
+
+  Snowflake::Client::RetryContext retry_context("dummyFile.csv", maxRetries);
+  int retryCount = 0;
+  do
+  {
+    retry_context.waitForNextRetry();
+    ++retryCount;
+  }while(retry_context.isRetryable(FAILED));
+
+  //The first run is not a retry.
+  assert_int_equal(retryCount-1, maxRetries);
+}
+void test_set_max_retry(void **unused)
+{
+  test_set_max_retry_core();
+}
+
 static int gr_setup(void **unused)
 {
   initialize_test(SF_BOOLEAN_FALSE);
@@ -202,6 +222,7 @@ static int gr_setup(void **unused)
 int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_simple_put_retry),
+    cmocka_unit_test(test_set_max_retry),
   };
   int ret = cmocka_run_group_tests(tests, gr_setup, NULL);
   return ret;


### PR DESCRIPTION
Adds the ability to configure the number of retries to perform when a put command fails.

Test case is added to test if the set number of retries are performed. 