### PR TITLE
SNOW-289058 Refactor RESULT_CAPTURE to allocate response space in-library

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -330,15 +330,13 @@ typedef struct SF_STATS {
  * For certain applications, we may wish to capture
  * the raw response after issuing a query to Snowflake.
  * This is a structure used for capturing the results.
- * Note that the caller is responsible for managing the memory
- * used for this, and that these should always be constructed
- * with snowflake_query_result_capture_init().
+ * Note that these should always be constructed
+ * with snowflake_query_result_capture_init(), and be
+ * destructed with snowflake_query_result_capture_term().
  */
 typedef struct SF_QUERY_RESULT_CAPTURE {
     // The buffer for storing the results
     char* capture_buffer;
-    // Size of the buffer
-    size_t buffer_size;
     // Actual response size
     size_t actual_response_size;
 } SF_QUERY_RESULT_CAPTURE;

--- a/lib/client.c
+++ b/lib/client.c
@@ -1340,7 +1340,6 @@ void STDCALL snowflake_query_result_capture_init(SF_QUERY_RESULT_CAPTURE **init)
     SF_QUERY_RESULT_CAPTURE *capture = (SF_QUERY_RESULT_CAPTURE *) SF_CALLOC(1, sizeof(SF_QUERY_RESULT_CAPTURE));
 
     capture->capture_buffer = NULL;
-    capture->buffer_size = 0;
     capture->actual_response_size = 0;
 
     *init = capture;
@@ -1375,7 +1374,7 @@ void STDCALL snowflake_bind_input_init(SF_BIND_INPUT * input)
  */
 void STDCALL snowflake_query_result_capture_term(SF_QUERY_RESULT_CAPTURE *capture) {
     if (capture) {
-        capture->capture_buffer = NULL;
+        SF_FREE(capture->capture_buffer);
         SF_FREE(capture);
     }
 }
@@ -1853,17 +1852,14 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
     if (request(sfstmt->connection, &resp, queryURL, url_params,
                 url_paramSize , s_body, NULL,
                 POST_REQUEST_TYPE, &sfstmt->error, is_put_get_command)) {
-        s_resp = snowflake_cJSON_Print(resp);
-        log_trace("Here is JSON response:\n%s", s_resp);
 
         // Store the full query-response text in the capture buffer, if defined.
-        if (result_capture != NULL && result_capture->capture_buffer != NULL) {
+        if (result_capture != NULL) {
+            // s_resp will be freed by snowflake_query_result_capture_term
+            s_resp = snowflake_cJSON_Print(resp);
+            log_trace("Here is JSON response:\n%s", s_resp);
             size_t resp_size = strlen(s_resp) + 1;
-            if (result_capture->buffer_size < resp_size) {
-                ret = SF_STATUS_ERROR_BUFFER_TOO_SMALL;
-                goto cleanup;
-            }
-            sb_strncpy(result_capture->capture_buffer, resp_size, s_resp, resp_size);
+            result_capture->capture_buffer = s_resp;
             result_capture->actual_response_size = resp_size;
         }
 
@@ -2085,8 +2081,16 @@ cleanup:
     snowflake_cJSON_Delete(body);
     snowflake_cJSON_Delete(resp);
     SF_FREE(s_body);
-    SF_FREE(s_resp);
     SF_FREE(qrmk);
+    if (ret != SF_STATUS_SUCCESS && result_capture != NULL) {
+        // No need to free s_resp if this function succeed. s_resp will be freed in
+        // snowflake_query_result_capture_term.
+        // No need to free s_resp if result_capture == NULL, as s_resp will be NULL as well.
+        SF_FREE(s_resp);
+        // reset states of result_capture to avoid potential double free of capture_buffer.
+        result_capture->capture_buffer = NULL;
+        result_capture->actual_response_size = 0;
+    }
 
     return ret;
 }

--- a/tests/test_get_query_result_response.c
+++ b/tests/test_get_query_result_response.c
@@ -26,25 +26,15 @@ void test_get_query_result_response(void **unused) {
     SF_QUERY_RESULT_CAPTURE *result_capture;
     snowflake_query_result_capture_init(&result_capture);
 
-    // Create a space for storing the query response text
-    size_t buffer_size = 5000;
-    char* resultBuffer = (char *) SF_CALLOC(1, buffer_size);
-    result_capture->capture_buffer = resultBuffer;
-
     clear_snowflake_error(&sfstmt->error);
     status = snowflake_prepare(sfstmt, "select randstr(100,random()) from table(generator(rowcount=>2))", 0);
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
-    // Try first with too small of a buffer size, we should return an error.
-    result_capture->buffer_size = 100;
-    status = snowflake_execute_with_capture(sfstmt, result_capture);
-    assert_int_equal(status, SF_STATUS_ERROR_BUFFER_TOO_SMALL);
-
-    // Now use the actual size
-    result_capture->buffer_size = buffer_size;
+    // Issue the query
     clear_snowflake_error(&sfstmt->error);
     status = snowflake_execute_with_capture(sfstmt, result_capture);
     assert_int_equal(status, SF_STATUS_SUCCESS);
+    char *resultBuffer = result_capture->capture_buffer;
 
     // Parse the JSON, and grab a few values to verify correctness
     cJSON *parsedJSON = snowflake_cJSON_Parse(resultBuffer);
@@ -61,7 +51,40 @@ void test_get_query_result_response(void **unused) {
 
     snowflake_cJSON_Delete(parsedJSON);
     snowflake_query_result_capture_term(result_capture);
-    free(resultBuffer);
+    snowflake_stmt_term(sfstmt);
+    snowflake_term(sf);
+}
+
+/**
+ * Tests fetching the query result response with failed query
+ * @param unused
+ */
+void test_get_query_result_response_failed(void **unused) {
+    SF_CONNECT *sf = setup_snowflake_connection();
+    SF_STATUS status = snowflake_connect(sf);
+
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sf->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    /* query */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    SF_QUERY_RESULT_CAPTURE *result_capture;
+    snowflake_query_result_capture_init(&result_capture);
+
+    clear_snowflake_error(&sfstmt->error);
+    status = snowflake_prepare(sfstmt, "wrong query", 0);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    // Issue the query
+    clear_snowflake_error(&sfstmt->error);
+    status = snowflake_execute_with_capture(sfstmt, result_capture);
+    assert_int_equal(status, SF_STATUS_ERROR_GENERAL);
+    assert_null(result_capture->capture_buffer);
+    assert_int_equal(result_capture->actual_response_size, 0);
+
+    snowflake_query_result_capture_term(result_capture);
     snowflake_stmt_term(sfstmt);
     snowflake_term(sf);
 }
@@ -70,6 +93,7 @@ int main(void) {
     initialize_test(SF_BOOLEAN_FALSE);
     const struct CMUnitTest tests[] = {
             cmocka_unit_test(test_get_query_result_response),
+            cmocka_unit_test(test_get_query_result_response_failed),
     };
     int ret = cmocka_run_group_tests(tests, NULL, NULL);
     snowflake_global_term();


### PR DESCRIPTION
Previously we require the caller of `snowflake_execute_with_capture` to allocate memory for `result_capture->capture_buffer`. The initial motivation is to make it easy for xp to manage dynamically allocated memories. However, the draw back is that caller have no idea about how much memory should be allocated. 

This PR aims to refactor RESULT_CAPTURE to allocate response space in library. The memory is allocated in `snowflake_execute_with_capture` to variable `result_capture->capture_buffer`. Then the memory is freed in `snowflake_query_result_capture_term`.

We rely on caller following the pattern of calling `snowflake_query_result_capture_init` to init result_capture and calling `snowflake_query_result_capture_term` to free the memory. 