### PR TITLE
Configurable get filesize threshold

### DIFF
--- a/cpp/FileMetadata.hpp
+++ b/cpp/FileMetadata.hpp
@@ -88,6 +88,10 @@ struct FileMetadata
   /// Enum for different timestamps
   enum putGetTimestamp{PUTGET_START=0,COMP_START, COMP_END, PUT_START, PUT_END, PUTGET_END, GET_START, GET_END};
 
+  // The flag to indicate if the file is larger than the threshold and needs to
+  // be treated as large file using multi-part uploading/downloading
+  bool isLarge;
+
   inline void recordPutGetTimestamp(putGetTimestamp ts=PUTGET_START)
   {
     tstamps[ts] = std::chrono::steady_clock::now();

--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -27,7 +27,8 @@ Snowflake::Client::FileMetadataInitializer::FileMetadataInitializer(
   std::vector<FileMetadata> &largeFileMetadata) :
   m_smallFileMetadata(smallFileMetadata),
   m_largeFileMetadata(largeFileMetadata),
-  m_autoCompress(true)
+  m_autoCompress(true),
+  m_downloadSizeThreshold(DOWNLOAD_DATA_SIZE_THRESHOLD)
 {
 }
 
@@ -45,7 +46,8 @@ Snowflake::Client::FileMetadataInitializer::initUploadFileMetadata(const std::st
   // process compression type
   initCompressionMetadata(fileMetadata);
 
-  std::vector<FileMetadata> &metaListToPush = fileSize > threshold ?
+  fileMetadata.isLarge = fileSize > threshold;
+  std::vector<FileMetadata> &metaListToPush = fileMetadata.isLarge ?
     m_largeFileMetadata : m_smallFileMetadata;
 
   metaListToPush.push_back(fileMetadata);
@@ -257,8 +259,8 @@ populateSrcLocDownloadMetadata(std::string &sourceLocation,
   if (outcome == RemoteStorageRequestOutcome::SUCCESS)
   {
     CXX_LOG_DEBUG("Success on getting remote file metadata");
-    std::vector<FileMetadata> &metaListToPush =
-      fileMetadata.srcFileSize > DOWNLOAD_DATA_SIZE_THRESHOLD ?
+    fileMetadata.isLarge = fileMetadata.srcFileSize > m_downloadSizeThreshold;
+    std::vector<FileMetadata> &metaListToPush = fileMetadata.isLarge ?
       m_largeFileMetadata : m_smallFileMetadata;
 
     metaListToPush.push_back(fileMetadata);

--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -27,8 +27,7 @@ Snowflake::Client::FileMetadataInitializer::FileMetadataInitializer(
   std::vector<FileMetadata> &largeFileMetadata) :
   m_smallFileMetadata(smallFileMetadata),
   m_largeFileMetadata(largeFileMetadata),
-  m_autoCompress(true),
-  m_downloadSizeThreshold(DOWNLOAD_DATA_SIZE_THRESHOLD)
+  m_autoCompress(true)
 {
 }
 
@@ -245,7 +244,8 @@ populateSrcLocDownloadMetadata(std::string &sourceLocation,
                                std::string *remoteLocation,
                                IStorageClient *storageClient,
                                EncryptionMaterial *encMat,
-                               std::string const& presignedUrl)
+                               std::string const& presignedUrl,
+                               size_t getThreshold)
 {
   std::string fullPath = *remoteLocation + sourceLocation;
   size_t dirSep = fullPath.find_last_of('/');
@@ -259,7 +259,7 @@ populateSrcLocDownloadMetadata(std::string &sourceLocation,
   if (outcome == RemoteStorageRequestOutcome::SUCCESS)
   {
     CXX_LOG_DEBUG("Success on getting remote file metadata");
-    fileMetadata.isLarge = fileMetadata.srcFileSize > m_downloadSizeThreshold;
+    fileMetadata.isLarge = fileMetadata.srcFileSize > getThreshold;
     std::vector<FileMetadata> &metaListToPush = fileMetadata.isLarge ?
       m_largeFileMetadata : m_smallFileMetadata;
 

--- a/cpp/FileMetadataInitializer.hpp
+++ b/cpp/FileMetadataInitializer.hpp
@@ -40,7 +40,7 @@ public:
   RemoteStorageRequestOutcome populateSrcLocDownloadMetadata(
     std::string &sourceLocation, std::string *remoteLocations,
     IStorageClient *storageClient, EncryptionMaterial *encMat,
-    std::string const& presignedUrl);
+    std::string const& presignedUrl, size_t getThreshold);
 
   /**
    * Init encryption metadata in file metadata
@@ -72,11 +72,6 @@ public:
     return m_randDevice;
   }
 
-  inline void setDownloadSizeThreshold(long threshold)
-  {
-    m_downloadSizeThreshold = threshold;
-  }
-
 private:
   /**
    * Given file name, populate metadata
@@ -106,9 +101,6 @@ private:
 
   /// Random device for crytpo random num generator.
   Crypto::CryptoRandomDevice m_randDevice;
-
-  // The threshold for using multi-parts downloading
-  long m_downloadSizeThreshold;
 };
 }
 }

--- a/cpp/FileMetadataInitializer.hpp
+++ b/cpp/FileMetadataInitializer.hpp
@@ -72,6 +72,11 @@ public:
     return m_randDevice;
   }
 
+  inline void setDownloadSizeThreshold(long threshold)
+  {
+    m_downloadSizeThreshold = threshold;
+  }
+
 private:
   /**
    * Given file name, populate metadata
@@ -101,6 +106,9 @@ private:
 
   /// Random device for crytpo random num generator.
   Crypto::CryptoRandomDevice m_randDevice;
+
+  // The threshold for using multi-parts downloading
+  long m_downloadSizeThreshold;
 };
 }
 }

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -156,12 +156,6 @@ void Snowflake::Client::FileTransferAgent::initFileMetadata(std::string *command
   m_FileMetadataInitializer.setSourceCompression(response.sourceCompression);
   m_FileMetadataInitializer.setEncryptionMaterials(&response.encryptionMaterials);
   m_FileMetadataInitializer.setRandomDev(m_useDevUrand);
-  if (m_transferConfig &&
-      (m_transferConfig->getSizeThreshold > DOWNLOAD_DATA_SIZE_THRESHOLD))
-  {
-    CXX_LOG_INFO("Set downloading threshold: %ld", m_transferConfig->getSizeThreshold);
-    m_FileMetadataInitializer.setDownloadSizeThreshold(m_transferConfig->getSizeThreshold);
-  }
 
   // Upload data from stream in memory
   if ((m_uploadStream) && (CommandType::UPLOAD == response.command))
@@ -203,10 +197,17 @@ void Snowflake::Client::FileTransferAgent::initFileMetadata(std::string *command
               response.presignedUrls.at(i) : "";
           EncryptionMaterial *encMat = (response.encryptionMaterials.size() > i) ?
                                  &response.encryptionMaterials.at(i) : NULL;
+          size_t getThreshold = DOWNLOAD_DATA_SIZE_THRESHOLD;
+          if (m_transferConfig &&
+            (m_transferConfig->getSizeThreshold > DOWNLOAD_DATA_SIZE_THRESHOLD))
+          {
+            CXX_LOG_INFO("Set downloading threshold: %ld", m_transferConfig->getSizeThreshold);
+            getThreshold = m_transferConfig->getSizeThreshold;
+          }
           RemoteStorageRequestOutcome outcome =
             m_FileMetadataInitializer.populateSrcLocDownloadMetadata(
               sourceLocations->at(i), &response.stageInfo.location,
-              m_storageClient, encMat, presignedUrl);
+              m_storageClient, encMat, presignedUrl, getThreshold);
 
           if (outcome == TOKEN_EXPIRED)
           {

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -156,6 +156,12 @@ void Snowflake::Client::FileTransferAgent::initFileMetadata(std::string *command
   m_FileMetadataInitializer.setSourceCompression(response.sourceCompression);
   m_FileMetadataInitializer.setEncryptionMaterials(&response.encryptionMaterials);
   m_FileMetadataInitializer.setRandomDev(m_useDevUrand);
+  if (m_transferConfig &&
+      (m_transferConfig->getSizeThreshold > DOWNLOAD_DATA_SIZE_THRESHOLD))
+  {
+    CXX_LOG_INFO("Set downloading threshold: %ld", m_transferConfig->getSizeThreshold);
+    m_FileMetadataInitializer.setDownloadSizeThreshold(m_transferConfig->getSizeThreshold);
+  }
 
   // Upload data from stream in memory
   if ((m_uploadStream) && (CommandType::UPLOAD == response.command))

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -233,7 +233,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::download(
   FileMetadata *fileMetadata,
   std::basic_iostream<char>* dataStream)
 {
-  if (fileMetadata->srcFileSize > DOWNLOAD_DATA_SIZE_THRESHOLD)
+  if (fileMetadata->isLarge)
     return doMultiPartDownload(fileMetadata, dataStream);
   else
     return doSingleDownload(fileMetadata, dataStream);

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -445,7 +445,7 @@ RemoteStorageRequestOutcome SnowflakeS3Client::download(
   FileMetadata *fileMetadata,
   std::basic_iostream<char>* dataStream)
 {
-  if (fileMetadata->srcFileSize > DOWNLOAD_DATA_SIZE_THRESHOLD)
+  if (fileMetadata->isLarge)
     return doMultiPartDownload(fileMetadata, dataStream);
   else
     return doSingleDownload(fileMetadata, dataStream);

--- a/include/snowflake/IFileTransferAgent.hpp
+++ b/include/snowflake/IFileTransferAgent.hpp
@@ -25,12 +25,14 @@ struct TransferConfig
     tempDir(NULL),
     useS3regionalUrl(false),
     compressLevel(-1),
-    proxy(NULL) {}
+    proxy(NULL),
+    getSizeThreshold(0) {}
   char * caBundleFile;
   char * tempDir;
   bool useS3regionalUrl;
   int compressLevel;
   Util::Proxy * proxy;
+  long getSizeThreshold;
 };
 
 class IFileTransferAgent

--- a/tests/test_unit_cred_renew.cpp
+++ b/tests/test_unit_cred_renew.cpp
@@ -342,6 +342,7 @@ void test_token_renew_large_file(void ** unused)
   }
   ofs.close();
   test_token_renew_core("large_file.csv");
+  std::remove(fullFileName.c_str());
 }
 
 void test_token_renew_get_remote_meta(void **unused)
@@ -455,7 +456,7 @@ int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_parse_exception),
     cmocka_unit_test(test_token_renew_small_files),
-    cmocka_unit_test_teardown(test_token_renew_large_file, large_file_removal),
+    cmocka_unit_test(test_token_renew_large_file),
     cmocka_unit_test(test_token_renew_get_remote_meta),
     cmocka_unit_test(test_transfer_exception_upload),
     cmocka_unit_test(test_transfer_exception_download)


### PR DESCRIPTION
Simba ticket 00389874

The downloaded file could be corrupted when using aws multi-parts downloading and getting retry-able error from server side during the process. The root cause likely to be inside AWS SDK, while in the customer case they have multiple files to download and disable multi-parts downloading could get better performance.
Provide a new configuration to allow changing the threshold of multi-parts downloading  (was hardcoded to 5MB before) from application.
Will add a new connection/configuration parameter on ODBC side so we can pass the setting from there.

Eventually will upgrade AWS SDK to latest version (currently it's 1.3.50 which was released 4 years ago) and see if that can fix the issue.