### PR TITLE
Passdown proxy without env for file transfer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,6 @@ set (SOURCE_FILES_PUT_GET
         cpp/util/ByteArrayStreamBuf.hpp
         cpp/util/CompressionUtil.cpp
         cpp/util/CompressionUtil.hpp
-        cpp/util/Proxy.hpp
         cpp/util/Proxy.cpp
         cpp/util/ThreadPool.hpp
         cpp/util/SnowflakeCommon.hpp
@@ -188,6 +187,7 @@ set (SOURCE_FILES_PUT_GET
         include/snowflake/SnowflakeTransferException.hpp
         include/snowflake/IJwt.hpp
         include/snowflake/IBase64.hpp
+        include/snowflake/Proxy.hpp
         )
 
 set(SOURCE_FILES_CPP_WRAPPER

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -8,7 +8,7 @@
 #include "snowflake/client.h"
 #include "util/Base64.hpp"
 #include "util/ByteArrayStreamBuf.hpp"
-#include "util/Proxy.hpp"
+#include "snowflake/Proxy.hpp"
 #include "crypto/CipherStreamBuf.hpp"
 #include "logger/SFAwsLogger.hpp"
 #include "logger/SFLogger.hpp"
@@ -119,7 +119,14 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
   }
 
   Util::Proxy proxy;
-  proxy.setProxyFromEnv();
+  if ((transferConfig != nullptr) && (transferConfig->proxy != nullptr))
+  {
+    proxy = *(transferConfig->proxy);
+  }
+  else
+  {
+    proxy.setProxyFromEnv();
+  }
 
   // Set Proxy
   if (!proxy.getMachine().empty()) {
@@ -137,6 +144,11 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
   if (proxy.getPort() != 0) {
     clientConfiguration.proxyPort = proxy.getPort();
     CXX_LOG_DEBUG("Proxy port: %d", proxy.getPort());
+  }
+
+  if (!proxy.getNoProxy().empty())
+  {
+    clientConfiguration.noProxy = Aws::String(proxy.getNoProxy());
   }
 
   CXX_LOG_DEBUG("CABundleFile used in aws sdk: %s", caFile.c_str());

--- a/cpp/util/Proxy.cpp
+++ b/cpp/util/Proxy.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2019 Snowflake Computing, Inc. All rights reserved.
  */
 
-#include "Proxy.hpp"
+#include "snowflake/Proxy.hpp"
 
 Snowflake::Client::Util::Proxy::Proxy(const std::string &proxy_str)
 {
@@ -82,4 +82,35 @@ void Snowflake::Client::Util::Proxy::setProxyFromEnv() {
     }
 
     stringToProxyParts(proxy);
+
+    // Get noproxy string
+    if (std::getenv("no_proxy")) {
+        m_noProxy = std::getenv("no_proxy");
+    } else if (std::getenv("NO_PROXY")) {
+        m_noProxy = std::getenv("NO_PROXY");
+    }
+}
+
+std::string Snowflake::Client::Util::Proxy::getHost() const
+{
+    if (m_machine.empty())
+    {
+        return "";
+    }
+    std::string host;
+    if (Protocol::HTTPS == m_protocol)
+    {
+        host = "https://";
+    }
+    else if (Protocol::HTTP == m_protocol)
+    {
+        host = "http://";
+    }
+    else
+    {
+        return "";
+    }
+    host += m_machine;
+
+    return host;
 }

--- a/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -106,6 +106,11 @@ namespace Aws
             */
             Aws::String proxyPassword;
             /**
+            * If you have users going through a proxy, set the list of host
+            * names that do not require a proxy here.
+            */
+            Aws::String noProxy;
+            /**
             * Threading Executor implementation. Default uses std::thread::detach()
             */
             std::shared_ptr<Aws::Utils::Threading::Executor> executor;

--- a/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
+++ b/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
@@ -52,6 +52,7 @@ private:
     Aws::String m_proxyPassword;
     Aws::String m_proxyScheme;
     Aws::String m_proxyHost;
+    Aws::String m_noProxy;
     unsigned m_proxyPort;
     bool m_verifySSL;
     Aws::String m_caPath;

--- a/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -293,7 +293,7 @@ CurlHttpClient::CurlHttpClient(const ClientConfiguration& clientConfig) :
     m_curlHandleContainer(clientConfig.maxConnections, clientConfig.requestTimeoutMs, clientConfig.connectTimeoutMs),
     m_isUsingProxy(!clientConfig.proxyHost.empty()), m_proxyUserName(clientConfig.proxyUserName),
     m_proxyPassword(clientConfig.proxyPassword), m_proxyScheme(SchemeMapper::ToString(clientConfig.proxyScheme)), m_proxyHost(clientConfig.proxyHost),
-    m_proxyPort(clientConfig.proxyPort), m_verifySSL(clientConfig.verifySSL), m_caPath(clientConfig.caPath),
+    m_noProxy(clientConfig.noProxy), m_proxyPort(clientConfig.proxyPort), m_verifySSL(clientConfig.verifySSL), m_caPath(clientConfig.caPath),
     m_caFile(clientConfig.caFile), m_allowRedirects(clientConfig.followRedirects)
 {
 }
@@ -412,6 +412,7 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(HttpRequest& request, 
             curl_easy_setopt(connectionHandle, CURLOPT_PROXYPORT, (long) m_proxyPort);
             curl_easy_setopt(connectionHandle, CURLOPT_PROXYUSERNAME, m_proxyUserName.c_str());
             curl_easy_setopt(connectionHandle, CURLOPT_PROXYPASSWORD, m_proxyPassword.c_str());
+            curl_easy_setopt(connectionHandle, CURLOPT_NOPROXY, m_noProxy.c_str());
         }
         else
         {

--- a/include/snowflake/IFileTransferAgent.hpp
+++ b/include/snowflake/IFileTransferAgent.hpp
@@ -8,6 +8,7 @@
 #include "ITransferResult.hpp"
 #include "ISFLogger.hpp"
 #include "IStatementPutGet.hpp"
+#include "Proxy.hpp"
 
 namespace Snowflake
 {
@@ -23,11 +24,13 @@ struct TransferConfig
     caBundleFile(NULL),
     tempDir(NULL),
     useS3regionalUrl(false),
-    compressLevel(-1) {}
+    compressLevel(-1),
+    proxy(NULL) {}
   char * caBundleFile;
   char * tempDir;
   bool useS3regionalUrl;
   int compressLevel;
+  Util::Proxy * proxy;
 };
 
 class IFileTransferAgent

--- a/include/snowflake/Proxy.hpp
+++ b/include/snowflake/Proxy.hpp
@@ -28,30 +28,42 @@ public:
 
     ~Proxy() = default;
 
-    inline const std::string& getUser()
+    inline const std::string& getUser() const
     {
         return this->m_user;
     }
 
-    inline const std::string& getPwd()
+    inline const std::string& getPwd() const
     {
         return this->m_pwd;
     }
 
-    inline const std::string& getMachine()
+    inline const std::string& getMachine() const
     {
         return this->m_machine;
     }
 
-    inline unsigned getPort()
+    inline unsigned getPort() const
     {
         return this->m_port;
     }
 
-    inline Protocol getScheme()
+    inline Protocol getScheme() const
     {
         return this->m_protocol;
     }
+
+    inline void setNoProxy(const std::string& noProxy)
+    {
+        this->m_noProxy = noProxy;
+    }
+
+    inline const std::string& getNoProxy() const
+    {
+        return this->m_noProxy;
+    }
+
+    std::string getHost() const;
 
     void clearPwd();
 
@@ -63,6 +75,7 @@ private:
     std::string m_machine;
     unsigned m_port = 0;
     Protocol m_protocol = Protocol::NONE;
+    std::string m_noProxy;
 
     void stringToProxyParts(const std::string &proxy);
 };

--- a/scripts/build_azuresdk.bat
+++ b/scripts/build_azuresdk.bat
@@ -2,7 +2,7 @@
 :: Build Azure cpp storage light sdk
 ::
 @echo off
-set azure_version=0.1.18
+set azure_version=0.1.19
 call %*
 goto :EOF
 

--- a/scripts/build_azuresdk.sh
+++ b/scripts/build_azuresdk.sh
@@ -10,7 +10,7 @@ function usage() {
 }
 set -o pipefail
 
-AZURE_VERSION=0.1.18
+AZURE_VERSION=0.1.19
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh $@

--- a/tests/test_simple_put.cpp
+++ b/tests/test_simple_put.cpp
@@ -1175,6 +1175,7 @@ int main(void) {
     cmocka_unit_test_teardown(test_simple_put_use_dev_urandom, teardown),
     cmocka_unit_test_teardown(test_simple_put_create_subfolder, teardown),
     cmocka_unit_test_teardown(test_simple_put_use_s3_regionalURL, teardown),
+    cmocka_unit_test_teardown(test_simple_put_passdown_proxy, teardown),
     cmocka_unit_test_teardown(test_server_side_encryption, donothing)
   };
   int ret = cmocka_run_group_tests(tests, gr_setup, gr_teardown);

--- a/tests/test_unit_proxy.cpp
+++ b/tests/test_unit_proxy.cpp
@@ -3,7 +3,7 @@
  */
 
 #include <cassert>
-#include "util/Proxy.hpp"
+#include "snowflake/Proxy.hpp"
 #include "utils/test_setup.h"
 #include "utils/TestSetup.hpp"
 


### PR DESCRIPTION
Fix for ODBC proxy issue. So far the ODBC driver pass down proxy settings through environment variables, which would affect all connections in the same process. The customer who report this issue is using multi-threading to handling connections from different users, which would need different proxy setting for each connection.
Add proxy settings for aws/azure api also add proxy setting for file transfer so the odbc driver can use that to pass down proxy settings from connection string.
No test case added as libsnowflakeclient still use environment variables for connection, but test cases added on odbc side in this branch and passed on my local. https://github.com/snowflakedb/snowflake-odbc/tree/passdown-proxy-without-env
Will make ODBC PR from there when this PR is merged and tagged with a new version.