### PR TITLE
snowflakeclient Disable secretDetection for XP

### DIFF
--- a/cpp/logger/SFLogger.cpp
+++ b/cpp/logger/SFLogger.cpp
@@ -58,5 +58,9 @@ std::string Snowflake::Client::SFLogger::getMaskedMsgVA(const char* fmt, va_list
     }
   }
 
+#ifdef LIBSFCLI_FOR_XP
+  return std::string(buf.data());
+#else
   return SecretDetector::maskSecrets(std::string(buf.data()));
+#endif
 }


### PR DESCRIPTION
To improve performance, We want to skip log secret detector when running in XP mode.