### PR TITLE
Adjust the log in libsfclient

### DIFF
--- a/lib/connection.c
+++ b/lib/connection.c
@@ -315,8 +315,6 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
     // Set to 0
     memset(query_code, 0, QUERYCODE_LEN);
 
-    //Debug tool, check if we into infinite loop
-    int counter = 0;
 
     do {
         if (!http_perform(curl, POST_REQUEST_TYPE, url, header, body, json,
@@ -438,13 +436,6 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
         }
 
         ret = SF_BOOLEAN_TRUE;
-        if(sf->log_query_exec_steps_info){
-            if(counter == 1000){
-                log_info("curl post call loop, query code : %s", query_code);
-                counter = 0;
-            }
-            counter++;
-        }
     }
     while (0); // Dummy loop to break out of
 
@@ -469,7 +460,6 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
 
     // Set to 0
     memset(query_code, 0, QUERYCODE_LEN);
-    int counter = 0;
     do {
         if (!http_perform(curl, GET_REQUEST_TYPE, url, header, NULL, json,
                           sf->network_timeout, SF_BOOLEAN_FALSE, error,
@@ -530,13 +520,6 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
         }
 
         ret = SF_BOOLEAN_TRUE;
-        if(sf->log_query_exec_steps_info){
-            if(counter == 1000){
-                log_info("curl get call loop, query code : %s", query_code);
-                counter = 0;
-            }
-            counter++;
-        }
     }
     while (0); // Dummy loop to break out of
 

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -313,7 +313,9 @@ sf_bool STDCALL http_perform(CURL *curl,
         retry = SF_BOOLEAN_FALSE;
 
         log_trace("Running curl call");
+        log_info("Start curl perform");
         res = curl_easy_perform(curl);
+        log_info("Finish curl perform");
         /* Check for errors */
         if (res != CURLE_OK) {
           if (res == CURLE_COULDNT_CONNECT && curl_retry_ctx.retry_count <


### PR DESCRIPTION
For this PR, I did two things:
1. Add log around the `curl_easy_perform` function because this is a function that may cause the query stuck in libsfclient, we should add log in advance so when the issue happens again, we could direct check it.
2. Delete some useless logs, it should be my fault, I made a small mistake in the curl_get_call and curl_post_call, the outside do while loop, the condition is while(0) so it will not cause an infinite loop here.

Next step:
I hope this is the last time to adjust the log in the third part of libsfclient. I will update the related log in XP's libsfclient