### PR TITLE
fix centos 7 compiler errors with sb_strcpy 

### DIFF
--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -40,11 +40,14 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
   const std::string azuresaskey("AZURE_SAS_KEY");
   char caBundleFile[MAX_PATH] = {0};
   if(transferConfig && transferConfig->caBundleFile) {
-      if ( strlen(transferConfig->caBundleFile) > MAX_PATH -1) {
+      size_t len = strlen(transferConfig->caBundleFile);
+      if ( len > MAX_PATH - 1) {
         throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,
             "CA bundle file path too long.");
       }
-      strcpy(caBundleFile, transferConfig->caBundleFile);
+      if( ! sb_strcpy(caBundleFile, (size_t)MAX_PATH, transferConfig->caBundleFile) ) {
+        caBundleFile[0] = 0;
+      }
       CXX_LOG_TRACE("ca bundle file from TransferConfig *%s*", caBundleFile);
   }
   else if( caBundleFile[0] == 0 ) {
@@ -57,7 +60,9 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
         throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,
             "CA bundle file path too long.");
       }
-      strcpy(caBundleFile, capath);
+      if ( ! sb_strcpy(caBundleFile, (size_t)MAX_PATH, capath) ) {
+        caBundleFile[0] = 0;
+      }
       CXX_LOG_TRACE("ca bundle file from SNOWFLAKE_TEST_CA_BUNDLE_FILE *%s*", caBundleFile);
   }
   if(caBundleFile[0] == 0) {

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -38,11 +38,13 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
   m_parallel(std::min(parallel, std::thread::hardware_concurrency()))
 {
   const std::string azuresaskey("AZURE_SAS_KEY");
-  char caBundleFile[MAX_PATH] ={0};
+  char caBundleFile[MAX_PATH] = {0};
   if(transferConfig && transferConfig->caBundleFile) {
-      int len = std::min((int)strlen(transferConfig->caBundleFile), MAX_PATH - 1);
-      sb_strncpy(caBundleFile, sizeof(caBundleFile), transferConfig->caBundleFile, len);
-      caBundleFile[len]=0;
+      if ( strlen(transferConfig->caBundleFile) > MAX_PATH -1) {
+        throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,
+            "CA bundle file path too long.");
+      }
+      strcpy(caBundleFile, transferConfig->caBundleFile);
       CXX_LOG_TRACE("ca bundle file from TransferConfig *%s*", caBundleFile);
   }
   else if( caBundleFile[0] == 0 ) {
@@ -51,9 +53,11 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
   }
   if( caBundleFile[0] == 0 ) {
       const char* capath = std::getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
-      int len = std::min((int)strlen(capath), MAX_PATH - 1);
-      sb_strncpy(caBundleFile, sizeof(caBundleFile), capath, len);
-      caBundleFile[len]=0;
+      if( capath && strlen(capath) > MAX_PATH - 1) {
+        throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,
+            "CA bundle file path too long.");
+      }
+      strcpy(caBundleFile, capath);
       CXX_LOG_TRACE("ca bundle file from SNOWFLAKE_TEST_CA_BUNDLE_FILE *%s*", caBundleFile);
   }
   if(caBundleFile[0] == 0) {


### PR DESCRIPTION
Fix compilation errors on centos 7 / g++82 compiler toolchain to make it build for XP
And also for porting libnsnowflakeclient to run on ARM processors.