### PR TITLE
SNOW-395243 Support application in connection settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ set(SOURCE_FILES_CPP_WRAPPER
         cpp/lib/ResultSetJson.cpp
         cpp/lib/ResultSetJson.hpp
         cpp/jwt/jwtWrapper.cpp
+        cpp/util/SnowflakeCommon.cpp
         lib/result_set.h
         lib/result_set_arrow.h
         lib/result_set_json.h)

--- a/cpp/util/SnowflakeCommon.cpp
+++ b/cpp/util/SnowflakeCommon.cpp
@@ -1,0 +1,34 @@
+/*
+* Copyright (c) 2021 Snowflake Computing, Inc. All rights reserved.
+*/
+#include <string.h>
+#include "boost/regex.hpp"
+#include "snowflake/basic_types.h"
+
+/**
+ * Validate partner application name.
+ * No cross-platform regex lib in C so we use C++ one.
+ * @param application partner application name
+ */
+extern "C" {
+
+sf_bool validate_application(const char* application)
+{
+  boost::regex APPLICATION_REGEX = boost::regex("^[A-Za-z][A-Za-z0-9\\.\\-_]{1,50}$", boost::regex::icase);
+
+  // It's OK to leave application unset.
+  if (!application || (strlen(application) == 0))
+  {
+    return SF_BOOLEAN_TRUE;
+  }
+
+  if (regex_match(application, APPLICATION_REGEX))
+  {
+    return SF_BOOLEAN_TRUE;
+  }
+
+  return SF_BOOLEAN_FALSE;
+}
+
+}
+

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -209,6 +209,7 @@ typedef enum SF_ATTRIBUTE {
     SF_CON_TIMEZONE,
     SF_CON_SERVICE_NAME,
     SF_CON_AUTOCOMMIT,
+    SF_CON_APPLICATION,
     SF_DIR_QUERY_URL,
     SF_DIR_QUERY_URL_PARAM,
     SF_DIR_QUERY_TOKEN,
@@ -278,6 +279,9 @@ typedef struct SF_CONNECT {
     // Overrider application name and version
     char *application_name;
     char *application_version;
+
+    // Partner application name
+    char * application;
 
     // Session info
     char *token;

--- a/lib/client.c
+++ b/lib/client.c
@@ -378,7 +378,7 @@ static void STDCALL log_term() {
 SF_STATUS STDCALL
 _snowflake_check_connection_parameters(SF_CONNECT *sf) {
     if (is_string_empty(sf->account)) {
-        // Invalid connection
+        // Invalid account
         log_error(ERR_MSG_ACCOUNT_PARAMETER_IS_MISSING);
         SET_SNOWFLAKE_ERROR(
             &sf->error,
@@ -389,7 +389,7 @@ _snowflake_check_connection_parameters(SF_CONNECT *sf) {
     }
 
     if (is_string_empty(sf->user)) {
-        // Invalid connection
+        // Invalid user name
         log_error(ERR_MSG_USER_PARAMETER_IS_MISSING);
         SET_SNOWFLAKE_ERROR(
             &sf->error,
@@ -400,7 +400,7 @@ _snowflake_check_connection_parameters(SF_CONNECT *sf) {
     }
 
     if (is_string_empty(sf->password)) {
-        // Invalid connection
+        // Invalid password
         log_error(ERR_MSG_PASSWORD_PARAMETER_IS_MISSING);
         SET_SNOWFLAKE_ERROR(
             &sf->error,
@@ -411,7 +411,7 @@ _snowflake_check_connection_parameters(SF_CONNECT *sf) {
     }
 
     if (SF_BOOLEAN_FALSE == validate_application(sf->application)) {
-        // Invalid connection
+        // Invalid parnter application name
         log_error(ERR_MSG_APPLICATION_PARAMETER_INVALID);
         SET_SNOWFLAKE_ERROR(
             &sf->error,

--- a/lib/client.c
+++ b/lib/client.c
@@ -46,6 +46,12 @@ static SF_STATUS STDCALL
 _reset_connection_parameters(SF_CONNECT *sf, cJSON *parameters,
                              cJSON *session_info, sf_bool do_validate);
 
+/**
+ * Validate partner application name.
+ * @param application partner application name
+ */
+sf_bool validate_application(const char *application);
+
 #define _SF_STMT_TYPE_DML 0x3000
 #define _SF_STMT_TYPE_INSERT (_SF_STMT_TYPE_DML + 0x100)
 #define _SF_STMT_TYPE_UPDATE (_SF_STMT_TYPE_DML + 0x200)
@@ -404,6 +410,17 @@ _snowflake_check_connection_parameters(SF_CONNECT *sf) {
         return SF_STATUS_ERROR_GENERAL;
     }
 
+    if (SF_BOOLEAN_FALSE == validate_application(sf->application)) {
+        // Invalid connection
+        log_error(ERR_MSG_APPLICATION_PARAMETER_INVALID);
+        SET_SNOWFLAKE_ERROR(
+            &sf->error,
+            SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+            ERR_MSG_APPLICATION_PARAMETER_INVALID,
+            SF_SQLSTATE_UNABLE_TO_CONNECT);
+        return SF_STATUS_ERROR_GENERAL;
+    }
+
     if (!sf->host) {
         // construct a host parameter if not specified,
         char buf[1024];
@@ -609,6 +626,7 @@ SF_CONNECT *STDCALL snowflake_init() {
         alloc_buffer_and_copy(&sf->authenticator, SF_AUTHENTICATOR_DEFAULT);
         alloc_buffer_and_copy(&sf->application_name, SF_API_NAME);
         alloc_buffer_and_copy(&sf->application_version, SF_API_VERSION);
+        sf->application = NULL;
 
         _mutex_init(&sf->mutex_parameters);
 
@@ -674,6 +692,7 @@ SF_STATUS STDCALL snowflake_term(SF_CONNECT *sf) {
     SF_FREE(sf->authenticator);
     SF_FREE(sf->application_name);
     SF_FREE(sf->application_version);
+    SF_FREE(sf->application);
     SF_FREE(sf->timezone);
     SF_FREE(sf->service_name);
     SF_FREE(sf->query_result_format);
@@ -749,7 +768,7 @@ SF_STATUS STDCALL snowflake_connect(SF_CONNECT *sf) {
     // Create body
     body = create_auth_json_body(
         sf,
-        sf->application_name,
+        sf->application,
         sf->application_name,
         sf->application_version,
         sf->timezone,
@@ -920,6 +939,9 @@ SF_STATUS STDCALL snowflake_set_attribute(
         case SF_CON_APPLICATION_VERSION:
             alloc_buffer_and_copy(&sf->application_version, value);
             break;
+        case SF_CON_APPLICATION:
+          alloc_buffer_and_copy(&sf->application, value);
+          break;
         case SF_CON_AUTHENTICATOR:
             alloc_buffer_and_copy(&sf->authenticator, value);
             break;
@@ -1012,6 +1034,9 @@ SF_STATUS STDCALL snowflake_get_attribute(
         case SF_CON_APPLICATION_VERSION:
             *value = sf->application_version;
             break;
+        case SF_CON_APPLICATION:
+          *value = sf->application;
+          break;
         case SF_CON_AUTHENTICATOR:
             *value = sf->authenticator;
             break;

--- a/lib/error.h
+++ b/lib/error.h
@@ -32,6 +32,7 @@ void STDCALL copy_snowflake_error(SF_ERROR_STRUCT *dst, SF_ERROR_STRUCT *src);
 #define ERR_MSG_ACCOUNT_PARAMETER_IS_MISSING "account parameter is missing"
 #define ERR_MSG_USER_PARAMETER_IS_MISSING "user parameter is missing"
 #define ERR_MSG_PASSWORD_PARAMETER_IS_MISSING "password parameter is missing"
+#define ERR_MSG_APPLICATION_PARAMETER_INVALID "application parameter is invalid"
 #define ERR_MSG_CONNECTION_ALREADY_EXISTS "Connection already exists."
 #define ERR_MSG_SESSION_TOKEN_INVALID "The session token is invalid. Please reconnect"
 #define ERR_MSG_GONE_SESSION "The session no longer exists on the server. Please reconnect"

--- a/tests/test_unit_connect_parameters.c
+++ b/tests/test_unit_connect_parameters.c
@@ -151,6 +151,57 @@ void test_connection_parameters_for_global_with_account_dashes(void **unused) {
     SF_FREE(sf);
 }
 
+/**
+ * Test no host
+ */
+void test_connection_parameters_application(void **unused) {
+    SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+    memset(sf, 0, sizeof(SF_CONNECT));
+    sf->account = "testaccount";
+    sf->user = "testuser";
+    sf->password = "testpassword";
+
+    // application is null
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_SUCCESS);
+
+    // application is empty
+    sf->application = "";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_SUCCESS);
+
+    // valid application names
+    sf->application = "test1234";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_SUCCESS);
+
+    sf->application = "test_1234";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_SUCCESS);
+
+    sf->application = "test-1234";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_SUCCESS);
+
+    sf->application = "test.1234";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_SUCCESS);
+
+    // invalid application names
+    sf->application = "1234test";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+
+    sf->application = "test$A";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+
+    sf->application = "test<script>";
+    assert_int_equal(
+        _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+
+    SF_FREE(sf);
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -161,6 +212,7 @@ int main(void) {
         cmocka_unit_test(test_connection_parameters_including_region_including_dot),
         cmocka_unit_test(test_connection_parameters_for_global_url_basic),
         cmocka_unit_test(test_connection_parameters_for_global_url_full),
+        cmocka_unit_test(test_connection_parameters_application),
     };
     int ret = cmocka_run_group_tests(tests, NULL, NULL);
     return ret;


### PR DESCRIPTION
Simba ticket 00349937. Allow user set the value for CLIENT_ENVIRONMENT::APPLICATION in the logging request via the 'application' connection setting. PHP connector is using libsnowflakeclient so we need the change here.