### PR TITLE
Ignore clang warning in SnowflakeTransferException.cpp

### DIFF
--- a/cpp/SnowflakeTransferException.cpp
+++ b/cpp/SnowflakeTransferException.cpp
@@ -28,12 +28,12 @@ Snowflake::Client::SnowflakeTransferException::SnowflakeTransferException(
 {
   const char * msgFmt = errorMsgFmts[(int)transferError];
   va_list args;
-#if defined(__APPLE__)
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvarargs"
 #endif
   va_start (args, transferError);
-#if defined(__APPLE__)
+#if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
   sb_vsnprintf(m_msg, sizeof(m_msg), sizeof(m_msg) - 1, msgFmt, args);


### PR DESCRIPTION
Simply replaces ifdef __APPLE__ with __clang__ as warning that needs
to be ignored isn't specific to apple.