### PR TITLE
Support server side encryption (SNOWFLAKE_SSE)

### DIFF
--- a/ci/test/test.sh
+++ b/ci/test/test.sh
@@ -54,7 +54,7 @@ function init_python()
     python3 -m venv $temp_dir/venv
     source $temp_dir/venv/bin/activate
     echo "=== installing pip"
-    curl -s https://bootstrap.pypa.io/get-pip.py | python >& /dev/null
+    curl -s https://bootstrap.pypa.io/get-pip.py | python >& /dev/null || true
     echo "=== installing python connector"
     pip install snowflake-connector-python >&/dev/null
     which python

--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -216,6 +216,7 @@ void Snowflake::Client::FileMetadataInitializer::initEncryptionMetadata(
   {
     // No encryption materials for server side encryption
     fileMetadata->encryptionMetadata.cipherStreamSize = fileMetadata->srcFileToUploadSize;
+    fileMetadata->destFileSize = fileMetadata->srcFileToUploadSize;
     fileMetadata->encryptionMetadata.fileKey.nbBits = 0;
     return;
   }

--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -212,6 +212,14 @@ void Snowflake::Client::FileMetadataInitializer::initCompressionMetadata(
 void Snowflake::Client::FileMetadataInitializer::initEncryptionMetadata(
   FileMetadata *fileMetadata)
 {
+  if (m_encMat->empty())
+  {
+    // No encryption materials for server side encryption
+    fileMetadata->encryptionMetadata.cipherStreamSize = fileMetadata->srcFileToUploadSize;
+    fileMetadata->encryptionMetadata.fileKey.nbBits = 0;
+    return;
+  }
+
   std::string randDev = (getRandomDev() == Crypto::CryptoRandomDevice::DEV_RANDOM)? "DEV_RANDOM" : "DEV_URANDOM";
   CXX_LOG_INFO("Snowflake::Client::FileMetadataInitializer::initEncryptionMetadata using random device %s.", randDev.c_str());
   EncryptionProvider::populateFileKeyAndIV(fileMetadata, &(m_encMat->at(0)), getRandomDev());
@@ -255,7 +263,14 @@ populateSrcLocDownloadMetadata(std::string &sourceLocation,
     metaListToPush.push_back(fileMetadata);
     metaListToPush.back().srcFileName = fullPath;
     metaListToPush.back().destFileName = dstFileName;
-    EncryptionProvider::decryptFileKey(&(metaListToPush.back()), encMat, getRandomDev());
+    if (encMat)
+    {
+      EncryptionProvider::decryptFileKey(&(metaListToPush.back()), encMat, getRandomDev());
+    }
+    else
+    {
+      metaListToPush.back().encryptionMetadata.fileKey.nbBits = 0;
+    }
   }
 
   return outcome;

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -343,13 +343,19 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::GetRemoteFileMetadata(
 
         std::size_t pos1 = encHdr.find("EncryptedKey")  + strlen("EncryptedKey") + 3;
         std::size_t pos2 = encHdr.find("\",\"Algorithm\"");
-        fileMetadata->encryptionMetadata.enKekEncoded = encHdr.substr(pos1, pos2-pos1);
+        if ((std::string::npos != pos1) && (std::string::npos != pos2) && (pos2 >= pos1))
+        {
+          fileMetadata->encryptionMetadata.enKekEncoded = encHdr.substr(pos1, pos2 - pos1);
+        }
 
         pos1 = encHdr.find("ContentEncryptionIV")  + strlen("ContentEncryptionIV") + 3;
         pos2 = encHdr.find("\",\"KeyWrappingMetadata\"");
-        std::string iv = encHdr.substr(pos1, pos2-pos1);
-
-        Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->encryptionMetadata.iv.data);
+        std::string iv("");
+        if ((std::string::npos != pos1) && (std::string::npos != pos2) && (pos2 >= pos1))
+        {
+          iv = encHdr.substr(pos1, pos2 - pos1);
+          Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->encryptionMetadata.iv.data);
+        }
 
         fileMetadata->encryptionMetadata.cipherStreamSize = blobProperty.size;
         fileMetadata->srcFileSize = (long)blobProperty.size;

--- a/cpp/SnowflakeGCSClient.cpp
+++ b/cpp/SnowflakeGCSClient.cpp
@@ -164,8 +164,14 @@ void SnowflakeGCSClient::parseEncryptionMetadataFromJSON(std::string const& json
   cJSON* encryptedIv =
           snowflake_cJSON_GetObjectItem(json, "ContentEncryptionIV");
 
-  key64 = encryptedKey->valuestring;
-  iv64 = encryptedIv->valuestring;
+  if (encryptedKey)
+  {
+    key64 = encryptedKey->valuestring;
+  }
+  if (encryptedIv)
+  {
+    iv64 = encryptedIv->valuestring;
+  }
 
   snowflake_cJSON_free(json);
 }

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -583,8 +583,12 @@ RemoteStorageRequestOutcome SnowflakeS3Client::GetRemoteFileMetadata(
 
     Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->
       encryptionMetadata.iv.data);
-    fileMetadata->encryptionMetadata.enKekEncoded = outcome.GetResult()
-      .GetMetadata().at(AMZ_KEY);
+    if (outcome.GetResult().GetMetadata().find(AMZ_KEY) !=
+        outcome.GetResult().GetMetadata().end())
+    {
+      fileMetadata->encryptionMetadata.enKekEncoded = outcome.GetResult()
+        .GetMetadata().at(AMZ_KEY);
+    }
 
     return RemoteStorageRequestOutcome::SUCCESS;
   }

--- a/cpp/StatementPutGet.cpp
+++ b/cpp/StatementPutGet.cpp
@@ -43,10 +43,13 @@ bool StatementPutGet::parsePutGetCommand(std::string *sql,
     putGetParseResponse->command = CommandType::UPLOAD;
 
     putGetParseResponse->threshold = (size_t)response->threshold;
-    putGetParseResponse->encryptionMaterials.emplace_back(
-      response->enc_mat_put->query_stage_master_key,
-      response->enc_mat_put->query_id,
-      response->enc_mat_put->smk_id);
+    if (response->enc_mat_put->query_stage_master_key)
+    {
+      putGetParseResponse->encryptionMaterials.emplace_back(
+        response->enc_mat_put->query_stage_master_key,
+        response->enc_mat_put->query_id,
+        response->enc_mat_put->smk_id);
+    }
   } else if (sf_strncasecmp(response->command, "DOWNLOAD", 8) == 0)
   {
     putGetParseResponse->command = CommandType::DOWNLOAD;


### PR DESCRIPTION
Simba ticket 00372396

When stage is created with "encryption = (type = 'SNOWFLAKE_SSE')", no encryption materials will be returned from server for put/get commands. ODBC driver doesn't support that and throws error.
Follow the implementation in JDBC, no encryption/decryption when either isClientSideEncrypted is off or encryption material is empty.