### PR TITLE
SNOW-293305 Add describe only api

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -691,6 +691,15 @@ SF_STATUS STDCALL snowflake_execute_with_capture(SF_STMT *sfstmt,
         SF_QUERY_RESULT_CAPTURE* result_capture);
 
 /**
+ * Executes a statement with capture in describe only mode.
+ * @param sfstmt SNOWFLAKE_STMT context.
+ * @param result_capture pointer to a SF_QUERY_RESULT_CAPTURE
+ * @return 0 if success, otherwise an errno is returned.
+ */
+SF_STATUS STDCALL snowflake_describe_with_capture(SF_STMT *sfstmt,
+                                                  SF_QUERY_RESULT_CAPTURE *result_capture);
+
+/**
  * Fetches the next row for the statement and stores on the bound buffer
  * if any. Noop if no buffer is bound.
  *

--- a/lib/client.c
+++ b/lib/client.c
@@ -1722,17 +1722,23 @@ cleanup:
     return ret;
 }
 
+SF_STATUS STDCALL snowflake_describe_with_capture(SF_STMT *sfstmt,
+                                                  SF_QUERY_RESULT_CAPTURE *result_capture) {
+    return _snowflake_execute_ex(sfstmt, _is_put_get_command(sfstmt->sql_text), result_capture, SF_BOOLEAN_TRUE);
+}
+
 SF_STATUS STDCALL snowflake_execute(SF_STMT *sfstmt) {
-    return _snowflake_execute_ex(sfstmt, _is_put_get_command(sfstmt->sql_text), NULL);
+    return _snowflake_execute_ex(sfstmt, _is_put_get_command(sfstmt->sql_text), NULL, SF_BOOLEAN_FALSE);
 }
 
 SF_STATUS STDCALL snowflake_execute_with_capture(SF_STMT *sfstmt, SF_QUERY_RESULT_CAPTURE *result_capture) {
-    return _snowflake_execute_ex(sfstmt, _is_put_get_command(sfstmt->sql_text), result_capture);
+    return _snowflake_execute_ex(sfstmt, _is_put_get_command(sfstmt->sql_text), result_capture, SF_BOOLEAN_FALSE);
 }
 
 SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
                                         sf_bool is_put_get_command,
-                                        SF_QUERY_RESULT_CAPTURE* result_capture) {
+                                        SF_QUERY_RESULT_CAPTURE* result_capture,
+                                        sf_bool is_describe_only) {
     if (!sfstmt) {
         return SF_STATUS_ERROR_STATEMENT_NOT_EXIST;
     }
@@ -1836,7 +1842,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
     // Create Body
     body = create_query_json_body(sfstmt->sql_text, sfstmt->sequence_counter,
                                   is_string_empty(sfstmt->connection->directURL) ?
-                                  NULL : sfstmt->request_id);
+                                  NULL : sfstmt->request_id, is_describe_only);
     if (bindings != NULL) {
         /* binding parameters if exists */
       snowflake_cJSON_AddItemToObject(body, "bindings", bindings);

--- a/lib/client_int.h
+++ b/lib/client_int.h
@@ -124,13 +124,15 @@ SF_PUT_GET_RESPONSE *STDCALL sf_put_get_response_allocate();
  * @param sfstmt SNOWFLAKE_STMT context.
  * @param sf_use_application_json_accept type true if this is a put/get command
  * @param raw_response_buffer optional pointer to an SF_QUERY_RESULT_CAPTURE,
+ * @param is_describe_only should the statement be executed in describe only mode
  * if the query response is to be captured.
  *
  * @return 0 if success, otherwise an errno is returned.
  */
 SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
                                         sf_bool use_application_json_accept_type,
-                                        struct SF_QUERY_RESULT_CAPTURE* result_capture);
+                                        struct SF_QUERY_RESULT_CAPTURE* result_capture,
+                                        sf_bool is_describe_only);
 
 /**
  * @return true if this is a put/get command, otherwise false

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -183,7 +183,7 @@ cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
     return body;
 }
 
-cJSON *STDCALL create_query_json_body(const char *sql_text, int64 sequence_id, const char *request_id) {
+cJSON *STDCALL create_query_json_body(const char *sql_text, int64 sequence_id, const char *request_id, sf_bool is_describe_only) {
     cJSON *body;
     double submission_time;
     // Create body
@@ -197,6 +197,7 @@ cJSON *STDCALL create_query_json_body(const char *sql_text, int64 sequence_id, c
     snowflake_cJSON_AddBoolToObject(body, "asyncExec", SF_BOOLEAN_FALSE);
     snowflake_cJSON_AddNumberToObject(body, "sequenceId", (double) sequence_id);
     snowflake_cJSON_AddNumberToObject(body, "querySubmissionTime", submission_time);
+    snowflake_cJSON_AddBoolToObject(body, "describeOnly", is_describe_only);
     if (request_id)
     {
         snowflake_cJSON_AddStringToObject(body, "requestId", request_id);

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -164,9 +164,10 @@ cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf, const char *application, co
  * @param sql_text The sql query to send to Snowflake
  * @param sequence_id Sequence ID from the Snowflake Connection object.
  * @param request_id  requestId to be passed as a part of body instead of header.
+ * @param is_describe_only is the query describe only.
  * @return Query cJSON Body.
  */
-cJSON *STDCALL create_query_json_body(const char *sql_text, int64 sequence_id, const char *request_id);
+cJSON *STDCALL create_query_json_body(const char *sql_text, int64 sequence_id, const char *request_id, sf_bool is_describe_only);
 
 /**
  * Creates a cJSON blob that is used to renew a session with Snowflake. cJSON blob must be freed by the caller using

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ SET(TESTS_C
         test_column_fetch
         test_native_timestamp
         test_get_query_result_response
+        test_get_describe_only_query_result
         test_arrow_force
 #        test_stats
         )

--- a/tests/test_get_describe_only_query_result.c
+++ b/tests/test_get_describe_only_query_result.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018-2020 Snowflake Computing, Inc. All rights reserved.
+ */
+#include "utils/test_setup.h"
+#include <cJSON.h>
+#include <string.h>
+#include <connection.h>
+#include <memory.h>
+#include <error.h>
+
+/**
+ * Tests fetching the describe only query result response directly from SFSTMT
+ * @param unused
+ */
+void test_get_describe_only_query_result(void **unused) {
+    SF_CONNECT *sf = setup_snowflake_connection();
+    SF_STATUS status = snowflake_connect(sf);
+
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sf->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    /* query */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    SF_QUERY_RESULT_CAPTURE *result_capture;
+    snowflake_query_result_capture_init(&result_capture);
+
+    clear_snowflake_error(&sfstmt->error);
+    status = snowflake_prepare(sfstmt, "select randstr(100,random()) from table(generator(rowcount=>2))", 0);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    // Issue the query
+    clear_snowflake_error(&sfstmt->error);
+    status = snowflake_describe_with_capture(sfstmt, result_capture);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+    char *resultBuffer = result_capture->capture_buffer;
+
+    // Parse the JSON, and grab a few values to verify correctness
+    cJSON *parsedJSON = snowflake_cJSON_Parse(resultBuffer);
+
+    sf_bool success;
+    json_copy_bool(&success, parsedJSON, "success");
+    assert_int_equal(success, SF_BOOLEAN_TRUE);
+
+    cJSON *data = snowflake_cJSON_GetObjectItem(
+            parsedJSON, "data");
+    assert_int_equal(
+            strlen(snowflake_cJSON_GetObjectItem(data, "queryID")->valuestring) + 1,
+            SF_UUID4_LEN);
+
+    // Make sure that the query is run in describe only mode and the actual result is empty
+    assert_int_equal(snowflake_cJSON_GetArraySize(snowflake_cJSON_GetObjectItem(data, "rowset")), 0);
+
+    snowflake_cJSON_Delete(parsedJSON);
+    snowflake_query_result_capture_term(result_capture);
+    snowflake_stmt_term(sfstmt);
+    snowflake_term(sf);
+}
+
+int main(void) {
+    initialize_test(SF_BOOLEAN_FALSE);
+    const struct CMUnitTest tests[] = {
+            cmocka_unit_test(test_get_describe_only_query_result),
+    };
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    snowflake_global_term();
+    return ret;
+}

--- a/tests/test_get_describe_only_query_result.c
+++ b/tests/test_get_describe_only_query_result.c
@@ -43,14 +43,16 @@ void test_get_describe_only_query_result(void **unused) {
     json_copy_bool(&success, parsedJSON, "success");
     assert_int_equal(success, SF_BOOLEAN_TRUE);
 
-    cJSON *data = snowflake_cJSON_GetObjectItem(
-            parsedJSON, "data");
+    cJSON *data = snowflake_cJSON_GetObjectItem(parsedJSON, "data");
     assert_int_equal(
             strlen(snowflake_cJSON_GetObjectItem(data, "queryID")->valuestring) + 1,
             SF_UUID4_LEN);
 
     // Make sure that the query is run in describe only mode and the actual result is empty
     assert_int_equal(snowflake_cJSON_GetArraySize(snowflake_cJSON_GetObjectItem(data, "rowset")), 0);
+    // Make sure row types are returned
+    cJSON *rowtype = snowflake_cJSON_GetArrayItem(snowflake_cJSON_GetObjectItem(data, "rowtype"), 0);
+    assert_string_equal(snowflake_cJSON_GetStringValue(snowflake_cJSON_GetObjectItem(rowtype, "type")), "text");
 
     snowflake_cJSON_Delete(parsedJSON);
     snowflake_query_result_capture_term(result_capture);


### PR DESCRIPTION
Currently libsnowflakeclient only support snowflake_execute, which will execute a snowflake statement. In JDBC, apart from statement.execute(), there is another API called statement.describe(), which will execute the query in describe only mode. Describe only means GS will only return some metadata associated with the sql, but won’t actually execute the query.

Statement.describe() is a key dependency for Java Stored Procedures, thus we want to add a new api in libsnowflakeclient, snowflake_describe, for Java SP.
