### PR TITLE
Check result status before calling ValueOrDie()

### DIFF
--- a/cpp/lib/ArrowChunkIterator.cpp
+++ b/cpp/lib/ArrowChunkIterator.cpp
@@ -42,6 +42,7 @@ ArrowChunkIterator::ArrowChunkIterator(arrow::BufferBuilder * chunk,
     while (true)
     {
         std::shared_ptr<arrow::RecordBatch> batch;
+        if (!batchReader.ok()) break;
         (void) batchReader.ValueOrDie()->ReadNext(&batch);
         if (batch == nullptr)
             break;
@@ -71,7 +72,7 @@ bool ArrowChunkIterator::next()
     m_currRowIndexInBatch++;
 
     //If its the first row in the batch then initialize the new set of columns.
-    if (m_columns.size() == 0)
+    if ((m_columns.size() == 0) && (m_batchCount > 0))
         this->initColumnChunks();
 
     if (m_currRowIndexInBatch < m_rowCountInBatch)


### PR DESCRIPTION
reflection from ODBC PR287 https://github.com/snowflakedb/snowflake-odbc/pull/287
Check result status before calling ValueOrDie() to avoid crash.
The comment in arrow's header file for ValueOrDie():
This method should only be called if this Result object's status is OK
(i.e. a call to ok() returns true), otherwise this call will abort.