### PR TITLE
Put 2gb file

### DIFF
--- a/cpp/FileMetadata.hpp
+++ b/cpp/FileMetadata.hpp
@@ -44,19 +44,19 @@ struct FileMetadata
   std::string srcFileName;
 
   /// original source file size
-  long srcFileSize;
+  size_t srcFileSize;
 
   /// Temp file if compressed is required, otherwise same as src file
   std::string srcFileToUpload;
 
   /// Temp file size if compressed is required, otherwise same as src file
-  long srcFileToUploadSize;
+  size_t srcFileToUploadSize;
 
   /// destination file name (no path)
   std::string destFileName;
 
   /// destination file size
-  long destFileSize;
+  size_t destFileSize;
 
   /// Absolute path to the destination (including the filename. /tmp/small_test_file.csv.gz)
   std::string destPath;
@@ -111,7 +111,7 @@ struct FileMetadata
     auto putTime = std::chrono::duration_cast<std::chrono::milliseconds>(tstamps[PUT_END] - tstamps[PUT_START]).count();
     auto putgetTime = std::chrono::duration_cast<std::chrono::milliseconds>(tstamps[PUTGET_END] - tstamps[PUTGET_START]).count();
 
-    unsigned long fssize = (srcFileToUploadSize > 0)? srcFileToUploadSize : srcFileSize ;
+    size_t fssize = (srcFileToUploadSize > 0)? srcFileToUploadSize : srcFileSize ;
 
     CXX_LOG_DEBUG("Time took for compression: %ld milli seconds, srcFilename:%s, srcFileSize:%ld.",
         compTime, srcFileName.c_str(), srcFileSize );

--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -33,7 +33,7 @@ Snowflake::Client::FileMetadataInitializer::FileMetadataInitializer(
 
 void
 Snowflake::Client::FileMetadataInitializer::initUploadFileMetadata(const std::string &fileDir, const char *fileName,
-                                                                   long fileSize, size_t threshold)
+                                                                   size_t fileSize, size_t threshold)
 {
   std::string fileNameFull = fileDir;
   fileNameFull += fileName;
@@ -91,7 +91,7 @@ void Snowflake::Client::FileMetadataInitializer::populateSrcLocUploadMetadata(st
         LARGE_INTEGER fileSize;
         fileSize.LowPart = fdd.nFileSizeLow;
         fileSize.HighPart = fdd.nFileSizeHigh;
-        initUploadFileMetadata(dirPath, (char *)fdd.cFileName, (long)fileSize.QuadPart, putThreshold);
+        initUploadFileMetadata(dirPath, (char *)fdd.cFileName, (size_t)fileSize.QuadPart, putThreshold);
       }
     }
   } while (FindNextFile(hFind, &fdd) != 0);
@@ -125,7 +125,7 @@ void Snowflake::Client::FileMetadataInitializer::populateSrcLocUploadMetadata(st
         {
           if (S_ISREG(fileStatus.st_mode)) {
             initUploadFileMetadata(dirPath, dir_entry->d_name,
-                                   (long) fileStatus.st_size, putThreshold);
+                                   (size_t) fileStatus.st_size, putThreshold);
           }
         }
         else
@@ -215,7 +215,7 @@ void Snowflake::Client::FileMetadataInitializer::initEncryptionMetadata(
   if (m_encMat->empty())
   {
     // No encryption materials for server side encryption
-    fileMetadata->encryptionMetadata.cipherStreamSize = fileMetadata->srcFileToUploadSize;
+    fileMetadata->encryptionMetadata.cipherStreamSize = (long long)fileMetadata->srcFileToUploadSize;
     fileMetadata->destFileSize = fileMetadata->srcFileToUploadSize;
     fileMetadata->encryptionMetadata.fileKey.nbBits = 0;
     return;
@@ -234,7 +234,7 @@ void Snowflake::Client::FileMetadataInitializer::initEncryptionMetadata(
   fileMetadata->encryptionMetadata.cipherStreamSize = (long long int)
     ((fileMetadata->srcFileToUploadSize + encryptionBlockSize) /
     encryptionBlockSize * encryptionBlockSize);
-  fileMetadata->destFileSize = (long)(fileMetadata->encryptionMetadata.cipherStreamSize);
+  fileMetadata->destFileSize = (size_t)(fileMetadata->encryptionMetadata.cipherStreamSize);
 }
 
 Snowflake::Client::RemoteStorageRequestOutcome

--- a/cpp/FileMetadataInitializer.hpp
+++ b/cpp/FileMetadataInitializer.hpp
@@ -77,7 +77,7 @@ private:
    * Given file name, populate metadata
    * @param fileName
    */
-  void initUploadFileMetadata(const std::string &fileDir, const char *fileName, long fileSize, size_t threshold);
+  void initUploadFileMetadata(const std::string &fileDir, const char *fileName, size_t fileSize, size_t threshold);
 
   /**
    * init compression metadata

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -136,7 +136,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::doSingleUpload(FileMetadata *f
   std::vector<std::pair<std::string, std::string>> userMetadata;
   addUserMetadata(&userMetadata, fileMetadata);
   //Calculate the length of the stream.
-  unsigned int len = (unsigned int) ((fileMetadata->encryptionMetadata.cipherStreamSize > 0) ? fileMetadata->encryptionMetadata.cipherStreamSize: fileMetadata->srcFileToUploadSize) ;
+  size_t len = (size_t) ((fileMetadata->encryptionMetadata.cipherStreamSize > 0) ? fileMetadata->encryptionMetadata.cipherStreamSize: fileMetadata->srcFileToUploadSize) ;
 
   //Azure does not provide to SHA256 or MD5 or checksum check of a file to check if it already exists.
   //Do not check if file exists if overwrite is specified.
@@ -182,7 +182,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::doMultiPartUpload(FileMetadata
     std::vector<std::pair<std::string, std::string>> userMetadata;
     addUserMetadata(&userMetadata, fileMetadata);
     //Calculate the length of the stream.
-    unsigned int len = (unsigned int) ((fileMetadata->encryptionMetadata.cipherStreamSize > 0) ? fileMetadata->encryptionMetadata.cipherStreamSize: fileMetadata->srcFileToUploadSize) ;
+    size_t len = (size_t) ((fileMetadata->encryptionMetadata.cipherStreamSize > 0) ? fileMetadata->encryptionMetadata.cipherStreamSize: fileMetadata->srcFileToUploadSize) ;
     if(! fileMetadata->overWrite ) {
         //Azure does not provide to SHA256 or MD5 or checksum check of a file to check if it already exists.
         bool exists = m_blobclient->blob_exists(containerName, blobName);
@@ -257,7 +257,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::doMultiPartDownload(
     //To fetch size of file.
     auto blobprop = m_blobclient->get_blob_property(cont, blob);
     std::string origEtag = blobprop.etag ;
-    fileMetadata->srcFileSize = (long)blobprop.size;
+    fileMetadata->srcFileSize = (size_t)blobprop.size;
     unsigned int partNum = (unsigned int)(fileMetadata->srcFileSize / DOWNLOAD_DATA_SIZE_THRESHOLD) + 1;
 
     Util::StreamAppender appender(dataStream, partNum, m_parallel, DOWNLOAD_DATA_SIZE_THRESHOLD);
@@ -277,7 +277,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::doMultiPartDownload(
 
             int partSize = ctx.m_partNumber == partNum - 1 ?
                            (int)(fileMetadata->srcFileSize -
-                                 ctx.m_partNumber * DOWNLOAD_DATA_SIZE_THRESHOLD)
+                                 (size_t)ctx.m_partNumber * DOWNLOAD_DATA_SIZE_THRESHOLD)
                                                            : DOWNLOAD_DATA_SIZE_THRESHOLD;
             Util::ByteArrayStreamBuf * buf = appender.GetBuffer(
                     m_threadPool->GetThreadIdx());
@@ -350,7 +350,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::GetRemoteFileMetadata(
     auto blobProperty = m_blobclient->get_blob_property(cont, blob  );
     if(blobProperty.valid()) {
         std::string encHdr = blobProperty.metadata[0].second;
-        fileMetadata->srcFileSize = (long)blobProperty.size;
+        fileMetadata->srcFileSize = (size_t)blobProperty.size;
         encHdr.erase(remove(encHdr.begin(), encHdr.end(), ' '), encHdr.end());  //Remove spaces from the string.
 
         std::size_t pos1 = encHdr.find("EncryptedKey")  + strlen("EncryptedKey") + 3;
@@ -370,7 +370,7 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::GetRemoteFileMetadata(
         }
 
         fileMetadata->encryptionMetadata.cipherStreamSize = blobProperty.size;
-        fileMetadata->srcFileSize = (long)blobProperty.size;
+        fileMetadata->srcFileSize = (size_t)blobProperty.size;
 
         return RemoteStorageRequestOutcome::SUCCESS;
     }

--- a/cpp/SnowflakeGCSClient.cpp
+++ b/cpp/SnowflakeGCSClient.cpp
@@ -106,7 +106,7 @@ RemoteStorageRequestOutcome SnowflakeGCSClient::GetRemoteFileMetadata(
                        fileMetadata->encryptionMetadata.iv.data);
   fileMetadata->encryptionMetadata.enKekEncoded = key;
 
-  fileMetadata->srcFileSize = strtol(headers["Content-Length"].c_str(), NULL, 10);
+  fileMetadata->srcFileSize = strtoull(headers["Content-Length"].c_str(), NULL, 10);
 
   return RemoteStorageRequestOutcome::SUCCESS;
 }

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -471,7 +471,7 @@ RemoteStorageRequestOutcome SnowflakeS3Client::doMultiPartDownload(
 
   Util::StreamAppender appender(dataStream, partNum, m_parallel, DOWNLOAD_DATA_SIZE_THRESHOLD);
   std::vector<MultiDownloadCtx> downloadParts;
-  for (unsigned int i = 0; i < partNum; i++)
+  for (size_t i = 0; i < partNum; i++)
   {
     std::stringstream rangeStream;
     rangeStream << "bytes=" << i * DOWNLOAD_DATA_SIZE_THRESHOLD << '-' <<
@@ -493,7 +493,7 @@ RemoteStorageRequestOutcome SnowflakeS3Client::doMultiPartDownload(
     m_threadPool->AddJob([&]()-> void {
       int partSize = ctx.m_partNumber == partNum - 1 ?
                      (int)(fileMetadata->srcFileSize -
-                       ctx.m_partNumber * DOWNLOAD_DATA_SIZE_THRESHOLD)
+                       (size_t)ctx.m_partNumber * DOWNLOAD_DATA_SIZE_THRESHOLD)
                      : DOWNLOAD_DATA_SIZE_THRESHOLD;
       Util::ByteArrayStreamBuf * buf = appender.GetBuffer(
         m_threadPool->GetThreadIdx());
@@ -587,7 +587,7 @@ RemoteStorageRequestOutcome SnowflakeS3Client::GetRemoteFileMetadata(
 
   if (outcome.IsSuccess())
   {
-    fileMetadata->srcFileSize = (long)outcome.GetResult().GetContentLength();
+    fileMetadata->srcFileSize = (size_t)outcome.GetResult().GetContentLength();
     CXX_LOG_INFO("Remote file %s content length: %ld.",
                   key.c_str(), fileMetadata->srcFileSize);
 

--- a/cpp/util/CompressionUtil.cpp
+++ b/cpp/util/CompressionUtil.cpp
@@ -22,7 +22,7 @@
 
 int Snowflake::Client::Util::CompressionUtil::compressWithGzip(FILE *source,
                                                                FILE *dest,
-                                                               long &destSize,
+                                                               size_t &destSize,
                                                                int level)
 {
   SET_BINARY_MODE(source);

--- a/cpp/util/CompressionUtil.hpp
+++ b/cpp/util/CompressionUtil.hpp
@@ -25,7 +25,7 @@ public:
    * @param level compression level
    * @return
    */
-  static int compressWithGzip(FILE *source, FILE *dest, long &destSize, int level = -1);
+  static int compressWithGzip(FILE *source, FILE *dest, size_t &destSize, int level = -1);
 
   /**
    * Compress file with gzip

--- a/scripts/build_azuresdk.bat
+++ b/scripts/build_azuresdk.bat
@@ -2,7 +2,7 @@
 :: Build Azure cpp storage light sdk
 ::
 @echo off
-set azure_version=0.1.20
+set azure_version=1.20
 call %*
 goto :EOF
 

--- a/scripts/build_azuresdk.bat
+++ b/scripts/build_azuresdk.bat
@@ -2,7 +2,7 @@
 :: Build Azure cpp storage light sdk
 ::
 @echo off
-set azure_version=1.20
+set azure_version=0.1.20
 call %*
 goto :EOF
 

--- a/scripts/build_azuresdk.bat
+++ b/scripts/build_azuresdk.bat
@@ -2,7 +2,7 @@
 :: Build Azure cpp storage light sdk
 ::
 @echo off
-set azure_version=0.1.19
+set azure_version=0.1.20
 call %*
 goto :EOF
 

--- a/scripts/build_azuresdk.sh
+++ b/scripts/build_azuresdk.sh
@@ -10,7 +10,7 @@ function usage() {
 }
 set -o pipefail
 
-AZURE_VERSION=1.20
+AZURE_VERSION=0.1.20
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh $@

--- a/scripts/build_azuresdk.sh
+++ b/scripts/build_azuresdk.sh
@@ -10,7 +10,7 @@ function usage() {
 }
 set -o pipefail
 
-AZURE_VERSION=0.1.19
+AZURE_VERSION=0.1.20
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh $@

--- a/scripts/build_azuresdk.sh
+++ b/scripts/build_azuresdk.sh
@@ -10,7 +10,7 @@ function usage() {
 }
 set -o pipefail
 
-AZURE_VERSION=0.1.20
+AZURE_VERSION=1.20
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh $@

--- a/tests/test_unit_put_fast_fail.cpp
+++ b/tests/test_unit_put_fast_fail.cpp
@@ -197,7 +197,7 @@ public:
   virtual RemoteStorageRequestOutcome GetRemoteFileMetadata(
     std::string * filePathFull, FileMetadata *fileMetadata)
   {
-    fileMetadata->srcFileSize = filesize;
+    fileMetadata->srcFileSize = (size_t)filesize;
     std::string iv = "fDnCvS9AFFdXnyM9bsEXcA==";
     Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->
                          encryptionMetadata.iv.data);


### PR DESCRIPTION
Simba ticket 00390901
Put command failed when file size is larger than 2GB.
Root cause: There are several places in libsnowflakeclient using long type variables for file size/offset, while long is 4 bytes on Windows and could cause data overflow when file size is larger than 2GB.
