### PR TITLE
SNOW-366837 add log when query code miss

### DIFF
--- a/cpp/jwt/ClaimSet.hpp
+++ b/cpp/jwt/ClaimSet.hpp
@@ -102,7 +102,7 @@ public:
 
   inline void removeClaim(const std::string &key) override
   {
-    snowflake_cJSON_DeleteItemFromObject(this->json_root_.get(), key.c_str());
+    snowflake_cJSON_DeleteItemFromObject(this->json_root_.get(), key.c_str(),cJSON_False);
   }
 
 private:

--- a/cpp/jwt/ClaimSet.hpp
+++ b/cpp/jwt/ClaimSet.hpp
@@ -102,7 +102,7 @@ public:
 
   inline void removeClaim(const std::string &key) override
   {
-    snowflake_cJSON_DeleteItemFromObject(this->json_root_.get(), key.c_str(),cJSON_False);
+    snowflake_cJSON_DeleteItemFromObject(this->json_root_.get(), key.c_str(), cJSON_False);
   }
 
 private:

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -2143,7 +2143,8 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *o
     return snowflake_cJSON_DetachItemViaPointer(object, to_detach);
 }
 
-//Delete the keyword in json object, if recurse = true, it will delete any children json object contain the keyword.
+//Delete the item with target keyword in json object, if recurse = true,
+// it will delete any children json object contain the item with target keyword.
 //For example, {"data1" : XXX, "data2" : XXX} and keyword = "data2", it will return {"data1" : XXX}.
 //When recurse = true, {"data1" : {"data2" : XXX, "data3" : XXX}} and key word = "data2", it will return
 // {"data1" : {"data3" : XXX}}

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -22,7 +22,7 @@
 
 /* cJSON */
 /* JSON parser in C. */
-
+#include <snowflake/logger.h>
 /* disable warnings about old C89 functions in MSVC */
 #if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
 #define _CRT_SECURE_NO_DEPRECATE
@@ -1645,6 +1645,7 @@ static cJSON_bool print_object(const cJSON * const item, printbuffer * const out
 
     while (current_item)
     {
+        log_trace("current item is: %s",current_item->string);
         if (output_buffer->format)
         {
             size_t i;

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -22,7 +22,6 @@
 
 /* cJSON */
 /* JSON parser in C. */
-#include <snowflake/logger.h>
 /* disable warnings about old C89 functions in MSVC */
 #if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
 #define _CRT_SECURE_NO_DEPRECATE
@@ -2145,7 +2144,7 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *o
 }
 
 //delete the key word, if recurse = true, it will delete any children contain the key word
-CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string,cJSON_bool recurse)
+CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string, cJSON_bool recurse)
 {
     snowflake_cJSON_Delete(snowflake_cJSON_DetachItemFromObject(object, string));
     if(recurse){

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -1645,7 +1645,10 @@ static cJSON_bool print_object(const cJSON * const item, printbuffer * const out
 
     while (current_item)
     {
-        log_trace("current item is: %s",current_item->string);
+        if(strcmp(current_item->string,"rowset") == 0){
+            current_item = current_item->next;
+            continue;
+        }
         if (output_buffer->format)
         {
             size_t i;

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -2144,6 +2144,7 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *o
     return snowflake_cJSON_DetachItemViaPointer(object, to_detach);
 }
 
+//delete the key word, if recurse = true, it will delete any children contain the key word
 CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string,cJSON_bool recurse)
 {
     snowflake_cJSON_Delete(snowflake_cJSON_DetachItemFromObject(object, string));

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -2143,8 +2143,9 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *o
     return snowflake_cJSON_DetachItemViaPointer(object, to_detach);
 }
 
-//Delete the item with target keyword in json object, if recurse = true,
-// it will delete any children json object contain the item with target keyword.
+//Delete the item with target keyword in json object, if recurse = false, it could only
+//delete the current level object's keyword
+// if recurse = true, it will delete any children json object contain the item with target keyword.
 //For example, {"data1" : XXX, "data2" : XXX} and keyword = "data2", it will return {"data1" : XXX}.
 //When recurse = true, {"data1" : {"data2" : XXX, "data3" : XXX}} and key word = "data2", it will return
 // {"data1" : {"data3" : XXX}}

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -2144,9 +2144,18 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *o
     return snowflake_cJSON_DetachItemViaPointer(object, to_detach);
 }
 
-CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string)
+CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string,cJSON_bool recurse)
 {
     snowflake_cJSON_Delete(snowflake_cJSON_DetachItemFromObject(object, string));
+    if(recurse){
+        cJSON *child = NULL;
+        child = object->child;
+        while (child != NULL)
+        {
+            snowflake_cJSON_DeleteItemFromObject(child, string, cJSON_True);
+            child = child->next;
+        }
+    }
 }
 
 CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string)

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -2143,7 +2143,10 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *o
     return snowflake_cJSON_DetachItemViaPointer(object, to_detach);
 }
 
-//delete the key word, if recurse = true, it will delete any children contain the key word
+//Delete the keyword in json object, if recurse = true, it will delete any children json object contain the keyword.
+//For example, {"data1" : XXX, "data2" : XXX} and keyword = "data2", it will return {"data1" : XXX}.
+//When recurse = true, {"data1" : {"data2" : XXX, "data3" : XXX}} and key word = "data2", it will return
+// {"data1" : {"data3" : XXX}}
 CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string, cJSON_bool recurse)
 {
     snowflake_cJSON_Delete(snowflake_cJSON_DetachItemFromObject(object, string));

--- a/lib/cJSON.c
+++ b/lib/cJSON.c
@@ -1645,10 +1645,6 @@ static cJSON_bool print_object(const cJSON * const item, printbuffer * const out
 
     while (current_item)
     {
-        if(strcmp(current_item->string,"rowset") == 0){
-            current_item = current_item->next;
-            continue;
-        }
         if (output_buffer->format)
         {
             size_t i;

--- a/lib/cJSON.h
+++ b/lib/cJSON.h
@@ -233,7 +233,7 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromArray(cJSON *array, int whic
 CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromArray(cJSON *array, int which);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObject(cJSON *object, const char *string);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string);
-CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObject(cJSON *object, const char *string, cJSON_bool recurse);
 CJSON_PUBLIC(void) snowflake_cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string);
 
 /* Update array items. */

--- a/lib/client.c
+++ b/lib/client.c
@@ -1850,7 +1850,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
     }
     s_body = snowflake_cJSON_Print(body);
     log_debug("Created body");
-    log_trace("Here is constructed body:\n%s", s_body);
+    log_trace("Here is constructed body test:\n%s", s_body);
 
     char* queryURL = is_string_empty(sfstmt->connection->directURL) ?
                      QUERY_URL : sfstmt->connection->directURL;

--- a/lib/client.c
+++ b/lib/client.c
@@ -1850,7 +1850,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
     }
     s_body = snowflake_cJSON_Print(body);
     log_debug("Created body");
-    log_trace("Here is constructed body test:\n%s", s_body);
+    log_trace("Here is constructed body:\n%s", s_body);
 
     char* queryURL = is_string_empty(sfstmt->connection->directURL) ?
                      QUERY_URL : sfstmt->connection->directURL;

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -327,6 +327,8 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
         if (SF_BOOLEAN_TRUE) {
             json_error = json_copy_string_no_alloc(query_code, *json, "code",
                                                    QUERYCODE_LEN);
+            const char* del = "rowset";
+            snowflake_cJSON_DetachItemFromObject(*json,del);
             log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -329,10 +329,10 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             SF_JSON_ERROR_NONE &&
             json_error != SF_JSON_ERROR_ITEM_NULL) {
             //modify the new Json since we need to keep the original json information
-            cJSON *newJson = snowflake_cJSON_Duplicate(*json,cJSON_True);
+            cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
             const char* del = "rowset";
             //delete the sensitive information in case it leaks to customer
-            snowflake_cJSON_DeleteItemFromObject(newJson,del,cJSON_True);
+            snowflake_cJSON_DeleteItemFromObject(newJson, del, cJSON_True);
             log_error("Missing query code:\n %s", snowflake_cJSON_Print(newJson));
             //free the memory
             snowflake_cJSON_free(newJson);
@@ -407,10 +407,10 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
               SF_JSON_ERROR_NONE &&
               json_error != SF_JSON_ERROR_ITEM_NULL) {
                 //modify the new Json since we need to keep the original json information
-                cJSON *newJson = snowflake_cJSON_Duplicate(*json,cJSON_True);
+                cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
                 const char* del = "rowset";
                 //delete the sensitive information in case it leaks to customer
-                snowflake_cJSON_DeleteItemFromObject(newJson,del,cJSON_True);
+                snowflake_cJSON_DeleteItemFromObject(newJson, del, cJSON_True);
                 log_error("Query code missing: %s", snowflake_cJSON_Print(newJson));
                 //free the memory
                 snowflake_cJSON_free(newJson);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -465,6 +465,14 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
                                                     QUERYCODE_LEN)) !=
             SF_JSON_ERROR_NONE &&
             json_error != SF_JSON_ERROR_ITEM_NULL) {
+            //modify the new Json since we need to keep the original json information
+            cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
+            const char* del = "rowset";
+            //delete the sensitive information in case it leaks to customer
+            snowflake_cJSON_DeleteItemFromObject(newJson, del, cJSON_True);
+            log_error("Query code missing: %s", snowflake_cJSON_Print(newJson));
+            //free the memory
+            snowflake_cJSON_free(newJson);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -327,7 +327,7 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
         if (SF_BOOLEAN_TRUE) {
             json_error = json_copy_string_no_alloc(query_code, *json, "code",
                                                    QUERYCODE_LEN);
-            log_trace("Query code missing: %s", snowflake_cJSON_Print(*json));
+            log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -327,7 +327,7 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
         if (SF_BOOLEAN_TRUE) {
             json_error = json_copy_string_no_alloc(query_code, *json, "code",
                                                     QUERYCODE_LEN);
-            log_warn("Query code missing: %s", *json);
+            log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -328,7 +328,7 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             json_error = json_copy_string_no_alloc(query_code, *json, "code",
                                                    QUERYCODE_LEN);
             const char* del = "rowset";
-            snowflake_cJSON_DetachItemFromObject(*json,del);
+            snowflake_cJSON_DeleteItemFromObject(*json,del,cJSON_True);
             log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -327,9 +327,12 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
         if (SF_BOOLEAN_TRUE) {
             json_error = json_copy_string_no_alloc(query_code, *json, "code",
                                                    QUERYCODE_LEN);
+            cJSON *newJson = snowflake_cJSON_Duplicate(*json,cJSON_True);
             const char* del = "rowset";
-            snowflake_cJSON_DeleteItemFromObject(*json,del,cJSON_True);
+            snowflake_cJSON_DeleteItemFromObject(newJson,del,cJSON_True);
             log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
+            //free the memory
+            snowflake_cJSON_free(newJson);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -324,10 +324,10 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        if (SF_BOOLEAN_TRUE) {
-            json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                    QUERYCODE_LEN);
-            log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
+        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                    QUERYCODE_LEN)) !=
+            SF_JSON_ERROR_NONE &&
+            json_error != SF_JSON_ERROR_ITEM_NULL) {
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);
@@ -445,10 +445,10 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                    QUERYCODE_LEN)) !=
-            SF_JSON_ERROR_NONE &&
-            json_error != SF_JSON_ERROR_ITEM_NULL) {
+        if (SF_BOOLEAN_TRUE) {
+            json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                   QUERYCODE_LEN);
+            log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -330,7 +330,7 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             cJSON *newJson = snowflake_cJSON_Duplicate(*json,cJSON_True);
             const char* del = "rowset";
             snowflake_cJSON_DeleteItemFromObject(newJson,del,cJSON_True);
-            log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
+            log_error("Query code missing: %s", snowflake_cJSON_Print(newJson));
             //free the memory
             snowflake_cJSON_free(newJson);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -324,13 +324,16 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        if (SF_BOOLEAN_TRUE) {
-            json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                   QUERYCODE_LEN);
+        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                    QUERYCODE_LEN)) !=
+            SF_JSON_ERROR_NONE &&
+            json_error != SF_JSON_ERROR_ITEM_NULL) {
+            //modify the new Json since we need to keep the original json information
             cJSON *newJson = snowflake_cJSON_Duplicate(*json,cJSON_True);
             const char* del = "rowset";
+            //delete the sensitive information in case it leaks to customer
             snowflake_cJSON_DeleteItemFromObject(newJson,del,cJSON_True);
-            log_error("Query code missing: %s", snowflake_cJSON_Print(newJson));
+            log_error("Missing query code:\n %s", snowflake_cJSON_Print(newJson));
             //free the memory
             snowflake_cJSON_free(newJson);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
@@ -403,6 +406,14 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
                                                       QUERYCODE_LEN)) !=
               SF_JSON_ERROR_NONE &&
               json_error != SF_JSON_ERROR_ITEM_NULL) {
+                //modify the new Json since we need to keep the original json information
+                cJSON *newJson = snowflake_cJSON_Duplicate(*json,cJSON_True);
+                const char* del = "rowset";
+                //delete the sensitive information in case it leaks to customer
+                snowflake_cJSON_DeleteItemFromObject(newJson,del,cJSON_True);
+                log_error("Query code missing: %s", snowflake_cJSON_Print(newJson));
+                //free the memory
+                snowflake_cJSON_free(newJson);
                 stop = SF_BOOLEAN_TRUE;
                 JSON_ERROR_MSG(json_error, error_msg, "Query code");
                 SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -324,10 +324,10 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                    QUERYCODE_LEN)) !=
-            SF_JSON_ERROR_NONE &&
-            json_error != SF_JSON_ERROR_ITEM_NULL) {
+        if (SF_BOOLEAN_TRUE) {
+            json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                   QUERYCODE_LEN);
+            log_trace("Query code missing: %s", snowflake_cJSON_Print(*json));
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);
@@ -445,10 +445,10 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        if (SF_BOOLEAN_TRUE) {
-            json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                   QUERYCODE_LEN);
-            log_error("Query code missing: %s", snowflake_cJSON_Print(*json));
+        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                    QUERYCODE_LEN)) !=
+            SF_JSON_ERROR_NONE &&
+            json_error != SF_JSON_ERROR_ITEM_NULL) {
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -324,10 +324,10 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                    QUERYCODE_LEN)) !=
-            SF_JSON_ERROR_NONE &&
-            json_error != SF_JSON_ERROR_ITEM_NULL) {
+        if (SF_BOOLEAN_TRUE) {
+            json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                    QUERYCODE_LEN);
+            log_warn("Query code missing: %s", *json);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);


### PR DESCRIPTION
In rare occasions LibSfClient complains that the received response from GS does not contain query code (which is set null for success and the corresponding error code in case of failure). With this task we want to log response in such case