### PR TITLE
Fix thread handle leak on Windows

### DIFF
--- a/lib/platform.c
+++ b/lib/platform.c
@@ -309,6 +309,7 @@ _thread_init(SF_THREAD_HANDLE *thread, void *(*proc)(void *), void *arg) {
 int STDCALL _thread_join(SF_THREAD_HANDLE thread) {
 #ifdef _WIN32
     DWORD ret = WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
     return ret == WAIT_OBJECT_0 ? 0 : 1;
 #else
     return pthread_join(thread, NULL);


### PR DESCRIPTION
simba incident 00294764: thread handle leak on Windows when using put/get command.