### PR TITLE
fix command injection vulnerability with temp directory for put.

### DIFF
--- a/lib/platform.c
+++ b/lib/platform.c
@@ -780,6 +780,11 @@ int STDCALL sf_create_directory_if_not_exists_recursive(const char * directoryNa
 
 int STDCALL sf_delete_directory_if_exists(const char * directoryName)
 {
+  // Check existence before calling system() to prevent command injection.
+  if (!sf_is_directory_exist(directoryName))
+  {
+    return 0;
+  }
 #ifdef _WIN32
   char rmCmd[500];
   sb_strcpy(rmCmd, sizeof(rmCmd), "rd /s /q ");


### PR DESCRIPTION
Command injection vulnerability found by Simba internally.
In libsnowflakeclient it's calling system() to delete temporary folder for the file compression during put command execution. The temporary folder is configurable by application (in ODBC, the application can set the path through PUT_TEMPDIR in connection string) so it could be used for command injection.
Check error when creating the temporary folder and confirm the existence before calling system() to delete.