### PR TITLE
AWS s3 private links now get regional URL when relevant parameter is set

### DIFF
--- a/cpp/FileMetadataInitializer.hpp
+++ b/cpp/FileMetadataInitializer.hpp
@@ -11,7 +11,7 @@
 #include "IStorageClient.hpp"
 
 // used to decide whether to upload in sequence or in parallel
-#define DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD 67108864 //64Mb
+#define DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD 209715200 //200Mb
 #define DOWNLOAD_DATA_SIZE_THRESHOLD 5242880 // 5MB
 
 namespace Snowflake

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -79,6 +79,13 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
   clientConfiguration.caFile = caFile;
   clientConfiguration.requestTimeoutMs = 40000;
   clientConfiguration.connectTimeoutMs = 30000;
+  if(transferConfig != nullptr && transferConfig->useS3regionalUrl)
+  {
+    clientConfiguration.endpointOverride = Aws::String("s3.")
+        + Aws::String(clientConfiguration.region)
+        + Aws::String(".amazonaws.com");
+  }
+
   Util::Proxy proxy;
   proxy.setProxyFromEnv();
 

--- a/include/snowflake/IFileTransferAgent.hpp
+++ b/include/snowflake/IFileTransferAgent.hpp
@@ -19,9 +19,10 @@ namespace Client
  */
 struct TransferConfig
 {
-  TransferConfig() : caBundleFile(NULL), tempDir(NULL) {}
+  TransferConfig() : caBundleFile(NULL), tempDir(NULL), useS3regionalUrl(false) {}
   char * caBundleFile;
   char * tempDir;
+  bool useS3regionalUrl;
 };
 
 class IFileTransferAgent

--- a/tests/test_simple_put.cpp
+++ b/tests/test_simple_put.cpp
@@ -53,7 +53,8 @@ void test_simple_put_core(const char * fileName,
                           size_t customThreshold=64*1024*1024,
                           bool useDevUrand=false,
                           bool createSubfolder=false,
-                          char * tmpDir = nullptr)
+                          char * tmpDir = nullptr,
+                          bool useS3regionalUrl = false)
 {
   /* init */
   SF_STATUS status;
@@ -119,6 +120,11 @@ void test_simple_put_core(const char * fileName,
   {
       transConfig.tempDir = tmpDir;
       transConfigPtr = &transConfig;
+  }
+  if(useS3regionalUrl)
+  {
+    transConfig.useS3regionalUrl = true;
+    transConfigPtr = &transConfig;
   }
   Snowflake::Client::FileTransferAgent agent(stmtPutGet.get(), transConfigPtr);
 
@@ -589,6 +595,20 @@ void test_simple_put_create_subfolder(void **unused)
   test_simple_put_core("small_file.csv.gz", "gzip", false, false, false, false, false, false, 100*1024*1024, false, true);
 }
 
+void test_simple_put_use_s3_regionalURL(void **unused)
+{
+  test_simple_put_core("small_file.csv.gz", "gzip", false,false,
+                       false,
+                       false,
+                       false,
+                       false,
+                       100*1024*1024,
+                       false,
+                       false,
+                       nullptr,
+                       true);
+}
+
 void test_simple_get(void **unused)
 {
   test_simple_put_core("small_file.csv", // filename
@@ -938,7 +958,8 @@ int main(void) {
     cmocka_unit_test_teardown(test_large_put_threshold, teardown),
     cmocka_unit_test_teardown(test_simple_put_uploadfail, teardown),
     cmocka_unit_test_teardown(test_simple_put_use_dev_urandom, teardown),
-    cmocka_unit_test_teardown(test_simple_put_create_subfolder, teardown)
+    cmocka_unit_test_teardown(test_simple_put_create_subfolder, teardown),
+    cmocka_unit_test_teardown(test_simple_put_use_s3_regionalURL, teardown)
   };
   int ret = cmocka_run_group_tests(tests, gr_setup, gr_teardown);
   return ret;


### PR DESCRIPTION
When the parameter FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS is set to true then invoke a different API to generate S3 regional url.
This does NOT break any existing customers. The above parameter will be set true to private link parameters in the AWS us-east-1 regions.