### PR TITLE
Update for FIPS support

### DIFF
--- a/ci/dev/CentOS-Base.repo
+++ b/ci/dev/CentOS-Base.repo
@@ -1,0 +1,24 @@
+# yum repo file for snowflake internal backup yum repo
+# Used as a temporary fix for ODBC docker before moving docker
+# maintenace to Engineer Infra Team
+
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://repo.int.snowflakecomputing.com:81/repos/base
+gpgcheck=1
+priority=10
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://repo.int.snowflakecomputing.com:81/repos/updates
+gpgcheck=1
+priority=10
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://repo.int.snowflakecomputing.com:81/repos/extras
+gpgcheck=1
+priority=10
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/ci/dev/Dockerfile
+++ b/ci/dev/Dockerfile
@@ -1,6 +1,20 @@
 ARG BASE_IMAGE_NAME
 FROM $BASE_IMAGE_NAME
 ARG LOCAL_USER_ID
+
+
+# replace outdated yum repo link with snowflake internal links
+COPY CentOS-Base.repo /etc/yum.repos.d/
+CMD chmod 644 /etc/yum.repos.d/CentOS-Base.repo
+RUN yum-config-manager --disable centos*
+RUN yum-config-manager --disable WANdisco-git
+RUN yum-config-manager --disable okay
+RUN yum-config-manager --disable base
+RUN yum-config-manager --disable updates
+RUN yum-config-manager --enable base
+RUN yum-config-manager --enable updates
+RUN yum-config-manager --enable extras
+
 # setup ssh server for debugging
 RUN yum install -y openssh-server
 

--- a/ci/scripts/login_internal_docker.sh
+++ b/ci/scripts/login_internal_docker.sh
@@ -4,7 +4,7 @@
 #
 if [[ -z "$GITHUB_ACTIONS" ]]; then
     echo "[INFO] Login the internal Docker Resistry"
-    NEXUS_USER=${USERNAME:-jenkins}
+    NEXUS_USER=${USERNAME:-${USER:-jenkins}}
     if [[ -z "$NEXUS_PASSWORD" ]]; then
         echo "[ERROR] Set NEXUS_PASSWORD to your LDAP password to access the internal repository!"
         exit 1

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -111,7 +111,7 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
   // FIPS mode check
   if (!(m_stageInfo->endPoint.empty())) {
     // FIPS mode is enabled, use the endpoint provided by GS directly
-    clientConfiguration.endPointOverride = Aws::String(stageInfo->endPoint);
+    clientConfiguration.endpointOverride = Aws::String(stageInfo->endPoint);
   } else if (transferConfig != nullptr && transferConfig->useS3regionalUrl) {
     clientConfiguration.endpointOverride = Aws::String("s3.")
         + Aws::String(clientConfiguration.region)

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -107,8 +107,12 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
   clientConfiguration.caFile = caFile;
   clientConfiguration.requestTimeoutMs = 40000;
   clientConfiguration.connectTimeoutMs = 30000;
-  if(transferConfig != nullptr && transferConfig->useS3regionalUrl)
-  {
+
+  // FIPS mode check
+  if (stageInfo->endPoint != nullptr) {
+    // FIPS mode is enabled, use the endpoint provided by GS directly
+    clientConfiguration.endPointOverride = Aws::String(stageInfo->endPoint);
+  } else if (transferConfig != nullptr && transferConfig->useS3regionalUrl) {
     clientConfiguration.endpointOverride = Aws::String("s3.")
         + Aws::String(clientConfiguration.region)
         + Aws::String(".amazonaws.com");

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -599,7 +599,7 @@ void SnowflakeS3Client::setMaxRetries(unsigned int maxRetries)
   m_maxRetries = maxRetries;
 }
 
-char * SnowflakeS3Client::GetClientConfigStageEndpoint()
+const char * SnowflakeS3Client::GetClientConfigStageEndpoint()
 {
   return clientConfiguration.endpointOverride.c_str();
 }

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -109,7 +109,7 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
   clientConfiguration.connectTimeoutMs = 30000;
 
   // FIPS mode check
-  if (stageInfo->endPoint != nullptr) {
+  if (!(m_stageInfo->endPoint.empty())) {
     // FIPS mode is enabled, use the endpoint provided by GS directly
     clientConfiguration.endPointOverride = Aws::String(stageInfo->endPoint);
   } else if (transferConfig != nullptr && transferConfig->useS3regionalUrl) {

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -599,5 +599,10 @@ void SnowflakeS3Client::setMaxRetries(unsigned int maxRetries)
   m_maxRetries = maxRetries;
 }
 
+char * SnowflakeS3Client::GetClientConfigStageEndpoint()
+{
+  return clientConfiguration.endpointOverride.c_str();
+}
+
 }
 }

--- a/cpp/SnowflakeS3Client.hpp
+++ b/cpp/SnowflakeS3Client.hpp
@@ -116,6 +116,12 @@ public:
   RemoteStorageRequestOutcome GetRemoteFileMetadata(
     std::string * filePathFull, FileMetadata *fileMetadata);
 
+  /*
+   * This is added only to assist in unit tests.
+   * SNOW-373871
+   */
+  const char *GetClientConfigStageEndpoint();
+
 private:
   Aws::SDKOptions options;
 

--- a/cpp/StatementPutGet.cpp
+++ b/cpp/StatementPutGet.cpp
@@ -74,6 +74,8 @@ bool StatementPutGet::parsePutGetCommand(std::string *sql,
   {
     putGetParseResponse->stageInfo.stageType = StageType::S3;
     putGetParseResponse->stageInfo.region = response->stage_info->region;
+    // FIPS Support
+    putGetParseResponse->stageInfo.endPoint = response->stage_info->endPoint;
     putGetParseResponse->stageInfo.credentials = {
             {"AWS_KEY_ID",     response->stage_info->stage_cred->aws_key_id},
             {"AWS_SECRET_KEY", response->stage_info->stage_cred->aws_secret_key},

--- a/cpp/StatementPutGet.cpp
+++ b/cpp/StatementPutGet.cpp
@@ -75,7 +75,9 @@ bool StatementPutGet::parsePutGetCommand(std::string *sql,
     putGetParseResponse->stageInfo.stageType = StageType::S3;
     putGetParseResponse->stageInfo.region = response->stage_info->region;
     // FIPS Support
-    putGetParseResponse->stageInfo.endPoint = response->stage_info->endPoint;
+    if (response->stage_info->endPoint != NULL) {
+      putGetParseResponse->stageInfo.endPoint = response->stage_info->endPoint;
+    }
     putGetParseResponse->stageInfo.credentials = {
             {"AWS_KEY_ID",     response->stage_info->stage_cred->aws_key_id},
             {"AWS_SECRET_KEY", response->stage_info->stage_cred->aws_secret_key},

--- a/include/snowflake/PutGetParseResponse.hpp
+++ b/include/snowflake/PutGetParseResponse.hpp
@@ -59,7 +59,7 @@ struct StageInfo
 
   std::string storageAccount; //Required by Azure
 
-  std::string endPoint;       //Required by Azure
+  std::string endPoint;       //Required by Azure & for S3 FIPS
 
   std::string presignedUrl;   //Required by GCS for uploading
 

--- a/lib/client.c
+++ b/lib/client.c
@@ -1285,6 +1285,8 @@ sf_put_get_response_deallocate(SF_PUT_GET_RESPONSE *put_get_response) {
     SF_FREE(put_get_response->stage_info->location);
     SF_FREE(put_get_response->stage_info->path);
     SF_FREE(put_get_response->stage_info->region);
+    SF_FREE(put_get_response->stage_info->endPoint);
+    SF_FREE(put_get_response->stage_info->storageAccount);
     SF_FREE(put_get_response->stage_info);
     SF_FREE(put_get_response->enc_mat_put->query_stage_master_key);
     SF_FREE(put_get_response->enc_mat_put);

--- a/lib/client.c
+++ b/lib/client.c
@@ -1285,8 +1285,6 @@ sf_put_get_response_deallocate(SF_PUT_GET_RESPONSE *put_get_response) {
     SF_FREE(put_get_response->stage_info->location);
     SF_FREE(put_get_response->stage_info->path);
     SF_FREE(put_get_response->stage_info->region);
-    SF_FREE(put_get_response->stage_info->endPoint);
-    SF_FREE(put_get_response->stage_info->storageAccount);
     SF_FREE(put_get_response->stage_info);
     SF_FREE(put_get_response->enc_mat_put->query_stage_master_key);
     SF_FREE(put_get_response->enc_mat_put);

--- a/lib/client_int.h
+++ b/lib/client_int.h
@@ -76,7 +76,7 @@ typedef struct SF_STAGE_INFO {
   char *path;
   char *region;
   char *storageAccount; // For Azure only
-  char *endPoint; //For FIPS support
+  char *endPoint; //For FIPS and Azure support
   SF_STAGE_CRED * stage_cred;
 } SF_STAGE_INFO;
 

--- a/lib/client_int.h
+++ b/lib/client_int.h
@@ -76,7 +76,7 @@ typedef struct SF_STAGE_INFO {
   char *path;
   char *region;
   char *storageAccount; // For Azure only
-  char *endPoint; //For Azure only.
+  char *endPoint; //For FIPS support
   SF_STAGE_CRED * stage_cred;
 } SF_STAGE_INFO;
 

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -674,7 +674,6 @@ json_copy_string(char **dest, cJSON *data, const char *item) {
         // make sure that the value is set to NULL to enable
         // NULL checks.
         SF_FREE(*dest);
-        *dest = NULL;
         return SF_JSON_ERROR_ITEM_MISSING;
     } else if (snowflake_cJSON_IsNull(blob)) {
         SF_FREE(*dest);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -670,10 +670,19 @@ json_copy_string(char **dest, cJSON *data, const char *item) {
     size_t blob_size;
     cJSON *blob = snowflake_cJSON_GetObjectItem(data, item);
     if (!blob) {
+        // We don't check the return status everywhere
+        // make sure that the value is set to NULL to enable
+        // NULL checks.
+        SF_FREE(*dest);
+        *dest = NULL;
         return SF_JSON_ERROR_ITEM_MISSING;
     } else if (snowflake_cJSON_IsNull(blob)) {
+        SF_FREE(*dest);
+        *dest = NULL;
         return SF_JSON_ERROR_ITEM_NULL;
     } else if (!snowflake_cJSON_IsString(blob)) {
+        SF_FREE(*dest);
+        *dest = NULL;
         return SF_JSON_ERROR_ITEM_WRONG_TYPE;
     } else {
         blob_size = strlen(blob->valuestring) + 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(TESTS_CXX
         test_unit_stream_splitter
         test_unit_put_retry
         test_unit_put_fast_fail
+        test_unit_put_get_fips
         test_unit_thread_pool
         test_unit_base64
         #test_cpp_select1

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -26,10 +26,10 @@ using namespace ::Snowflake::Client;
 class MockedPutGetAgent : public Snowflake::Client::FileTransferAgent
 {
 public:
-    MockedTransferAgent(IStatementPutGet *statement)
+    MockedPutGetAgent(IStatementPutGet *statement)
       : m_stmtPutGet(statement) {}
 
-    virtual const char * getStageEndpoint(string *command)
+    virtual const char * getStageEndpoint(std::string *command)
     {
       assert_true(m_stmtPutGet->parsePutGetCommand(&response));
       m_storageClient = StorageClientFactory::getClient(&response.stageInfo,

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -103,7 +103,7 @@ void test_simple_put_stage_endpoint_core(std::string fileName,
 
   const char *cfg_stageEndpoint = agent.getStageEndpoint();
 
-  assert_string_equal(stageEndpoint, std::string(cfg_stageEndpoint));
+  assert_string_equal(stageEndpoint.c_str(), cfg_stageEndpoint);
 }
 
 void test_simple_put_stage_endpoint(void ** unused)

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -80,6 +80,13 @@ public:
   {
     m_stageInfo.stageType = StageType::S3;
     m_stageInfo.endPoint = stageEndpoint;
+    char aws_token[] = "AWS_TOKEN";
+    char aws_key_id[] = "AWS_KEY_ID";
+    char aws_secret_key[] = "AWS_SECRET_KEY";
+    m_stageInfo.credentials.insert( {{"AWS_TOKEN", aws_token},
+                                     {"AWS_KEY_ID", aws_key_id},
+                                     {"AWS_SECRET_KEY", aws_secret_key}});
+
     std::string dataDir = TestSetup::getDataDir();
     m_srcLocations.push_back(dataDir + fileName);
     m_encryptionMaterial.emplace_back(
@@ -137,8 +144,9 @@ void test_simple_put_stage_endpoint_no_regional(std::string fileName,
                                                 std::string stageEndpoint)
 {
   TransferConfig transferConfig;
+  char cafile[] = "/tmp/cafile";
   transferConfig.useS3regionalUrl = false;
-  transferConfig.caBundleFile = nullptr;
+  transferConfig.caBundleFile = cafile;
   test_simple_put_stage_endpoint_core(fileName,
                                       stageEndpoint,
                                       &transferConfig);

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -161,7 +161,7 @@ void test_simple_put_stage_endpoint(void ** unused)
                                              "abc.testendpoint.us-east-1.snowflakecomputing.com");
 
   //test_simple_put_stage_endpoint_with_regional("small_file.csv.gz",
-                                               "abc.testendpoint.us-east-1.snowflakecomputing.com");
+  //                                             "abc.testendpoint.us-east-1.snowflakecomputing.com");
 }
 
 

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -46,7 +46,7 @@ public:
       // we can assume that the dynamic cast will work. If this test were to be made
       // generic such we don't know what the underlying object type is this piece of
       // code might cause a null pointer dereference.
-      return (dynamic_cast<SnowflakeS3Client *>m_storageClient)->GetClientConfigStageEndpoint();
+      return (dynamic_cast<SnowflakeS3Client *>(m_storageClient))->GetClientConfigStageEndpoint();
     }
 
     // Not used implemented to prevent abstract class

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -42,7 +42,24 @@ public:
                                                         response.threshold,
                                                         m_transferConfig,
                                                         m_stmtPutGet);
-      return ((SnowflakeS3Client)m_storageClient)->GetClientConfigStageEndpoint();
+      // Since we know that the object is originally pointing to SnowflakeS3Client
+      // we can assume that the dynamic cast will work. If this test were to be made
+      // generic such we don't know what the underlying object type is this piece of
+      // code might cause a null pointer dereference.
+      return (dynamic_cast<SnowflakeS3Client *>m_storageClient)->GetClientConfigStageEndpoint();
+    }
+
+    // Not used implemented to prevent abstract class
+    virtual ITransferResult *execute(std::string *command)
+    {
+      return nullptr;
+    }
+
+    // Not used implemented to prevent abstract class
+    virtual void setUploadStream(std::basic_iostream<char> * uploadStream,
+                                 size_t dataSize)
+    {
+      return;
     }
 private:
     IStatementPutGet *m_stmtPutGet;
@@ -134,7 +151,7 @@ void test_simple_put_stage_endpoint_with_regional(std::string fileName,
   transferConfig.caBundleFile = nullptr;
   test_simple_put_stage_endpoint_core(fileName,
                                       stageEndpoint,
-                                      &transConfig);
+                                      &transferConfig);
 }
 
 void test_simple_put_stage_endpoint(void ** unused)

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2019-2020 Snowflake Computing, Inc. All rights reserved.
+ */
+
+/**
+ * Testing Put retry
+ *
+ * Note: s3 client in this class is mocked
+ */
+
+#include "snowflake/IStatementPutGet.hpp"
+#include "snowflake/PutGetParseResponse.hpp"
+#include <fstream>
+#include <memory>
+#include <cstdio>
+#include <snowflake/SnowflakeTransferException.hpp>
+#include "util/Base64.hpp"
+#include "FileTransferExecutionResult.hpp"
+#include "FileTransferAgent.hpp"
+#include "StorageClientFactory.hpp"
+#include "utils/test_setup.h"
+#include "utils/TestSetup.hpp"
+
+using namespace ::Snowflake::Client;
+
+class MockedPutGetAgent : public Snowflake::Client::FileTransferAgent
+{
+public:
+    MockedTransferAgent(IStatementPutGet *statement)
+      : m_stmtPutGet(statement) {}
+
+    virtual const char * getStageEndpoint(string *command)
+    {
+      assert_true(m_stmtPutGet->parsePutGetCommand(&response));
+      m_storageClient = StorageClientFactory::getClient(&response.stageInfo,
+                                                        (unsigned int) response.parallel,
+                                                        response.threshold,
+                                                        m_transferConfig,
+                                                        m_stmtPutGet);
+      return ((Snowflake::Client::SnowflakeS3Client)m_storageClient)->GetClientConfigStageEndpoint();
+    }
+private:
+    IStatementPutGet *m_stmtPutGet;
+
+    IStorageClient *m_storageClient;
+
+    PutGetParseResponse response;
+};
+
+class MockedStatementPut : public Snowflake::Client::IStatementPutGet
+{
+public:
+  MockedStatementPut(std::string fileName,
+                     std::string stageEndpoint)
+    : IStatementPutGet()
+  {
+    m_stageInfo.stageType = StageType::S3;
+    m_stageInfo.endPoint = stageEndpoint;
+    std::string dataDir = TestSetup::getDataDir();
+    m_srcLocations.push_back(dataDir + fileName);
+    m_encryptionMaterial.emplace_back(
+      (char *)"3dOoaBhkB1wSw4hyfA5DJw==\0",
+      (char *)"1234\0",
+      1234);
+  }
+
+  virtual bool parsePutGetCommand(PutGetParseResponse *putGetParseResponse)
+  {
+    putGetParseResponse->stageInfo = m_stageInfo;
+    putGetParseResponse->command = CommandType::UPLOAD;
+    putGetParseResponse->sourceCompression = (char *)"NONE";
+    putGetParseResponse->srcLocations = m_srcLocations;
+    putGetParseResponse->threshold = DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD;
+    putGetParseResponse->autoCompress = false;
+    putGetParseResponse->parallel = 4;
+    putGetParseResponse->encryptionMaterials = m_encryptionMaterial;
+
+    return true;
+  }
+
+private:
+  StageInfo m_stageInfo;
+
+  std::vector<EncryptionMaterial> m_encryptionMaterial;
+
+  std::vector<std::string> m_srcLocations;
+
+};
+
+/**
+ * Simple put test case 
+ * @param fileName
+ */
+void test_simple_put_stage_endpoint_core(std::string fileName,
+                                std::string stageEndpoint)
+{
+  std::string cmd = std::string("put file://") + fileName + std::string("@odbctestStage AUTO_COMPRESS=false OVERWRITE=true");
+
+  MockedStatementPut mockedStatementPut(fileName,
+                                        stageEndpoint);
+
+  MockedPutGetAgent agent(&mockedStatementPut);
+
+  const char *cfg_stageEndpoint = agent.getStageEndpoint();
+
+  assert_string_equal(stageEndpoint, std::string(cfg_stageEndpoint));
+}
+
+void test_simple_put_stage_endpoint(void ** unused)
+{
+  test_simple_put_stage_endpoint_core("small_file.csv.gz",
+                                      "abc.testendpoint.us-east-1.snowflakecomputing.com");
+}
+
+
+static int gr_setup(void **unused)
+{
+  initialize_test(SF_BOOLEAN_FALSE);
+  return 0;
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_simple_put_stage_endpoint),
+  };
+  int ret = cmocka_run_group_tests(tests, gr_setup, NULL);
+  return ret;
+}
+

--- a/tests/test_unit_put_get_fips.cpp
+++ b/tests/test_unit_put_get_fips.cpp
@@ -129,6 +129,7 @@ void test_simple_put_stage_endpoint_core(std::string fileName,
 
   const char *cfg_stageEndpoint = agent.getStageEndpoint(&cmd);
 
+  assert_non_null(cfg_stageEndpoint);
   assert_string_equal(stageEndpoint.c_str(), cfg_stageEndpoint);
 }
 
@@ -159,7 +160,7 @@ void test_simple_put_stage_endpoint(void ** unused)
   test_simple_put_stage_endpoint_no_regional("small_file.csv.gz",
                                              "abc.testendpoint.us-east-1.snowflakecomputing.com");
 
-  test_simple_put_stage_endpoint_with_regional("small_file.csv.gz",
+  //test_simple_put_stage_endpoint_with_regional("small_file.csv.gz",
                                                "abc.testendpoint.us-east-1.snowflakecomputing.com");
 }
 


### PR DESCRIPTION
This change only affects PUT / GET functionality in Libsnowflakeclient and ODBC Driver. 

Till now the driver could only support default stage URLs or region based stage URLs. However while using Gov Cloud, there are certain security requirements that only few deployments and stages can adhere to at the moment. These stages / deployments are FIPS enabled. To ensure that the driver only connects to stages that are FIPS enabled, the GS would send to the driver exact URL that it needs to connect to. 

This fix updates the driver to accept the new information and use that instead of the default S3 URL. 