### PR TITLE
Avoid empty log file generation.

### DIFF
--- a/include/snowflake/logger.h
+++ b/include/snowflake/logger.h
@@ -92,6 +92,10 @@ log_log_va_list(int level, const char *file, int line, const char *ns,
 
 SF_LOG_LEVEL log_from_str_to_level(const char *level_in_str);
 
+void log_set_path(const char* path);
+
+void log_close();
+
 #if defined(__cplusplus)
 }
 #endif

--- a/lib/client.c
+++ b/lib/client.c
@@ -357,18 +357,8 @@ static sf_bool STDCALL log_init(const char *log_path, SF_LOG_LEVEL log_level) {
                     strerror(errno));
             goto cleanup;
         }
-        // Open log file
-        LOG_FP = fopen(LOG_PATH, "w+");
-        if (LOG_FP) {
-            // Set log file
-            log_set_fp(LOG_FP);
-        } else {
-            fprintf(stderr,
-                    "Error opening file from file path: %s\nError code: %s\n",
-                    LOG_PATH, strerror(errno));
-            goto cleanup;
-        }
-
+        // Set the log path only, the log file will be created when actual log output is needed.
+        log_set_path(LOG_PATH);
     } else {
         fprintf(stderr,
                 "Log path is NULL. Was there an error during path construction?\n");
@@ -385,11 +375,8 @@ cleanup:
  * Cleans up memory allocated for log init and closes log file.
  */
 static void STDCALL log_term() {
+    log_close();
     SF_FREE(LOG_PATH);
-    if (LOG_FP) {
-        fclose(LOG_FP);
-        log_set_fp(NULL);
-    }
     _mutex_term(&gmlocaltime_lock);
     _mutex_term(&log_lock);
 }

--- a/tests/test_unit_logger.c
+++ b/tests/test_unit_logger.c
@@ -4,6 +4,9 @@
 
 
 #include "utils/test_setup.h"
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 /**
  * Tests converting a string representation of log level to the log level enum
@@ -21,9 +24,40 @@ void test_log_str_to_level(void **unused) {
     assert_int_equal(log_from_str_to_level(NULL), SF_LOG_FATAL);
 }
 
+#ifndef _WIN32
+/**
+ * Tests timing of log file creation
+ */
+void test_log_creation(void **unused) {
+    char logname[] = "dummy.log";
+
+    // ensure the log file doesn't exist at the beginning
+    remove(logname);
+    assert_int_not_equal(access(logname, F_OK), 0);
+
+    log_set_lock(NULL);
+    log_set_level(SF_LOG_WARN);
+    log_set_quiet(1);
+    log_set_path(logname);
+
+    // info log won't trigger the log file creation since log level is set to warning
+    log_info("dummy info log");
+    assert_int_not_equal(access(logname, F_OK), 0);
+
+    // warning log will trigger the log file creation
+    log_warn("dummy warning log");
+    assert_int_equal(access(logname, F_OK), 0);
+
+    remove(logname);
+}
+#endif
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_log_str_to_level),
+#ifndef _WIN32
+        cmocka_unit_test(test_log_creation),
+#endif
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Simba incident 00295760: PHP driver creates empty log files.
Delay log file creation to when actual log output is needed.