### PR TITLE
fix put/get issue with CLIENT_ENCRYPTION_KEY_SIZE = 256

### DIFF
--- a/cpp/EncryptionProvider.cpp
+++ b/cpp/EncryptionProvider.cpp
@@ -11,7 +11,7 @@
 void Snowflake::Client::EncryptionProvider::encryptFileKey(
   FileMetadata *fileMetadata, EncryptionMaterial *encryptionMaterial, Crypto::CryptoRandomDevice randomDevice)
 {
-  char encryptedFileKey[32];
+  char encryptedFileKey[128];
   Crypto::CryptoIV iv;
   Crypto::CryptoKey queryStageMasterKey;
   Crypto::Cryptor::generateIV(iv, randomDevice);
@@ -26,7 +26,7 @@ void Snowflake::Client::EncryptionProvider::encryptFileKey(
   Crypto::CipherContext context =
     Crypto::Cryptor::getInstance().createCipherContext(Crypto::CryptoAlgo::AES,
                                                        Crypto::CryptoMode::ECB,
-                                                       Crypto::CryptoPadding::NONE,
+                                                       Crypto::CryptoPadding::PKCS5,
                                                        queryStageMasterKey,
                                                        iv);
 
@@ -78,7 +78,7 @@ void Snowflake::Client::EncryptionProvider::decryptFileKey(
   Crypto::CipherContext context =
     Crypto::Cryptor::getInstance().createCipherContext(Crypto::CryptoAlgo::AES,
                                                        Crypto::CryptoMode::ECB,
-                                                       Crypto::CryptoPadding::NONE,
+                                                       Crypto::CryptoPadding::PKCS5,
                                                        queryStageMasterKey,
                                                        iv);
 

--- a/cpp/crypto/CipherContext.cpp
+++ b/cpp/crypto/CipherContext.cpp
@@ -106,26 +106,6 @@ CipherContext::Impl::Impl(const CryptoAlgo algo,
 
   // Initialize the library context.
   this->ctx = EVP_CIPHER_CTX_new();
-
-  // Set padding.
-  bool pad;
-  switch (padding)
-  {
-    case CryptoPadding::NONE:
-      pad = false;
-      break;
-    case CryptoPadding::PKCS5:
-      pad = true;
-      break;
-    default:
-      //TODO port assertion framework
-      throw;
-  }
-  //TODO
-  if (EVP_CIPHER_CTX_set_padding(this->ctx, pad) != 1)
-    //TODO throw exception
-    throw;
-  //SF_THROW_CRYPTO(pad);
 }
 
 CipherContext::Impl::~Impl() noexcept
@@ -232,6 +212,29 @@ void CipherContext::initialize(const CryptoOperation op,
   if (success == 0)
     throw;
   //SF_THROW_CRYPTO(static_cast<int>(op));
+
+
+  // Set padding.
+  // EVP_CIPHER_CTX_set_padding() must be called after initialize
+  // https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_set_padding.html
+  bool pad;
+  switch (impl.padding)
+  {
+  case CryptoPadding::NONE:
+    pad = false;
+    break;
+  case CryptoPadding::PKCS5:
+    pad = true;
+    break;
+  default:
+    //TODO port assertion framework
+    throw;
+  }
+  //TODO
+  if (EVP_CIPHER_CTX_set_padding(impl.ctx, pad) != 1)
+    //TODO throw exception
+    throw;
+  //SF_THROW_CRYPTO(pad);
 
   // Remember operation and offset.
   impl.op = op;

--- a/cpp/crypto/CryptoTypes.hpp
+++ b/cpp/crypto/CryptoTypes.hpp
@@ -84,8 +84,11 @@ struct CryptoKey final
   }
 
   size_t nbBits;      /// 128, 192, or 256
+
+  // between 128 and 256 bits of key data, @see nbBits
+  // Add block size of 16 for possible padding
   char data[
-    256 / 8]; /// between 128 and 256 bits of key data, @see nbBits
+    256 / 8 + 16];
 };
 
 /**


### PR DESCRIPTION
Simba ticket 00374351
When CLIENT_ENCRYPTION_KEY_SIZE=256 and uploaded data file using put command through ODBC driver, got error of "Failed to decrypt. Check file key and master key" when try to load data to table from the uploaded data file using copy into command.

The root cause is that the driver is designed to use no padding for key encryption so the buffer size is defined accordingly, while actually padding is used and causes buffer overflow.
1. EVP_CIPHER_CTX_set_padding() is called in CipherContext::Impl::Impl(), before EVP_EncryptInit_ex()/EVP_DecryptInit_ex() being called in CipherContext::initialize(), while in OpenSSL documentation EVP_CIPHER_CTX_set_padding() must be called after initialization. This causes the call of EVP_CIPHER_CTX_set_padding() never worked and padding is always used and causes buffer overflow.
2. After fixing 1, no padding is used for key encryption and data file uploaded by the driver can be downloaded by the driver correctly, but loading data from the data file still get same error. That means the encryption on driver side is not match the way on server side. Change to use encryption with padding and changing the buffer size accordingly fixes the issue, I believe encryption with padding is what used on sever side and should be used on driver side as well.

Actually just increasing the buffer size would fix the issue because without fix in 1 encryption with padding is always used, but to make the logic correct in case we could change the padding behavior in the future, also made fix in 1.

No test case added in libsnowflakeclient as it needs accountadmin to run the test and not sure the test user for libsnowflakeclient has that. Added test on ODBC side in this branch: https://github.com/snowflakedb/snowflake-odbc/tree/bugfix-putget-with-encryptionkeysize256 and test passed on my local. Will make odbc PR from there when this change is merged.