### PR TITLE
allow put to a subfolder without ending with /

### DIFF
--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -70,6 +70,12 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
   auto bc = std::make_shared<azure::storage_lite::blob_client>(account, m_parallel, caBundleFile);
   m_blobclient= new azure::storage_lite::blob_client_wrapper(bc);
 
+  //Ensure the stage location ended with /
+  if ((!m_stageInfo->location.empty()) && (m_stageInfo->location.back() != '/'))
+  {
+    m_stageInfo->location.push_back('/');
+  }
+
   CXX_LOG_TRACE("Successfully created Azure client. End of constructor.");
 }
 

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -111,6 +111,13 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
           clientConfiguration,
           Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
           true); // explicitly set virtual addressing style to be true
+
+  //Ensure the stage location ended with /
+  if ((!m_stageInfo->location.empty()) && (m_stageInfo->location.back() != '/'))
+  {
+    m_stageInfo->location.push_back('/');
+  }
+
   CXX_LOG_TRACE("Successfully created s3 client. End of constructor.");
 }
 

--- a/tests/test_simple_put.cpp
+++ b/tests/test_simple_put.cpp
@@ -51,7 +51,8 @@ void test_simple_put_core(const char * fileName,
                           bool createDupTable=false,
                           bool setCustomThreshold=false,
                           size_t customThreshold=64*1024*1024,
-                          bool useDevUrand=false)
+                          bool useDevUrand=false,
+                          bool createSubfolder=false)
 {
   /* init */
   SF_STATUS status;
@@ -88,6 +89,11 @@ void test_simple_put_core(const char * fileName,
   {
       putCommand = "put file://" + std::string(fileName) + " @%test_small_put_dup";
   }
+  else if (createSubfolder)
+  {
+       putCommand = "put file://" + file + " @%test_small_put/subfolder";
+  }
+
   if (!autoCompress)
   {
     putCommand += " auto_compress=false";
@@ -535,6 +541,11 @@ void test_simple_put_threshold(void **unused)
   test_simple_put_core("small_file.csv.gz", "gzip", false, false, false, false, false, false, 100*1024*1024);
 }
 
+void test_simple_put_create_subfolder(void **unused)
+{
+  test_simple_put_core("small_file.csv.gz", "gzip", false, false, false, false, false, false, 100*1024*1024, false, true);
+}
+
 void test_simple_get(void **unused)
 {
   test_simple_put_core("small_file.csv", // filename
@@ -882,7 +893,8 @@ int main(void) {
     cmocka_unit_test_teardown(test_verify_upload, teardown),
     cmocka_unit_test_teardown(test_large_put_threshold, teardown),
     cmocka_unit_test_teardown(test_simple_put_uploadfail, teardown),
-    cmocka_unit_test_teardown(test_simple_put_use_dev_urandom, teardown)
+    cmocka_unit_test_teardown(test_simple_put_use_dev_urandom, teardown),
+    cmocka_unit_test_teardown(test_simple_put_create_subfolder, teardown)
   };
   int ret = cmocka_run_group_tests(tests, gr_setup, gr_teardown);
   return ret;


### PR DESCRIPTION
Simba incident 00298808
When execute put command on AWS, having a subfolder in the stage and not ending it with / will cause failure.
example: put file://c:\puttest\data.tar.gz @stage/subfolder
In the case of Azure, the last charater of the subfolder name is truncated, so the file is uploaded to stage/subfulde
The reason is that the S3Client and AzureClient expect stage location end with /, while in the case of subfolder, it's not.