### PR TITLE
Simplify the log in response json

### DIFF
--- a/lib/chunk_downloader.c
+++ b/lib/chunk_downloader.c
@@ -206,7 +206,7 @@ sf_bool STDCALL download_chunk(char *url, SF_HEADER *headers, cJSON **chunk, SF_
     CURL *curl = NULL;
     curl = curl_easy_init();
 
-    if (!curl || !http_perform(curl, GET_REQUEST_TYPE, url, headers, NULL, chunk, DEFAULT_SNOWFLAKE_REQUEST_TIMEOUT, SF_BOOLEAN_TRUE, error, insecure_mode, 0)) {
+    if (!curl || !http_perform(curl, GET_REQUEST_TYPE, url, headers, NULL, chunk, DEFAULT_SNOWFLAKE_REQUEST_TIMEOUT, SF_BOOLEAN_TRUE, error, insecure_mode, 0, SF_BOOLEAN_FALSE)) {
         // Error set in perform function
         goto cleanup;
     }

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -330,7 +330,7 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
         if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
                                                     QUERYCODE_LEN)) !=
             SF_JSON_ERROR_NONE &&
-            json_error != SF_JSON_ERROR_ITEM_NULL)  {
+            json_error != SF_JSON_ERROR_ITEM_NULL) {
             //Log the useful response information
             create_json_resp_log(json);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -327,10 +327,10 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        sf_bool flag = SF_BOOLEAN_TRUE;
-        if (flag) {
-            json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                   QUERYCODE_LEN);
+        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                    QUERYCODE_LEN)) !=
+            SF_JSON_ERROR_NONE &&
+            json_error != SF_JSON_ERROR_ITEM_NULL)  {
             //modify the new Json since we need to keep the original json information
             //cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
             //const char* del = "rowset";

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -1140,5 +1140,4 @@ void STDCALL create_json_resp_log(cJSON **json){
     log_error("Missing query code:\n %s", snowflake_cJSON_Print(newJson));
     //free the memory
     snowflake_cJSON_free(newJson);
-    free(dels);
 }

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -332,13 +332,13 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             json_error = json_copy_string_no_alloc(query_code, *json, "code",
                                                    QUERYCODE_LEN);
             //modify the new Json since we need to keep the original json information
-            cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
-            const char* del = "rowset";
+            //cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
+            //const char* del = "rowset";
             //delete the sensitive information in case it leaks to customer
-            snowflake_cJSON_DeleteItemFromObject(newJson, del, cJSON_True);
-            log_error("Missing query code:\n %s", snowflake_cJSON_Print(newJson));
+            //snowflake_cJSON_DeleteItemFromObject(newJson, del, cJSON_True);
+            log_error("Missing query code:\n %s", snowflake_cJSON_Print(*json));
             //free the memory
-            snowflake_cJSON_free(newJson);
+            //snowflake_cJSON_free(newJson);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -341,9 +341,9 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
                 snowflake_cJSON_DeleteItemFromObject(newJson, dels[i], cJSON_True);
                 i++;
             }
-            log_error("Missing query code:\n %s", snowflake_cJSON_Print(*json));
+            log_error("Missing query code:\n %s", snowflake_cJSON_Print(newJson));
             //free the memory
-            //snowflake_cJSON_free(newJson);
+            snowflake_cJSON_free(newJson);
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_STATUS_ERROR_BAD_JSON, error_msg,
                                 SF_SQLSTATE_UNABLE_TO_CONNECT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -327,10 +327,10 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             // Error is set in the perform function
             break;
         }
-        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code",
-                                                    QUERYCODE_LEN)) !=
-            SF_JSON_ERROR_NONE &&
-            json_error != SF_JSON_ERROR_ITEM_NULL) {
+        sf_bool flag = SF_BOOLEAN_TRUE;
+        if (flag) {
+            json_error = json_copy_string_no_alloc(query_code, *json, "code",
+                                                   QUERYCODE_LEN);
             //modify the new Json since we need to keep the original json information
             cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
             const char* del = "rowset";

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -322,7 +322,8 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
         if (!http_perform(curl, POST_REQUEST_TYPE, url, header, body, json,
                           sf->network_timeout, SF_BOOLEAN_FALSE, error,
                           sf->insecure_mode,
-                          sf->retry_on_curle_couldnt_connect_count) ||
+                          sf->retry_on_curle_couldnt_connect_count,
+                          sf->log_query_exec_steps_info) ||
             !*json) {
             // Error is set in the perform function
             break;
@@ -469,7 +470,8 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
         if (!http_perform(curl, GET_REQUEST_TYPE, url, header, NULL, json,
                           sf->network_timeout, SF_BOOLEAN_FALSE, error,
                           sf->insecure_mode,
-                          sf->retry_on_curle_couldnt_connect_count) ||
+                          sf->retry_on_curle_couldnt_connect_count,
+                          sf->log_debug_mod) ||
             !*json) {
             // Error is set in the perform function
             break;

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -332,10 +332,15 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
             SF_JSON_ERROR_NONE &&
             json_error != SF_JSON_ERROR_ITEM_NULL)  {
             //modify the new Json since we need to keep the original json information
-            //cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
-            //const char* del = "rowset";
-            //delete the sensitive information in case it leaks to customer
-            //snowflake_cJSON_DeleteItemFromObject(newJson, del, cJSON_True);
+            cJSON *newJson = snowflake_cJSON_Duplicate(*json, cJSON_True);
+            //delete the sensitive and useless information in case it leaks to customer
+            const char* dels[] = {"parameters", "rowtype", "rowset", 0};
+
+            int i = 0;
+            while (dels[i] != (void *)0){
+                snowflake_cJSON_DeleteItemFromObject(newJson, dels[i], cJSON_True);
+                i++;
+            }
             log_error("Missing query code:\n %s", snowflake_cJSON_Print(*json));
             //free the memory
             //snowflake_cJSON_free(newJson);

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -371,7 +371,7 @@ size_t json_resp_cb(char *data, size_t size, size_t nmemb, RAW_JSON_BUFFER *raw_
 sf_bool STDCALL http_perform(CURL *curl, SF_REQUEST_TYPE request_type, char *url, SF_HEADER *header,
                              char *body, cJSON **json, int64 network_timeout, sf_bool chunk_downloader,
                              SF_ERROR_STRUCT *error, sf_bool insecure_mode,
-                             int8 retry_on_curle_couldnt_connect_count);
+                             int8 retry_on_curle_couldnt_connect_count, sf_bool log_query_exec_steps_info);
 
 /**
  * Returns true if HTTP code is retryable, false otherwise.

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -458,7 +458,7 @@ SF_HEADER* STDCALL sf_header_create();
 
 void STDCALL sf_header_destroy(SF_HEADER *sf_header);
 
-void STDCALL create_json_resp_log(cJSON **json);
+cJSON *STDCALL create_json_resp_log(cJSON **json);
 
 #ifdef __cplusplus
 }

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -458,6 +458,8 @@ SF_HEADER* STDCALL sf_header_create();
 
 void STDCALL sf_header_destroy(SF_HEADER *sf_header);
 
+void STDCALL create_json_resp_log(cJSON **json);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -150,7 +150,8 @@ sf_bool STDCALL http_perform(CURL *curl,
                              sf_bool chunk_downloader,
                              SF_ERROR_STRUCT *error,
                              sf_bool insecure_mode,
-                             int8 retry_on_curle_couldnt_connect_count) {
+                             int8 retry_on_curle_couldnt_connect_count,
+                             sf_bool log_query_exec_steps_info) {
     CURLcode res;
     sf_bool ret = SF_BOOLEAN_FALSE;
     sf_bool retry = SF_BOOLEAN_FALSE;
@@ -397,7 +398,7 @@ sf_bool STDCALL http_perform(CURL *curl,
     // We were successful so parse JSON from text
     if (ret) {
         //Check if the "code" attribute exist in the response texts
-        if(!strstr(buffer.buffer, "\"code\"")){
+        if(log_query_exec_steps_info && !strstr(buffer.buffer, "\"code\"")){
             log_error("code does not exist in the original text");
         }
         if (chunk_downloader) {

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -408,8 +408,6 @@ sf_bool STDCALL http_perform(CURL *curl,
         *json = NULL;
         log_error("buffer information:\n %s", buffer.buffer);
         *json = snowflake_cJSON_Parse(buffer.buffer);
-        log_error("raw json:\n %s",*json);
-        log_error("parse information:\n %s",snowflake_cJSON_Print(*json));
         if (*json) {
             ret = SF_BOOLEAN_TRUE;
         } else {

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -242,6 +242,7 @@ sf_bool STDCALL http_perform(CURL *curl,
             log_error("Failed to set writer [%s]", curl_easy_strerror(res));
             break;
         }
+
         
         res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *) &buffer);
         if (res != CURLE_OK) {

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -242,9 +242,7 @@ sf_bool STDCALL http_perform(CURL *curl,
             log_error("Failed to set writer [%s]", curl_easy_strerror(res));
             break;
         }
-        log_error("buffer before %s\n",buffer.buffer);
         res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *) &buffer);
-        log_error("buffer after %s\n",buffer.buffer);
         if (res != CURLE_OK) {
             log_error("Failed to set write data [%s]", curl_easy_strerror(res));
             break;
@@ -397,6 +395,10 @@ sf_bool STDCALL http_perform(CURL *curl,
 
     // We were successful so parse JSON from text
     if (ret) {
+        //Check if the "code" attribute exist in the response texts
+        if(!strstr(buffer.buffer, "code")){
+            log_error("code does not exist in the original text");
+        }
         if (chunk_downloader) {
             buffer.buffer = (char *) SF_REALLOC(buffer.buffer, buffer.size +
                                                                2); // 1 byte for closing bracket, 1 for null terminator
@@ -407,9 +409,6 @@ sf_bool STDCALL http_perform(CURL *curl,
         }
         snowflake_cJSON_Delete(*json);
         *json = NULL;
-        if(!strstr(buffer.buffer, "code")){
-            log_error("buffer information:\n %s", buffer.buffer);
-        }
         *json = snowflake_cJSON_Parse(buffer.buffer);
         if (*json) {
             ret = SF_BOOLEAN_TRUE;

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -406,6 +406,7 @@ sf_bool STDCALL http_perform(CURL *curl,
         }
         snowflake_cJSON_Delete(*json);
         *json = NULL;
+        log_error("buffer information", buffer.buffer);
         *json = snowflake_cJSON_Parse(buffer.buffer);
         if (*json) {
             ret = SF_BOOLEAN_TRUE;

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -243,6 +243,7 @@ sf_bool STDCALL http_perform(CURL *curl,
             break;
         }
         res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *) &buffer);
+
         if (res != CURLE_OK) {
             log_error("Failed to set write data [%s]", curl_easy_strerror(res));
             break;
@@ -396,8 +397,8 @@ sf_bool STDCALL http_perform(CURL *curl,
     // We were successful so parse JSON from text
     if (ret) {
         //Check if the "code" attribute exist in the response texts
-        if(!strstr(buffer.buffer, "code")){
-            log_error("code does not exist in the original text");
+        if(strstr(buffer.buffer, "\"code\"")){
+            log_error("code does not exist in the original text\n%s",buffer.buffer);
         }
         if (chunk_downloader) {
             buffer.buffer = (char *) SF_REALLOC(buffer.buffer, buffer.size +

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -242,7 +242,7 @@ sf_bool STDCALL http_perform(CURL *curl,
             log_error("Failed to set writer [%s]", curl_easy_strerror(res));
             break;
         }
-        
+
         res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *) &buffer);
         if (res != CURLE_OK) {
             log_error("Failed to set write data [%s]", curl_easy_strerror(res));

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -242,7 +242,6 @@ sf_bool STDCALL http_perform(CURL *curl,
             log_error("Failed to set writer [%s]", curl_easy_strerror(res));
             break;
         }
-
         
         res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *) &buffer);
         if (res != CURLE_OK) {

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -242,8 +242,8 @@ sf_bool STDCALL http_perform(CURL *curl,
             log_error("Failed to set writer [%s]", curl_easy_strerror(res));
             break;
         }
+        
         res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *) &buffer);
-
         if (res != CURLE_OK) {
             log_error("Failed to set write data [%s]", curl_easy_strerror(res));
             break;
@@ -397,8 +397,8 @@ sf_bool STDCALL http_perform(CURL *curl,
     // We were successful so parse JSON from text
     if (ret) {
         //Check if the "code" attribute exist in the response texts
-        if(strstr(buffer.buffer, "\"code\"")){
-            log_error("code does not exist in the original text\n%s",buffer.buffer);
+        if(!strstr(buffer.buffer, "\"code\"")){
+            log_error("code does not exist in the original text");
         }
         if (chunk_downloader) {
             buffer.buffer = (char *) SF_REALLOC(buffer.buffer, buffer.size +

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -406,8 +406,10 @@ sf_bool STDCALL http_perform(CURL *curl,
         }
         snowflake_cJSON_Delete(*json);
         *json = NULL;
-        log_error("buffer information", buffer.buffer);
+        log_error("buffer information:\n %s", buffer.buffer);
         *json = snowflake_cJSON_Parse(buffer.buffer);
+        log_error("raw json:\n %s",*json);
+        log_error("parse information:\n %s",snowflake_cJSON_Print(*json));
         if (*json) {
             ret = SF_BOOLEAN_TRUE;
         } else {

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -242,8 +242,9 @@ sf_bool STDCALL http_perform(CURL *curl,
             log_error("Failed to set writer [%s]", curl_easy_strerror(res));
             break;
         }
-
+        log_error("buffer before %s\n",buffer.buffer);
         res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *) &buffer);
+        log_error("buffer after %s\n",buffer.buffer);
         if (res != CURLE_OK) {
             log_error("Failed to set write data [%s]", curl_easy_strerror(res));
             break;
@@ -406,7 +407,9 @@ sf_bool STDCALL http_perform(CURL *curl,
         }
         snowflake_cJSON_Delete(*json);
         *json = NULL;
-        log_error("buffer information:\n %s", buffer.buffer);
+        if(!strstr(buffer.buffer, "code")){
+            log_error("buffer information:\n %s", buffer.buffer);
+        }
         *json = snowflake_cJSON_Parse(buffer.buffer);
         if (*json) {
             ret = SF_BOOLEAN_TRUE;

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -103,16 +103,17 @@ void log_log(int level, const char *file, int line, const char *ns,
       // va_list can only be consumed once. Make a copy so we can use it again
       va_list copy;
       va_copy(copy, args);
-
+      size_t linedFmt_length = strlen(fmt) +
+                                  NO_OF_CHARS_FOR_LOG_LINE /*max num of digits for line*/ +
+                                  3;
       // Add the line (since logLineVA doesn't take line)
-      char linedFmt[strlen(fmt) +
-                    NO_OF_CHARS_FOR_LOG_LINE /*max num of digits for line*/ +
-                    3];
+      char* linedFmt = malloc(linedFmt_length);
       sprintf(linedFmt, "%d: %s", line, fmt);
 
       externalLogger_logLineVA((SF_LOG_LEVEL) level,
                                sf_filename_from_path(file), linedFmt, copy);
       va_end(copy);
+      free(linedFmt);
     }
 
     log_log_va_list(level, file, line, ns, fmt, args);

--- a/lib/mock_http_perform.h
+++ b/lib/mock_http_perform.h
@@ -18,7 +18,8 @@ extern "C" {
 // This is just the mock interface
 sf_bool STDCALL __wrap_http_perform(CURL *curl, SF_REQUEST_TYPE request_type, char *url, SF_HEADER *header,
                                     char *body, cJSON **json, int64 network_timeout, sf_bool chunk_downloader,
-                                    SF_ERROR_STRUCT *error, sf_bool insecure_mode);
+                                    SF_ERROR_STRUCT *error, sf_bool insecure_mode, int8 retry_on_curle_couldnt_connect_count,
+                                    sf_bool log_query_exec_steps_info);
 
 #endif
 


### PR DESCRIPTION
Issue: Snowhouse has the limitation of the log message size. Therefore, we need to keep the useful information and delete inessential attributes in response json. 
On the other hand, I just check the original text if it exist the "code" attribute to triage the "miss code" issue happened in libsfclient or GS side.

Add a parameter to avoid string search for each query, I plan to continue using the previous parameter because the issue still happened in query execution step( which the parameter name is make sense). Also since we are roll out the port libsfclient to XP, I do not want to add too much temporary parameter. cc @sfc-gh-kwang Do you think we need to make the same change in your branch(XP part of libsfclient).