### PR TITLE
Disable DEV_RANDOM test on Linux

### DIFF
--- a/tests/test_unit_cipher_stream_buf.cpp
+++ b/tests/test_unit_cipher_stream_buf.cpp
@@ -41,24 +41,33 @@ void test_cipher_stream_core(int blockSize, const char * testData, int dataSize,
   assert_memory_equal(testData, outputString.str().c_str(), dataSize);
 }
 
+/*
+ * Disable DEV_RANDOM test on Linux as it could be blocked
+ */
 void test_cipher_stream_buf_zero(void **unused)
 {
   const char * testData = "123456789123456789123456789\0";
+#ifndef __linux__
   test_cipher_stream_core(16, testData, strlen(testData), CryptoRandomDevice::DEV_RANDOM);
+#endif
   test_cipher_stream_core(16, testData, strlen(testData), CryptoRandomDevice::DEV_URANDOM);
 }
 
 void test_cipher_stream_buf_one(void **unused)
 {
   const char * testData = "123456789123456789123456789\0";
+#ifndef __linux__
   test_cipher_stream_core(512, testData, strlen(testData), CryptoRandomDevice::DEV_RANDOM);
+#endif
   test_cipher_stream_core(512, testData, strlen(testData), CryptoRandomDevice::DEV_URANDOM);
 }
 
 void test_cipher_stream_buf_two(void **unused)
 {
   const char * testData = "0123456789012345\0";
+#ifndef __linux__
   test_cipher_stream_core(16, testData, strlen(testData), CryptoRandomDevice::DEV_RANDOM);
+#endif
   test_cipher_stream_core(16, testData, strlen(testData), CryptoRandomDevice::DEV_URANDOM);
 }
 

--- a/tests/test_unit_stream_splitter.cpp
+++ b/tests/test_unit_stream_splitter.cpp
@@ -43,8 +43,14 @@ void test_byte_array_stream(void **unused)
  */
 void test_stream_splitter_appender(void **unused)
 {
+// Disable DEV_RANDOM test on Linux as it could be blocked
+#ifdef __linux__
+  int numDevices = 1;
+  CryptoRandomDevice devices[]={CryptoRandomDevice::DEV_URANDOM};
+#else
   int numDevices = 2;
   CryptoRandomDevice devices[]={CryptoRandomDevice::DEV_RANDOM, CryptoRandomDevice::DEV_URANDOM};
+#endif
   for(int i=0; i< numDevices ; ++i)
   {
     std::string inputStr = "123456789012345678901234567890";


### PR DESCRIPTION
Disable test using DEV_RANDOM on Linux as it could be blocked for a long time.