### PR TITLE
SNOW-514869 loading OCSP cache file always fail

### DIFF
--- a/tests/unit_test_ocsp/CMakeLists.txt
+++ b/tests/unit_test_ocsp/CMakeLists.txt
@@ -6,9 +6,4 @@ add_executable(
         test_ocsp
         test_ocsp.c)
 
-if (LINUX)
-    target_link_libraries(test_ocsp
-            rt dl z m
-            curl ssl crypto
-            )
-endif ()
+target_link_libraries(test_ocsp ${TESTLIB_OPTS_C})


### PR DESCRIPTION
The size of buffer for loading OCSP cache file is hardcoded as 24KB which is smaller than usual file size (150KB) and causes the loading always fail.
Tested with unit_ocsp_test manually, all cases passed and confirmed "OCSP cache file was successfully loaded" output in curl log.
