### PR TITLE
remove system() call to prevent command injection

### DIFF
--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -590,7 +590,12 @@ void Snowflake::Client::FileTransferAgent::compressSourceFile(
     level = m_transferConfig->compressLevel;
     if (m_transferConfig->tempDir)
     {
-      sb_strcat(tempDir, sizeof(tempDir), m_transferConfig->tempDir);
+      std::string tmpDirSetting(m_transferConfig->tempDir);
+      // ban characters that could use for command injection
+      if (std::string::npos == tmpDirSetting.find_first_of("&;\""))
+      {
+        sb_strcat(tempDir, sizeof(tempDir), m_transferConfig->tempDir);
+      }
     }
   }
   sf_get_uniq_tmp_dir(tempDir);

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -590,12 +590,7 @@ void Snowflake::Client::FileTransferAgent::compressSourceFile(
     level = m_transferConfig->compressLevel;
     if (m_transferConfig->tempDir)
     {
-      std::string tmpDirSetting(m_transferConfig->tempDir);
-      // ban characters that could use for command injection
-      if (std::string::npos == tmpDirSetting.find_first_of("&;\""))
-      {
-        sb_strcat(tempDir, sizeof(tempDir), m_transferConfig->tempDir);
-      }
+      sb_strcat(tempDir, sizeof(tempDir), m_transferConfig->tempDir);
     }
   }
   sf_get_uniq_tmp_dir(tempDir);

--- a/cpp/util/SnowflakeCommon.cpp
+++ b/cpp/util/SnowflakeCommon.cpp
@@ -3,7 +3,9 @@
 */
 #include <string.h>
 #include "boost/regex.hpp"
+#include "boost/filesystem.hpp"
 #include "snowflake/basic_types.h"
+#include "snowflake/platform.h"
 
 /**
  * Validate partner application name.
@@ -28,6 +30,26 @@ sf_bool validate_application(const char* application)
   }
 
   return SF_BOOLEAN_FALSE;
+}
+
+int STDCALL sf_delete_directory_if_exists(const char * directoryName)
+{
+  if (!sf_is_directory_exist(directoryName))
+  {
+    return 0;
+  }
+
+  boost::system::error_code err;
+  try
+  {
+    boost::filesystem::remove_all(boost::filesystem::path(directoryName), err);
+  }
+  catch (...)
+  {
+    return -1;
+  }
+
+  return err.value();
 }
 
 }

--- a/lib/platform.c
+++ b/lib/platform.c
@@ -787,13 +787,15 @@ int STDCALL sf_delete_directory_if_exists(const char * directoryName)
   }
 #ifdef _WIN32
   char rmCmd[500];
-  sb_strcpy(rmCmd, sizeof(rmCmd), "rd /s /q ");
+  sb_strcpy(rmCmd, sizeof(rmCmd), "rd /s /q \"");
   sb_strcat(rmCmd, sizeof(rmCmd), directoryName);
+  sb_strcat(rmCmd, sizeof(rmCmd), "\"");
   return system(rmCmd);
 #else
   char rmCmd[500];
-  sb_strcpy(rmCmd, sizeof(rmCmd), "rm -rf ");
+  sb_strcpy(rmCmd, sizeof(rmCmd), "rm -rf \"");
   sb_strcat(rmCmd, sizeof(rmCmd), directoryName);
+  sb_strcat(rmCmd, sizeof(rmCmd), "\"");
   return system(rmCmd);
 #endif
 }

--- a/lib/platform.c
+++ b/lib/platform.c
@@ -778,28 +778,6 @@ int STDCALL sf_create_directory_if_not_exists_recursive(const char * directoryNa
   return 0;
 }
 
-int STDCALL sf_delete_directory_if_exists(const char * directoryName)
-{
-  // Check existence before calling system() to prevent command injection.
-  if (!sf_is_directory_exist(directoryName))
-  {
-    return 0;
-  }
-#ifdef _WIN32
-  char rmCmd[500];
-  sb_strcpy(rmCmd, sizeof(rmCmd), "rd /s /q \"");
-  sb_strcat(rmCmd, sizeof(rmCmd), directoryName);
-  sb_strcat(rmCmd, sizeof(rmCmd), "\"");
-  return system(rmCmd);
-#else
-  char rmCmd[500];
-  sb_strcpy(rmCmd, sizeof(rmCmd), "rm -rf \"");
-  sb_strcat(rmCmd, sizeof(rmCmd), directoryName);
-  sb_strcat(rmCmd, sizeof(rmCmd), "\"");
-  return system(rmCmd);
-#endif
-}
-
 void STDCALL sf_get_tmp_dir(char * tmpDir)
 {
 #ifdef _WIN32


### PR DESCRIPTION
Remove system() call and replace it with boost::filesystem::remove_all()