### PR TITLE
Smirzaei get column string representation from raw value

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -845,6 +845,32 @@ SF_STATUS STDCALL snowflake_column_as_timestamp(SF_STMT *sfstmt, int idx, SF_TIM
 SF_STATUS STDCALL snowflake_column_as_const_str(SF_STMT *sfstmt, int idx, const char **value_ptr);
 
 /**
+ * Given the raw value as a string, returns the string representation
+ *
+ * @param sfstmt (can be null) SF_STMT context to be used for extracting sfqid and error
+ * @param const_str_val the src raw value
+ * @param type the target type
+ *  (caller is responsible to make sure currect type is passed in for the raw value)
+ * @param connection_timezone to be used for extracting timestamp string values
+ * @param scale to be used for extracting timestamp string values
+ * @param isNull
+ * @param value_ptr Copied Column data is stored in this pointer (if conversion was successful)
+ * @param value_len_ptr The length of the string value. This is what you would get if you were to call strlen(*value_ptr).
+ * @param max_value_size_ptr The size of the value buffer. If value_ptr is reallocated because the data to copy is too
+ *        large, then this ptr will hold the value of the new buffer size.
+ * @return 0 if success, otherwise an errno is returned
+ * @return
+ */
+SF_STATUS STDCALL snowflake_raw_value_to_str_rep(SF_STMT *sfstmt,
+                                                 const char *const_str_val,
+                                                 const SF_DB_TYPE type,
+                                                 const char *connection_timezone,
+                                                 int32 scale, sf_bool isNull,
+                                                 char **value_ptr,
+                                                 size_t *value_len_ptr,
+                                                 size_t *max_value_size_ptr);
+
+/**
  * Converts a column into a string, copies to the buffer provided and stores that buffer address in value_ptr. If
  * *value_ptr is not NULL and max_value_size_ptr is not NULL and greater than 0, then the library will copy the string
  * data into the provided buffer. If the provided buffer if not large enough, the library will reallocate this string

--- a/lib/client.c
+++ b/lib/client.c
@@ -2710,6 +2710,13 @@ SF_STATUS STDCALL snowflake_raw_value_to_str_rep(SF_STMT *sfstmt, const char* co
         SF_TIMESTAMP ts;
         if (scale < 0)
         {
+          // If scale is not provided, try to calculate it.
+          // E.g., for raw value "1234567890 2040" scale is 0
+          // E.g., for raw value "1234567890.1234 2040" scale is from "." to " "
+          // before TZ offset
+          // E.g., for raw value "1234567890.1234" scale is calculated as length
+          // of input minus length of "1234567890." part
+
           const char *scalePtr = strchr(const_str_val, (int) '.');
           if (scalePtr == NULL)
           {
@@ -2723,6 +2730,7 @@ SF_STATUS STDCALL snowflake_raw_value_to_str_rep(SF_STMT *sfstmt, const char* co
               scale = tzOffsetPtr - scalePtr - 1;
             }
           }
+          log_info("scale is calculated as %d", scale);
         }
 
         if (snowflake_timestamp_from_epoch_seconds(&ts,

--- a/lib/client.c
+++ b/lib/client.c
@@ -2605,9 +2605,9 @@ SF_STATUS STDCALL snowflake_raw_value_to_str_rep(SF_STMT *sfstmt, const char* co
     // If value_ptr isn't null and max_value_size exists and is greater than 0,
     // then the user passed in a buffer and we should reallocate if needed
     if (*value_ptr != NULL && max_value_size_ptr != NULL && *max_value_size_ptr != 0) {
-      value = *value_ptr;
-      init_value_len = *max_value_size_ptr;
-      preallocated = SF_BOOLEAN_TRUE;
+        value = *value_ptr;
+        init_value_len = *max_value_size_ptr;
+        preallocated = SF_BOOLEAN_TRUE;
     }
 
 
@@ -2779,17 +2779,16 @@ SF_STATUS STDCALL snowflake_raw_value_to_str_rep(SF_STMT *sfstmt, const char* co
         break;
     }
 
-
     // Everything went okay
     status = SF_STATUS_SUCCESS;
 
-    cleanup:
+cleanup:
     *value_ptr = value;
     if (max_value_size_ptr) {
-      *max_value_size_ptr = max_value_size;
+        *max_value_size_ptr = max_value_size;
     }
     if (value_len_ptr) {
-      *value_len_ptr = value_len;
+        *value_len_ptr = value_len;
     }
     return status;
 }
@@ -2928,11 +2927,11 @@ SF_STATUS STDCALL snowflake_timestamp_from_parts(SF_TIMESTAMP *ts, int32 nanosec
 
 SF_STATUS STDCALL snowflake_timestamp_from_epoch_seconds(SF_TIMESTAMP *ts, const char *str, const char *timezone,
                                                          int32 scale, SF_DB_TYPE ts_type) {
+    if (!ts) {
+        return SF_STATUS_ERROR_NULL_POINTER;
+    }
 
-  if (!ts) {
-    return SF_STATUS_ERROR_NULL_POINTER;
-  }
-  SF_STATUS ret = SF_STATUS_ERROR_GENERAL;
+    SF_STATUS ret = SF_STATUS_ERROR_GENERAL;
     time_t nsec = 0L;
     time_t sec = 0L;
     int64 tzoffset = 0;

--- a/lib/client.c
+++ b/lib/client.c
@@ -2610,17 +2610,6 @@ SF_STATUS STDCALL snowflake_raw_value_to_str_rep(SF_STMT *sfstmt, const char* co
       preallocated = SF_BOOLEAN_TRUE;
     }
 
-    if (isNull != SF_BOOLEAN_TRUE && isNull != SF_BOOLEAN_FALSE)
-    {
-      // If nullablity is not provided try to extract if from the input raw value
-      if (strncmp(const_str_val, "null", 4) == 0)
-      {
-        isNull = SF_BOOLEAN_TRUE;
-      }
-      else{
-        isNull = SF_BOOLEAN_FALSE;
-      }
-    }
 
     if (isNull == SF_BOOLEAN_TRUE) {
       // If value is NULL, allocate buffer for empty string


### PR DESCRIPTION
This is a change that we need for our use case in SQL stored procedures. 
Basically here is a short background on this change: Inside SQL stored procs (which are translated to JS stored procs) we will be evaluating expressions as much as we can on the XP side (through XP expression evaluation framework) instead of issuing an individual child job through LibSnowflakeClient. E.g. consider expression `'2020-10-10' + 1` which we can via two approaches, i.e., 1) either directly in XP or 2) or with a child query `SELECT '2020-10-10' + 1` through libSfClient where the result is extracted using `snowflake_column_as_str` as a string. But if this expression is evaluated on XP side we get the internal representation which is an epoch value (the same raw value representation in LibSfClient). So to have consistent representation between this two approach, we should be able to go from raw representation to LibSfClient's string representation.

Edit: unit testing is missing which I will add it soon