### PR TITLE
Simba incident 00284803: crash with named parameters more than 8

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -1195,7 +1195,7 @@ static void STDCALL _snowflake_add_to_named_param_list(void *name_list, char * n
     nparams = (NamedParams *)name_list;
     if (cur_size == nparams->allocd)
     {
-        nparams->name_list = SF_REALLOC(nparams->name_list,(2*cur_size));
+        nparams->name_list = SF_REALLOC(nparams->name_list,(2 * cur_size * sizeof(void *)));
         nparams->allocd = 2 * cur_size;
     }
     nparams->name_list[cur_size] = (void *)name;

--- a/tests/test_bind_named_params.c
+++ b/tests/test_bind_named_params.c
@@ -103,6 +103,53 @@ void test_bind_named_parameters(void **unused) {
     status = snowflake_execute(stmt);
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
+    // test with parameters more than 8
+    status = snowflake_prepare(
+      stmt,
+      "select :v1,:v2,:v3,:v4,:v5,:v6,:v7,:v8,:v9",
+      0
+    );
+
+    string_input.idx = 0;
+    string_input.name = "v1";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v2";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v3";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v4";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v5";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v6";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v7";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v8";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    string_input.name = "v9";
+    status = snowflake_bind_param(stmt, &string_input);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    status = snowflake_execute(stmt);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
 done:
 
     snowflake_stmt_term(stmt);

--- a/tests/test_bind_params.c
+++ b/tests/test_bind_params.c
@@ -91,6 +91,22 @@ void test_bind_parameters(void **unused) {
     status = snowflake_execute(stmt);
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
+    // test with parameters more than 8
+    status = snowflake_prepare(
+      stmt,
+      "select ?,?,?,?,?,?,?,?,?",
+      0
+    );
+
+    for (string_input.idx = 1; string_input.idx <= 9; string_input.idx++)
+    {
+      status = snowflake_bind_param(stmt, &string_input);
+      assert_int_equal(status, SF_STATUS_SUCCESS);
+    }
+
+    status = snowflake_execute(stmt);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
     snowflake_stmt_term(stmt);
     snowflake_term(sf);
 }


### PR DESCRIPTION
This is for the issue reported for PHP driver https://github.com/snowflakedb/pdo_snowflake/issues/220
The root cause is that the new size is incorrect when growing the buffer for named parameters.
Add test cases for more than 8 named parameters and positional parameters as well.