### PR TITLE
SNOW-303289 Fix error in xp

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -2090,13 +2090,9 @@ cleanup:
     if (result_capture == NULL) {
         // If no result capture, we always free s_resp
         SF_FREE(s_resp);
-    } else if (ret != SF_STATUS_SUCCESS) {
-        // If result capture failed, free s_resp.
-        SF_FREE(s_resp);
-        // reset states of result_capture to avoid potential double free of capture_buffer.
-        result_capture->capture_buffer = NULL;
-        result_capture->actual_response_size = 0;
-    } // If result capture succeeded, we don't need to free s_resp.
+    }
+    // Caller should always call result_capture_term to free s_resp,
+    // if result_capture is not NULL
 
     return ret;
 }

--- a/tests/test_get_query_result_response.c
+++ b/tests/test_get_query_result_response.c
@@ -81,8 +81,7 @@ void test_get_query_result_response_failed(void **unused) {
     clear_snowflake_error(&sfstmt->error);
     status = snowflake_execute_with_capture(sfstmt, result_capture);
     assert_int_equal(status, SF_STATUS_ERROR_GENERAL);
-    assert_null(result_capture->capture_buffer);
-    assert_int_equal(result_capture->actual_response_size, 0);
+    assert_int_not_equal(result_capture->actual_response_size, 0);
 
     snowflake_query_result_capture_term(result_capture);
     snowflake_stmt_term(sfstmt);


### PR DESCRIPTION
In XP, when the query we issued to GS failed, we want to propagate the error message to UDF server.
Currently in libsfclient, if the execution failed, we free the memory space where we store the GS response. This PR changed this behavior that even if GS returns a failed message, snowflake_execute_with_capture will always stores the response in the passed in result_capture struct. 
This won't cause memory leak, because caller will always call snowflake_result_capture_term to free the memory in result_capture struct.