### PR TITLE
support configurable compress level

### DIFF
--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -556,9 +556,14 @@ void Snowflake::Client::FileTransferAgent::compressSourceFile(
   CXX_LOG_DEBUG("Starting file compression");
   
   char tempDir[MAX_PATH]={0};
-  if (m_transferConfig && m_transferConfig->tempDir)
+  int level = -1;
+  if (m_transferConfig)
   {
-    sb_strcat(tempDir, sizeof(tempDir), m_transferConfig->tempDir);
+    level = m_transferConfig->compressLevel;
+    if (m_transferConfig->tempDir)
+    {
+      sb_strcat(tempDir, sizeof(tempDir), m_transferConfig->tempDir);
+    }
   }
   sf_get_uniq_tmp_dir(tempDir);
   std::string stagingFile(tempDir);
@@ -576,7 +581,7 @@ void Snowflake::Client::FileTransferAgent::compressSourceFile(
     throw SnowflakeTransferException(TransferError::FILE_OPEN_ERROR, fileMetadata->srcFileToUpload.c_str(), -1);
   }
   int ret = Util::CompressionUtil::compressWithGzip(sourceFile, destFile,
-                                          fileMetadata->srcFileToUploadSize);
+                                          fileMetadata->srcFileToUploadSize, level);
   if (ret != 0)
   {
     CXX_LOG_ERROR("Failed to compress source file. Error code: %d", ret);

--- a/cpp/util/CompressionUtil.cpp
+++ b/cpp/util/CompressionUtil.cpp
@@ -22,7 +22,8 @@
 
 int Snowflake::Client::Util::CompressionUtil::compressWithGzip(FILE *source,
                                                                FILE *dest,
-                                                               long &destSize)
+                                                               long &destSize,
+                                                               int level)
 {
   SET_BINARY_MODE(source);
   SET_BINARY_MODE(dest);
@@ -37,7 +38,11 @@ int Snowflake::Client::Util::CompressionUtil::compressWithGzip(FILE *source,
   strm.zalloc = Z_NULL;
   strm.zfree = Z_NULL;
   strm.opaque = Z_NULL;
-  ret = deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
+  if ((level < 0) || (level > 9))
+  {
+      level = Z_DEFAULT_COMPRESSION;
+  }
+  ret = deflateInit2(&strm, level, Z_DEFLATED,
                      WINDOW_BIT | GZIP_ENCODING, 8, Z_DEFAULT_STRATEGY);
   if (ret != Z_OK)
     return ret;

--- a/cpp/util/CompressionUtil.hpp
+++ b/cpp/util/CompressionUtil.hpp
@@ -22,9 +22,10 @@ public:
    * @param source source file to compress
    * @param dest destination file that compress result will write to
    * @param destSize file size of compression result
+   * @param level compression level
    * @return
    */
-  static int compressWithGzip(FILE *source, FILE *dest, long &destSize);
+  static int compressWithGzip(FILE *source, FILE *dest, long &destSize, int level = -1);
 
   /**
    * Compress file with gzip

--- a/include/snowflake/IFileTransferAgent.hpp
+++ b/include/snowflake/IFileTransferAgent.hpp
@@ -19,10 +19,15 @@ namespace Client
  */
 struct TransferConfig
 {
-  TransferConfig() : caBundleFile(NULL), tempDir(NULL), useS3regionalUrl(false) {}
+  TransferConfig() :
+    caBundleFile(NULL),
+    tempDir(NULL),
+    useS3regionalUrl(false),
+    compressLevel(-1) {}
   char * caBundleFile;
   char * tempDir;
   bool useS3regionalUrl;
+  int compressLevel;
 };
 
 class IFileTransferAgent

--- a/tests/test_simple_put.cpp
+++ b/tests/test_simple_put.cpp
@@ -54,7 +54,9 @@ void test_simple_put_core(const char * fileName,
                           bool useDevUrand=false,
                           bool createSubfolder=false,
                           char * tmpDir = nullptr,
-                          bool useS3regionalUrl = false)
+                          bool useS3regionalUrl = false,
+                          int compressLevel = -1,
+                          bool overwrite = false)
 {
   /* init */
   SF_STATUS status;
@@ -111,6 +113,10 @@ void test_simple_put_core(const char * fileName,
     putCommand += std::to_string(customThreshold);
   }
 
+  if (overwrite)
+  {
+      putCommand += " overwrite=true";
+  }
   std::unique_ptr<IStatementPutGet> stmtPutGet = std::unique_ptr
     <StatementPutGet>(new Snowflake::Client::StatementPutGet(sfstmt));
 
@@ -126,6 +132,12 @@ void test_simple_put_core(const char * fileName,
     transConfig.useS3regionalUrl = true;
     transConfigPtr = &transConfig;
   }
+  if(compressLevel > 0)
+  {
+    transConfig.compressLevel = compressLevel;
+    transConfigPtr = &transConfig;
+  }
+
   Snowflake::Client::FileTransferAgent agent(stmtPutGet.get(), transConfigPtr);
 
   if(useDevUrand){
@@ -518,6 +530,38 @@ void test_simple_put_auto_compress(void **unused)
                        "auto", //source compression
                        true // auto compress
   );
+
+  test_simple_put_core("small_file.csv", // filename
+                       "auto", //source compression
+                       true, // auto compress
+                       false,
+                       false,
+                       false,
+                       false,
+                       false,
+                       100*1024*1024,
+                       false,
+                       false,
+                       nullptr,
+                       false,
+                       1,
+                       true);
+
+  test_simple_put_core("small_file.csv", // filename
+                       "auto", //source compression
+                       true, // auto compress
+                       false,
+                       false,
+                       false,
+                       false,
+                       false,
+                       100*1024*1024,
+                       false,
+                       false,
+                       nullptr,
+                       false,
+                       9,
+                       true);
 }
 
 void test_simple_put_config_temp_dir(void **unused)


### PR DESCRIPTION
Fix for simba ticket 00316238. Make compress level configurable. Will make another PR on ODBC side when this PR is merged.