### PR TITLE
fix downloading issue on network retry with aws

### DIFF
--- a/cpp/util/ByteArrayStreamBuf.cpp
+++ b/cpp/util/ByteArrayStreamBuf.cpp
@@ -21,6 +21,13 @@ Snowflake::Client::Util::ByteArrayStreamBuf::~ByteArrayStreamBuf()
   delete[] m_dataBuffer;
 }
 
+void Snowflake::Client::Util::ByteArrayStreamBuf::reset()
+{
+  memset(m_dataBuffer, 0, m_capacity);
+  setg(m_dataBuffer, m_dataBuffer, m_dataBuffer + m_capacity);
+  setp(m_dataBuffer, m_dataBuffer + m_capacity);
+}
+
 void * Snowflake::Client::Util::ByteArrayStreamBuf::updateSize(
   long updatedSize)
 {

--- a/cpp/util/ByteArrayStreamBuf.hpp
+++ b/cpp/util/ByteArrayStreamBuf.hpp
@@ -40,6 +40,8 @@ public:
 
   void * updateSize(long updatedSize);
 
+  void reset();
+
   inline long getSize()
   {
     return size;


### PR DESCRIPTION
Simba ticket 00389874
Fix the root cause of corrupted file with aws downloading
I thought it was aws sdk issue so made workaround in https://github.com/snowflakedb/libsnowflakeclient/pull/466
Tried fix it with updating aws sdk https://github.com/snowflakedb/libsnowflakeclient/pull/478 but the issue still there.
The root cause:
The driver provide response stream factory to aws sdk, and aws sdk expects it to return clean stream each time while the driver actually just return the same stream. When network retry occurs, the data from last failed attempt left over and make the data corrupted.
Add test cases to cover both single downloading and multi-parts downloading. It might not hit the network retry every time but could cover it sometime.
Tested locally to cut off network during the test and then resume, reproduced the corrupted files without the fix and worked fine with the fix.