### PR TITLE
SNOW-249762: Refactor Query-Result Capture

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -421,8 +421,11 @@ typedef struct SF_TIMESTAMP {
 
 /**
  * Initializes an SF_QUERY_RESPONSE_CAPTURE struct.
+ * Note that these need to be released by calling snowflake_query_result_capture_term().
+ *
+ * @param input pointer to an uninitialized SF_QUERY_RESULT_CAPTURE struct pointer.
  */
-SF_QUERY_RESULT_CAPTURE snowflake_query_result_capture_init();
+void STDCALL snowflake_query_result_capture_init(SF_QUERY_RESULT_CAPTURE **input);
 
 /**
  * Checks whether the client is running in force_arrow mode.
@@ -430,7 +433,7 @@ SF_QUERY_RESULT_CAPTURE snowflake_query_result_capture_init();
  * @param connection pointer to SF_CONNECT
  * @return SF_BOOLEAN_TRUE if the connection is running in force_arrow mode, otherwise SF_BOOLEAN_FALSE
  */
-sf_bool is_force_arrow_mode(const SF_CONNECT *connection);
+sf_bool STDCALL snowflake_is_force_arrow_mode(const SF_CONNECT *connection);
 
 /**
  * Global Snowflake initialization.
@@ -517,6 +520,14 @@ SF_STATUS STDCALL snowflake_get_attribute(
  * @param sfstmt SNOWFLAKE_STMT context.
  */
 SF_STMT *STDCALL snowflake_stmt(SF_CONNECT *sf);
+
+/**
+ * Frees the memory used by a SF_QUERY_RESULT_CAPTURE struct.
+ *
+ * @param capture SF_QUERY_RESULT_CAPTURE pointer whose memory to clear.
+ *
+ */
+ void STDCALL snowflake_query_result_capture_term(SF_QUERY_RESULT_CAPTURE *capture);
 
 /**
  * Closes and terminates a statement context

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -332,7 +332,7 @@ typedef struct SF_STATS {
  * This is a structure used for capturing the results.
  * Note that the caller is responsible for managing the memory
  * used for this, and that these should always be constructed
- * with sf_query_result_capture_init().
+ * with snowflake_query_result_capture_init().
  */
 typedef struct SF_QUERY_RESULT_CAPTURE {
     // The buffer for storing the results
@@ -422,7 +422,7 @@ typedef struct SF_TIMESTAMP {
 /**
  * Initializes an SF_QUERY_RESPONSE_CAPTURE struct.
  */
-SF_QUERY_RESULT_CAPTURE sf_query_result_capture_init();
+SF_QUERY_RESULT_CAPTURE snowflake_query_result_capture_init();
 
 /**
  * Checks whether the client is running in force_arrow mode.

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -523,6 +523,8 @@ SF_STMT *STDCALL snowflake_stmt(SF_CONNECT *sf);
 
 /**
  * Frees the memory used by a SF_QUERY_RESULT_CAPTURE struct.
+ * Note that this only frees the struct itself, and *not* the underlying
+ * capture buffer! The caller is responsible for managing that.
  *
  * @param capture SF_QUERY_RESULT_CAPTURE pointer whose memory to clear.
  *

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -327,6 +327,23 @@ typedef struct SF_STATS {
 } SF_STATS;
 
 /**
+ * For certain applications, we may wish to capture
+ * the raw response after issuing a query to Snowflake.
+ * This is a structure used for capturing the results.
+ * Note that the caller is responsible for managing the memory
+ * used for this, and that these should always be constructed
+ * with sf_query_result_capture_init().
+ */
+typedef struct SF_QUERY_RESULT_CAPTURE {
+    // The buffer for storing the results
+    char* capture_buffer;
+    // Size of the buffer
+    size_t buffer_size;
+    // Actual response size
+    size_t actual_response_size;
+} SF_QUERY_RESULT_CAPTURE;
+
+/**
  * Chunk downloader context
  */
 typedef struct SF_CHUNK_DOWNLOADER SF_CHUNK_DOWNLOADER;
@@ -346,7 +363,6 @@ typedef struct SF_STMT {
     SF_ERROR_STRUCT error;
     SF_CONNECT *connection;
     char *sql_text;
-    char *query_response_text;
     void *raw_results;
     void *cur_row;
     int64 chunk_rowcount;
@@ -402,6 +418,11 @@ typedef struct SF_TIMESTAMP {
     int32 scale;
     SF_DB_TYPE ts_type;
 } SF_TIMESTAMP;
+
+/**
+ * Initializes an SF_QUERY_RESPONSE_CAPTURE struct.
+ */
+SF_QUERY_RESULT_CAPTURE sf_query_result_capture_init();
 
 /**
  * Checks whether the client is running in force_arrow mode.
@@ -648,6 +669,15 @@ snowflake_stmt_get_attr(SF_STMT *sfstmt, SF_STMT_ATTRIBUTE type, void **value);
  * @return 0 if success, otherwise an errno is returned.
  */
 SF_STATUS STDCALL snowflake_execute(SF_STMT *sfstmt);
+
+/**
+ * Executes a statement with capture.
+ * @param sfstmt SNOWFLAKE_STMT context.
+ * @param result_capture pointer to a SF_QUERY_RESULT_CAPTURE
+ * @return 0 if success, otherwise an errno is returned.
+ */
+SF_STATUS STDCALL snowflake_execute_with_capture(SF_STMT *sfstmt,
+        SF_QUERY_RESULT_CAPTURE* result_capture);
 
 /**
  * Fetches the next row for the statement and stores on the bound buffer

--- a/lib/client.c
+++ b/lib/client.c
@@ -1345,7 +1345,7 @@ SF_STMT *STDCALL snowflake_stmt(SF_CONNECT *sf) {
 /**
  * Initializes an SF_QUERY_RESPONSE_CAPTURE struct.
  */
-SF_QUERY_RESULT_CAPTURE sf_query_result_capture_init() {
+SF_QUERY_RESULT_CAPTURE snowflake_query_result_capture_init() {
     SF_QUERY_RESULT_CAPTURE capture = {NULL, 0, 0};
     return capture;
 }

--- a/lib/client.c
+++ b/lib/client.c
@@ -1380,13 +1380,14 @@ void STDCALL snowflake_bind_input_init(SF_BIND_INPUT * input)
 
 /**
  * Frees the memory used by a SF_QUERY_RESULT_CAPTURE struct.
+ * Note that this only frees the struct itself, and *not* the underlying
+ * capture buffer! The caller is responsible for managing that.
  *
  * @param capture SF_QUERY_RESULT_CAPTURE pointer whose memory to clear.
  *
  */
 void STDCALL snowflake_query_result_capture_term(SF_QUERY_RESULT_CAPTURE *capture) {
     if (capture) {
-        SF_FREE(capture->capture_buffer);
         capture->capture_buffer = NULL;
         SF_FREE(capture);
     }

--- a/lib/client_int.h
+++ b/lib/client_int.h
@@ -123,11 +123,14 @@ SF_PUT_GET_RESPONSE *STDCALL sf_put_get_response_allocate();
  * Executes a statement.
  * @param sfstmt SNOWFLAKE_STMT context.
  * @param sf_use_application_json_accept type true if this is a put/get command
+ * @param raw_response_buffer optional pointer to an SF_QUERY_RESULT_CAPTURE,
+ * if the query response is to be captured.
  *
  * @return 0 if success, otherwise an errno is returned.
  */
 SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
-                                        sf_bool use_application_json_accept_type);
+                                        sf_bool use_application_json_accept_type,
+                                        struct SF_QUERY_RESULT_CAPTURE* result_capture);
 
 /**
  * @return true if this is a put/get command, otherwise false

--- a/tests/test_arrow_force.c
+++ b/tests/test_arrow_force.c
@@ -20,7 +20,7 @@ void test_arrow_force(void **unused) {
     SF_STATUS status = enable_arrow_force(sf);
 
     // Skip test if server doesn't support arrow_force param in response
-    if(!is_force_arrow_mode(sf)) {
+    if(!snowflake_is_force_arrow_mode(sf)) {
         snowflake_term(sf);
         return;
     }

--- a/tests/test_get_query_result_response.c
+++ b/tests/test_get_query_result_response.c
@@ -58,6 +58,7 @@ void test_get_query_result_response(void **unused) {
             strlen(snowflake_cJSON_GetObjectItem(data, "queryID")->valuestring) + 1,
             SF_UUID4_LEN);
 
+    snowflake_cJSON_Delete(parsedJSON);
     snowflake_query_result_capture_term(result_capture);
     snowflake_stmt_term(sfstmt);
     snowflake_term(sf);

--- a/tests/test_get_query_result_response.c
+++ b/tests/test_get_query_result_response.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <connection.h>
 #include <memory.h>
+#include <error.h>
 
 /**
  * Tests fetching the query result response directly from SFSTMT
@@ -13,14 +14,7 @@
  */
 void test_get_query_result_response(void **unused) {
     SF_CONNECT *sf = setup_snowflake_connection();
-    snowflake_connect(sf);
-    SF_STATUS status = enable_arrow_force(sf);
-
-    // Skip test if server doesn't support arrow_force param in response
-    if(!is_force_arrow_mode(sf)) {
-        snowflake_term(sf);
-        return;
-    }
+    SF_STATUS status = snowflake_connect(sf);
 
     if (status != SF_STATUS_SUCCESS) {
         dump_error(&(sf->error));
@@ -29,15 +23,29 @@ void test_get_query_result_response(void **unused) {
 
     /* query */
     SF_STMT *sfstmt = snowflake_stmt(sf);
-    status = snowflake_query(
-            sfstmt, "select randstr(100,random()) from table(generator(rowcount=>2))",
-            0);
-    if (status != SF_STATUS_SUCCESS) {
-        dump_error(&(sfstmt->error));
-    }
+    SF_QUERY_RESULT_CAPTURE result_capture = sf_query_result_capture_init();
+
+    // Create a space for storing the query response text
+    size_t buffer_size = 5000;
+    result_capture.capture_buffer = (char *) SF_CALLOC(1, buffer_size);
+
+    clear_snowflake_error(&sfstmt->error);
+    status = snowflake_prepare(sfstmt, "select randstr(100,random()) from table(generator(rowcount=>2))", 0);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    // Try first with too small of a buffer size, we should return an error.
+    result_capture.buffer_size = 100;
+    status = snowflake_execute_with_capture(sfstmt, &result_capture);
+    assert_int_equal(status, SF_STATUS_ERROR_BUFFER_TOO_SMALL);
+
+    // Now use the actual size
+    result_capture.buffer_size = buffer_size;
+    clear_snowflake_error(&sfstmt->error);
+    status = snowflake_execute_with_capture(sfstmt, &result_capture);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
 
     // Parse the JSON, and grab a few values to verify correctness
-    cJSON* parsedJSON = snowflake_cJSON_Parse(sfstmt->query_response_text);
+    cJSON *parsedJSON = snowflake_cJSON_Parse(result_capture.capture_buffer);
 
     sf_bool success;
     json_copy_bool(&success, parsedJSON, "success");
@@ -50,6 +58,7 @@ void test_get_query_result_response(void **unused) {
             SF_UUID4_LEN);
 
     snowflake_cJSON_Delete(parsedJSON);
+    free(result_capture.capture_buffer);
     snowflake_stmt_term(sfstmt);
     snowflake_term(sf);
 }

--- a/tests/test_get_query_result_response.c
+++ b/tests/test_get_query_result_response.c
@@ -23,29 +23,30 @@ void test_get_query_result_response(void **unused) {
 
     /* query */
     SF_STMT *sfstmt = snowflake_stmt(sf);
-    SF_QUERY_RESULT_CAPTURE result_capture = snowflake_query_result_capture_init();
+    SF_QUERY_RESULT_CAPTURE *result_capture;
+    snowflake_query_result_capture_init(&result_capture);
 
     // Create a space for storing the query response text
     size_t buffer_size = 5000;
-    result_capture.capture_buffer = (char *) SF_CALLOC(1, buffer_size);
+    result_capture->capture_buffer = (char *) SF_CALLOC(1, buffer_size);
 
     clear_snowflake_error(&sfstmt->error);
     status = snowflake_prepare(sfstmt, "select randstr(100,random()) from table(generator(rowcount=>2))", 0);
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
     // Try first with too small of a buffer size, we should return an error.
-    result_capture.buffer_size = 100;
-    status = snowflake_execute_with_capture(sfstmt, &result_capture);
+    result_capture->buffer_size = 100;
+    status = snowflake_execute_with_capture(sfstmt, result_capture);
     assert_int_equal(status, SF_STATUS_ERROR_BUFFER_TOO_SMALL);
 
     // Now use the actual size
-    result_capture.buffer_size = buffer_size;
+    result_capture->buffer_size = buffer_size;
     clear_snowflake_error(&sfstmt->error);
-    status = snowflake_execute_with_capture(sfstmt, &result_capture);
+    status = snowflake_execute_with_capture(sfstmt, result_capture);
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
     // Parse the JSON, and grab a few values to verify correctness
-    cJSON *parsedJSON = snowflake_cJSON_Parse(result_capture.capture_buffer);
+    cJSON *parsedJSON = snowflake_cJSON_Parse(result_capture->capture_buffer);
 
     sf_bool success;
     json_copy_bool(&success, parsedJSON, "success");
@@ -57,8 +58,7 @@ void test_get_query_result_response(void **unused) {
             strlen(snowflake_cJSON_GetObjectItem(data, "queryID")->valuestring) + 1,
             SF_UUID4_LEN);
 
-    snowflake_cJSON_Delete(parsedJSON);
-    free(result_capture.capture_buffer);
+    snowflake_query_result_capture_term(result_capture);
     snowflake_stmt_term(sfstmt);
     snowflake_term(sf);
 }

--- a/tests/test_get_query_result_response.c
+++ b/tests/test_get_query_result_response.c
@@ -23,7 +23,7 @@ void test_get_query_result_response(void **unused) {
 
     /* query */
     SF_STMT *sfstmt = snowflake_stmt(sf);
-    SF_QUERY_RESULT_CAPTURE result_capture = sf_query_result_capture_init();
+    SF_QUERY_RESULT_CAPTURE result_capture = snowflake_query_result_capture_init();
 
     // Create a space for storing the query response text
     size_t buffer_size = 5000;

--- a/tests/test_get_query_result_response.c
+++ b/tests/test_get_query_result_response.c
@@ -28,7 +28,8 @@ void test_get_query_result_response(void **unused) {
 
     // Create a space for storing the query response text
     size_t buffer_size = 5000;
-    result_capture->capture_buffer = (char *) SF_CALLOC(1, buffer_size);
+    char* resultBuffer = (char *) SF_CALLOC(1, buffer_size);
+    result_capture->capture_buffer = resultBuffer;
 
     clear_snowflake_error(&sfstmt->error);
     status = snowflake_prepare(sfstmt, "select randstr(100,random()) from table(generator(rowcount=>2))", 0);
@@ -46,7 +47,7 @@ void test_get_query_result_response(void **unused) {
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
     // Parse the JSON, and grab a few values to verify correctness
-    cJSON *parsedJSON = snowflake_cJSON_Parse(result_capture->capture_buffer);
+    cJSON *parsedJSON = snowflake_cJSON_Parse(resultBuffer);
 
     sf_bool success;
     json_copy_bool(&success, parsedJSON, "success");
@@ -60,6 +61,7 @@ void test_get_query_result_response(void **unused) {
 
     snowflake_cJSON_Delete(parsedJSON);
     snowflake_query_result_capture_term(result_capture);
+    free(resultBuffer);
     snowflake_stmt_term(sfstmt);
     snowflake_term(sf);
 }


### PR DESCRIPTION
In SNOW-237995, and in PR #253, I modified SF_STMT to contain a field `query_response_text`, which used memory allocated by libsnowflakeclient.

This task is to track refactoring this code to instead use caller-managed memory via a new struct called SF_QUERY_RESPONSE_CAPTURE and a method `snowflake_execute_with_capture`.