### PR TITLE
Add support for negative epoch on Windows.

### DIFF
--- a/tests/test_timestamp_ltz.c
+++ b/tests/test_timestamp_ltz.c
@@ -19,7 +19,6 @@ void test_timestamp_ltz_helper(sf_bool useZeroPrecision)
 {
 
   TEST_CASE_TO_STRING test_cases[] = {
-#ifndef _WIN32
           {.c1in = 1, .c2in = "2014-05-03 13:56:46.123 -04:00", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
                                                                          ? "2014-05-03 13:56:46"
                                                                          : "2014-05-03 13:56:46.12300"},
@@ -29,22 +28,23 @@ void test_timestamp_ltz_helper(sf_bool useZeroPrecision)
           {.c1in = 3, .c2in = "1960-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
                                                                    ? "1960-01-01 00:00:00"
                                                                    : "1960-01-01 00:00:00.00000"},
-#ifndef __APPLE__
+#ifdef __linux__
           // Must run the tests High Sierra (10.13) or newer OS.
+          // Windows get inaccurate result as well.
           {.c1in = 4, .c2in = "1500-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
                                                                    ? "1500-01-01 00:00:00"
                                                                    : "1500-01-01 00:00:00.00000"},
           // High Sierra (10.13) fixed the calendar issue before 1600, yet the output is slightly different from Linux.
+          // Windows get the same output as MacOS
           // {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = "0001-01-01 00:00:00.00000"},
           {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
                                                                    ? "1-01-01 00:00:00"
                                                                    : "1-01-01 00:00:00.00000"},
-#endif // __APPLE__
+#endif // __linux__
           {.c1in = 6, .c2in = "9999-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
                                                                    ? "9999-01-01 00:00:00"
                                                                    : "9999-01-01 00:00:00.00000"},
           {.c1in = 7, .c2in = "99999-12-31 23:59:59.9999", .c2out = "", .error_code=100035},
-#endif // _WIN32
           {.c1in = 8, .c2in = NULL, .c2out = NULL},
           /* // none of the platform supports this
           {.c1in = 9, .c2in = "9999-12-31 23:59:59.9999", .c2out = "9999-12-31 23:59:59.99990 -05:00"},

--- a/tests/test_timestamp_ltz.c
+++ b/tests/test_timestamp_ltz.c
@@ -13,16 +13,28 @@ typedef struct test_case_to_string {
     SF_STATUS error_code;
 } TEST_CASE_TO_STRING;
 
+#ifdef _WIN32
+// On Windows TZ variable has different syntax.
+// https://docs.microsoft.com/en-us/previous-versions/90s5c885(v=vs.140)#remarks
+// timezone in connection property like America/New_York won't change local
+// timezone setting as expected, while server doesn't accept Windows syntax like
+// UTC-5:00. Setting session timezone to the actual timezone of the client would
+// work so it won't causing any issue on customer side. But since we need to make
+// the test case work on any timezone, "UTC" is the only timezone setting can be
+// accepted by both server and client side.
+#define USER_TZ "UTC"
+#else
 #define USER_TZ "America/New_York"
+#endif // _WIN32
 
 void test_timestamp_ltz_helper(sf_bool useZeroPrecision)
 {
 
   TEST_CASE_TO_STRING test_cases[] = {
-          {.c1in = 1, .c2in = "2014-05-03 13:56:46.123 -04:00", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+          {.c1in = 1, .c2in = "2014-05-03 13:56:46.123", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
                                                                          ? "2014-05-03 13:56:46"
                                                                          : "2014-05-03 13:56:46.12300"},
-          {.c1in = 2, .c2in = "1969-11-21 05:17:23.0123 -05:00", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
+          {.c1in = 2, .c2in = "1969-11-21 05:17:23.0123", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE
                                                                           ? "1969-11-21 05:17:23"
                                                                           : "1969-11-21 05:17:23.01230"},
           {.c1in = 3, .c2in = "1960-01-01 00:00:00.0000", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE

--- a/tests/test_timestamp_ntz.c
+++ b/tests/test_timestamp_ntz.c
@@ -19,7 +19,6 @@ void test_timestamp_ntz_helper(sf_bool useZeroPrecision){
           {.c1in = 1, .c2in = "2014-05-03 13:56:46.123", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ? "2014-05-03 13:56:46"
                                               : "2014-05-03 13:56:46.1230"},
-#ifndef _WIN32
           {.c1in = 2, .c2in = "1969-11-21 05:17:23.0123", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ? "1969-11-21 05:17:23"
                                               : "1969-11-21 05:17:23.0123"},
@@ -29,7 +28,7 @@ void test_timestamp_ntz_helper(sf_bool useZeroPrecision){
           {.c1in = 4, .c2in = "1500-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ? "1500-01-01 00:00:00"
                                               : "1500-01-01 00:00:00.0000"},
-#if defined __APPLE__
+#ifndef __linux__
           {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ? "0001-01-01 00:00:00"
                                               : "0001-01-01 00:00:00.0000"},
@@ -37,7 +36,7 @@ void test_timestamp_ntz_helper(sf_bool useZeroPrecision){
           {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ? "1-01-01 00:00:00"
                                               : "1-01-01 00:00:00.0000"},
-#endif // __APPLE__
+#endif // __linux__
           {.c1in = 6, .c2in = "9999-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ? "9999-01-01 00:00:00"
                                               : "9999-01-01 00:00:00.0000"},
@@ -45,7 +44,6 @@ void test_timestamp_ntz_helper(sf_bool useZeroPrecision){
           useZeroPrecision == SF_BOOLEAN_TRUE ? "9999-12-31 23:59:59"
                                               : "9999-12-31 23:59:59.9999"},
           {.c1in = 8, .c2in = "99999-12-31 23:59:59.9999", .c2out = "", .error_code=100035},
-#endif // _WIN32
           {.c1in = 9, .c2in = NULL, .c2out = NULL, .error_code=0},
           {.c1in = 10, .c2in = "GARBAGE", .c2out = "", .error_code=100035},
   };

--- a/tests/test_timestamp_tz.c
+++ b/tests/test_timestamp_tz.c
@@ -18,7 +18,6 @@ typedef struct test_case_to_string {
 
 void test_timestamp_tz_helper(sf_bool useZeroPrecision){
   TEST_CASE_TO_STRING test_cases[] = {
-#ifndef _WIN32
           {.c1in = 1, .c2in = "2014-05-03 13:56:46.123 +09:00", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE
           ? "2014-05-03 13:56:46 +09:00" : "2014-05-03 13:56:46.12300 +09:00"},
@@ -32,7 +31,7 @@ void test_timestamp_tz_helper(sf_bool useZeroPrecision){
           {.c1in = 4, .c2in = "1500-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE
           ? "1500-01-01 00:00:02 -04:56" : "1500-01-01 00:00:02.00000 -04:56"},
-#ifdef __APPLE__
+#ifndef __linux__
           {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ?
           "0001-01-01 00:00:02 -04:56" : "0001-01-01 00:00:02.00000 -04:56"},
@@ -40,7 +39,7 @@ void test_timestamp_tz_helper(sf_bool useZeroPrecision){
           {.c1in = 5, .c2in = "0001-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE ? "1-01-01 00:00:02 -04:56"
                                               : "1-01-01 00:00:02.00000 -04:56"},
-#endif // __APPLE__
+#endif // __linux__
           {.c1in = 6, .c2in = "9999-01-01 00:00:00.0000", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE
           ? "9999-01-01 00:00:00 -05:00" : "9999-01-01 00:00:00.00000 -05:00"},
@@ -55,7 +54,6 @@ void test_timestamp_tz_helper(sf_bool useZeroPrecision){
           {.c1in = 11, .c2in = "1969-11-21 08:19:34.123 -02:30", .c2out =
           useZeroPrecision == SF_BOOLEAN_TRUE
           ? "1969-11-21 08:19:34 -02:30" : "1969-11-21 08:19:34.12300 -02:30"},
-#endif // _WIN32
           {.c1in = 12, .c2in = NULL, .c2out = NULL},
           /*
           {.c1in = 11, .c2in = "9999-12-31 23:59:59.9999", .c2out = useZeroPrecision == SF_BOOLEAN_TRUE ? "9999-12-31 23:59:59.99990 -05:00"},


### PR DESCRIPTION
PHP driver is using libsnowflakeclient and negative epoch caused test case failures on Windows.
The implementation is taken from ODBC driver in Platform/DataConversion.cpp.