### PR TITLE
support proxy settings in connection attributes

### DIFF
--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -67,7 +67,6 @@ Snowflake::Client::FileTransferAgent::FileTransferAgent(
   m_executionResults(nullptr),
   m_storageClient(nullptr),
   m_lastRefreshTokenSec(0),
-  m_transferConfig(transferConfig),
   m_uploadStream(nullptr),
   m_uploadStreamSize(0),
   m_useDevUrand(false),
@@ -77,6 +76,14 @@ Snowflake::Client::FileTransferAgent::FileTransferAgent(
   m_getFastFail(false)
 {
   _mutex_init(&m_parallelTokRenewMutex);
+  if (transferConfig)
+  {
+    m_transferConfig = *transferConfig;
+  }
+  if (!m_transferConfig.proxy)
+  {
+    m_transferConfig.proxy = m_stmtPutGet->get_proxy();
+  }
 }
 
 Snowflake::Client::FileTransferAgent::~FileTransferAgent()
@@ -121,7 +128,7 @@ Snowflake::Client::FileTransferAgent::execute(string *command)
   m_storageClient = StorageClientFactory::getClient(&response.stageInfo,
                                                     (unsigned int) response.parallel,
                                                     response.threshold,
-                                                    m_transferConfig,
+                                                    &m_transferConfig,
                                                     m_stmtPutGet);
 
   // init file metadata
@@ -198,11 +205,10 @@ void Snowflake::Client::FileTransferAgent::initFileMetadata(std::string *command
           EncryptionMaterial *encMat = (response.encryptionMaterials.size() > i) ?
                                  &response.encryptionMaterials.at(i) : NULL;
           size_t getThreshold = DOWNLOAD_DATA_SIZE_THRESHOLD;
-          if (m_transferConfig &&
-            (m_transferConfig->getSizeThreshold > DOWNLOAD_DATA_SIZE_THRESHOLD))
+          if (m_transferConfig.getSizeThreshold > DOWNLOAD_DATA_SIZE_THRESHOLD)
           {
-            CXX_LOG_INFO("Set downloading threshold: %ld", m_transferConfig->getSizeThreshold);
-            getThreshold = m_transferConfig->getSizeThreshold;
+            CXX_LOG_INFO("Set downloading threshold: %ld", m_transferConfig.getSizeThreshold);
+            getThreshold = m_transferConfig.getSizeThreshold;
           }
           RemoteStorageRequestOutcome outcome =
             m_FileMetadataInitializer.populateSrcLocDownloadMetadata(
@@ -442,7 +448,7 @@ void Snowflake::Client::FileTransferAgent::renewToken(std::string *command)
     m_storageClient = StorageClientFactory::getClient(&response.stageInfo,
                                                       (unsigned int) response.parallel,
                                                       response.threshold,
-                                                      m_transferConfig);
+                                                      &m_transferConfig);
     m_lastRefreshTokenSec = now;
   }
 }
@@ -591,14 +597,10 @@ void Snowflake::Client::FileTransferAgent::compressSourceFile(
   CXX_LOG_DEBUG("Starting file compression");
   
   char tempDir[MAX_PATH]={0};
-  int level = -1;
-  if (m_transferConfig)
+  int level = m_transferConfig.compressLevel;
+  if (m_transferConfig.tempDir)
   {
-    level = m_transferConfig->compressLevel;
-    if (m_transferConfig->tempDir)
-    {
-      sb_strcat(tempDir, sizeof(tempDir), m_transferConfig->tempDir);
-    }
+    sb_strcat(tempDir, sizeof(tempDir), m_transferConfig.tempDir);
   }
   sf_get_uniq_tmp_dir(tempDir);
   // tempDir could be passed in from application. Check if the folder can be

--- a/cpp/FileTransferAgent.hpp
+++ b/cpp/FileTransferAgent.hpp
@@ -311,7 +311,7 @@ private:
   long m_lastRefreshTokenSec;
 
   /// config struct that is passed in.
-  TransferConfig * m_transferConfig;
+  TransferConfig m_transferConfig;
 
   /// The stream for uploading data from memory. (NOT OWN)
   std::basic_iostream<char>* m_uploadStream;

--- a/cpp/FileTransferAgent.hpp
+++ b/cpp/FileTransferAgent.hpp
@@ -311,7 +311,7 @@ private:
   long m_lastRefreshTokenSec;
 
   /// config struct that is passed in.
-  TransferConfig m_transferConfig;
+  TransferConfig * m_transferConfig;
 
   /// The stream for uploading data from memory. (NOT OWN)
   std::basic_iostream<char>* m_uploadStream;

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -31,7 +31,8 @@ namespace Client
 SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
                                            unsigned int parallel,
                                            size_t uploadThreshold,
-                                           TransferConfig *transferConfig) :
+                                           TransferConfig *transferConfig,
+                                           IStatementPutGet* statement) :
   m_stageInfo(stageInfo),
   m_threadPool(nullptr),
   m_uploadThreshold(uploadThreshold),
@@ -77,14 +78,22 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
   std::shared_ptr<azure::storage_lite::storage_credential>  cred = std::make_shared<azure::storage_lite::shared_access_signature_credential>(sas_key);
   std::shared_ptr<azure::storage_lite::storage_account> account = std::make_shared<azure::storage_lite::storage_account>(account_name, cred, true, endpoint);
   std::shared_ptr<azure::storage_lite::blob_client> bc;
-  if(transferConfig && transferConfig->proxy) {
+
+  Util::Proxy * proxy;
+  if (transferConfig && transferConfig->proxy) {
+    proxy = transferConfig->proxy;
+  }
+  else {
+    proxy = statement->get_proxy();
+  }
+  if (proxy) {
     bc = std::make_shared<azure::storage_lite::blob_client>(
                 account, m_parallel, caBundleFile,
-                transferConfig->proxy->getHost(),
-                transferConfig->proxy->getPort(),
-                transferConfig->proxy->getUser(),
-                transferConfig->proxy->getPwd(),
-                transferConfig->proxy->getNoProxy());
+                proxy->getHost(),
+                proxy->getPort(),
+                proxy->getUser(),
+                proxy->getPwd(),
+                proxy->getNoProxy());
   }
   else
   {

--- a/cpp/SnowflakeAzureClient.hpp
+++ b/cpp/SnowflakeAzureClient.hpp
@@ -75,7 +75,7 @@ class SnowflakeAzureClient : public Snowflake::Client::IStorageClient
 {
 public:
   SnowflakeAzureClient(StageInfo *stageInfo, unsigned int parallel, size_t uploadThreshold,
-                       TransferConfig *transferConfig);
+                       TransferConfig *transferConfig, IStatementPutGet* statement);
 
   ~SnowflakeAzureClient();
 

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -70,7 +70,8 @@ namespace Client
 SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
                                      unsigned int parallel,
                                      size_t uploadThreshold,
-                                     TransferConfig *transferConfig) :
+                                     TransferConfig *transferConfig,
+                                     IStatementPutGet* statement) :
   m_stageInfo(stageInfo),
   m_threadPool(nullptr),
   m_uploadThreshold(uploadThreshold),
@@ -122,6 +123,10 @@ SnowflakeS3Client::SnowflakeS3Client(StageInfo *stageInfo,
   if ((transferConfig != nullptr) && (transferConfig->proxy != nullptr))
   {
     proxy = *(transferConfig->proxy);
+  }
+  else if (statement->get_proxy())
+  {
+    proxy = *(statement->get_proxy());
   }
   else
   {

--- a/cpp/SnowflakeS3Client.hpp
+++ b/cpp/SnowflakeS3Client.hpp
@@ -90,7 +90,8 @@ public:
   SnowflakeS3Client(StageInfo *stageInfo,
                     unsigned int parallel,
                     size_t uploadThreshold,
-                    TransferConfig *transferConfig);
+                    TransferConfig *transferConfig,
+                    IStatementPutGet* statement);
 
   ~SnowflakeS3Client();
 

--- a/cpp/StatementPutGet.cpp
+++ b/cpp/StatementPutGet.cpp
@@ -9,8 +9,17 @@
 using namespace Snowflake::Client;
 
 StatementPutGet::StatementPutGet(SF_STMT *stmt) :
-  m_stmt(stmt)
+  m_stmt(stmt), m_useProxy(false)
 {
+  if (m_stmt && m_stmt->connection && m_stmt->connection->proxy)
+  {
+    m_useProxy = true;
+    m_proxy = Util::Proxy(std::string(m_stmt->connection->proxy));
+    if (m_stmt->connection->no_proxy)
+    {
+      m_proxy.setNoProxy(std::string(m_stmt->connection->no_proxy));
+    }
+  }
 }
 
 bool StatementPutGet::parsePutGetCommand(std::string *sql,
@@ -101,4 +110,16 @@ bool StatementPutGet::parsePutGetCommand(std::string *sql,
     putGetParseResponse->stageInfo.stageType = StageType::LOCAL_FS;
   }
   return true;
+}
+
+Util::Proxy* StatementPutGet::get_proxy()
+{
+  if (!m_useProxy)
+  {
+    return NULL;
+  }
+  else
+  {
+    return &m_proxy;
+  }
 }

--- a/cpp/StatementPutGet.hpp
+++ b/cpp/StatementPutGet.hpp
@@ -26,8 +26,12 @@ public:
   virtual bool parsePutGetCommand(std::string *sql,
                                   PutGetParseResponse *putGetParseResponse);
 
+  virtual Util::Proxy* get_proxy() override;
+
 private:
   SF_STMT *m_stmt;
+  Util::Proxy m_proxy;
+  bool m_useProxy;
 };
 }
 }

--- a/cpp/StorageClientFactory.cpp
+++ b/cpp/StorageClientFactory.cpp
@@ -26,12 +26,12 @@ IStorageClient * StorageClientFactory::getClient(StageInfo *stageInfo,
   {
     case StageType::S3:
       CXX_LOG_INFO("Creating S3 client");
-      return new SnowflakeS3Client(stageInfo, parallel, uploadThreshold, transferConfig);
+      return new SnowflakeS3Client(stageInfo, parallel, uploadThreshold, transferConfig, statement);
     case StageType::MOCKED_STAGE_TYPE:
       return injectedClient;
     case StageType::AZURE:
       CXX_LOG_INFO("Creating Azure client");
-      return new SnowflakeAzureClient(stageInfo, parallel, uploadThreshold, transferConfig);
+      return new SnowflakeAzureClient(stageInfo, parallel, uploadThreshold, transferConfig, statement);
     case StageType::GCS:
       CXX_LOG_INFO("Creating GCS client");
       return new SnowflakeGCSClient(stageInfo, parallel, transferConfig, statement);

--- a/include/snowflake/IStatementPutGet.hpp
+++ b/include/snowflake/IStatementPutGet.hpp
@@ -6,6 +6,7 @@
 #define SNOWFLAKECLIENT_ISTATEMENT_HPP
 
 #include "PutGetParseResponse.hpp"
+#include "Proxy.hpp"
 #include <iostream>
 
 namespace Snowflake
@@ -69,6 +70,11 @@ public:
                         bool headerOnly)
   {
     return false;
+  }
+
+  virtual Util::Proxy* get_proxy()
+  {
+    return NULL;
   }
 
   virtual ~IStatementPutGet()

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -230,6 +230,8 @@ typedef enum SF_ATTRIBUTE {
     SF_CON_JWT_TIMEOUT,
     SF_CON_JWT_CNXN_WAIT_TIME,
     SF_CON_MAX_CON_RETRY,
+    SF_CON_PROXY,
+    SF_CON_NO_PROXY,
     SF_DIR_QUERY_URL,
     SF_DIR_QUERY_URL_PARAM,
     SF_DIR_QUERY_TOKEN,
@@ -311,6 +313,10 @@ typedef struct SF_CONNECT {
 
     // Partner application name
     char * application;
+
+    // Proxy
+    char * proxy;
+    char * no_proxy;
 
     // Session info
     char *token;

--- a/lib/chunk_downloader.h
+++ b/lib/chunk_downloader.h
@@ -65,6 +65,10 @@ struct SF_CHUNK_DOWNLOADER {
 
     // callback function to create non-json response buffer. Json format will be used if this is set to NULL.
     NON_JSON_RESP* (*callback_create_resp)(void);
+
+    // proxy settings
+    char *proxy;
+    char *no_proxy;
 };
 
 SF_CHUNK_DOWNLOADER *STDCALL chunk_downloader_init(const char *qrmk,
@@ -74,7 +78,9 @@ SF_CHUNK_DOWNLOADER *STDCALL chunk_downloader_init(const char *qrmk,
                                                    uint64 fetch_slots,
                                                    SF_ERROR_STRUCT *sf_error,
                                                    sf_bool insecure_mode,
-                                                   NON_JSON_RESP* (*callback_create_resp)(void));
+                                                   NON_JSON_RESP* (*callback_create_resp)(void),
+                                                   const char *proxy,
+                                                   const char *no_proxy);
 sf_bool STDCALL chunk_downloader_term(SF_CHUNK_DOWNLOADER *chunk_downloader);
 sf_bool STDCALL get_shutdown_or_error(SF_CHUNK_DOWNLOADER *chunk_downloader);
 sf_bool STDCALL get_shutdown(SF_CHUNK_DOWNLOADER *chunk_downloader);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -336,7 +336,8 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
                           sf->insecure_mode,
                           sf->retry_on_curle_couldnt_connect_count,
                           renew_timeout, retry_max_count, elapsed_time,
-                          retried_count, is_renew, renew_injection) ||
+                          retried_count, is_renew, renew_injection,
+                          sf->proxy, sf->no_proxy) ||
             !*json) {
             // Error is set in the perform function
             break;
@@ -460,7 +461,8 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
                           sf->network_timeout, SF_BOOLEAN_FALSE, error,
                           sf->insecure_mode,
                           sf->retry_on_curle_couldnt_connect_count,
-                          0, 0, NULL, NULL, NULL, SF_BOOLEAN_FALSE) ||
+                          0, 0, NULL, NULL, NULL, SF_BOOLEAN_FALSE,
+                          sf->proxy, sf->no_proxy) ||
             !*json) {
             // Error is set in the perform function
             break;

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -425,6 +425,8 @@ size_t json_resp_cb(char *data, size_t size, size_t nmemb, RAW_JSON_BUFFER *raw_
  * @param is_renew        The output paramter to indecate whether http_perform()
  *                        returns due to renew timeout.
  * @param renew_injection For test purpose, forcely trigger the autentication renew.
+ * @param proxy           proxy setting
+ * @param no_proxy        exclusion of proxy
  *
  * @return Success/failure status of http request call. 1 = Success; 0 = Failure/renew timeout
  */
@@ -434,7 +436,8 @@ sf_bool STDCALL http_perform(CURL *curl, SF_REQUEST_TYPE request_type, char *url
                              int8 retry_on_curle_couldnt_connect_count,
                              int64 renew_timeout, int8 retry_max_count,
                              int64 *elapsed_time, int8 *retried_count,
-                             sf_bool *is_renew, sf_bool renew_injection);
+                             sf_bool *is_renew, sf_bool renew_injection,
+                             char *proxy, char *no_proxy);
 
 /**
  * Returns true if HTTP code is retryable, false otherwise.
@@ -538,6 +541,16 @@ sf_bool STDCALL set_tokens(SF_CONNECT *sf, cJSON *data, const char *session_toke
 SF_HEADER* STDCALL sf_header_create();
 
 void STDCALL sf_header_destroy(SF_HEADER *sf_header);
+
+/**
+* Set proxy settings to curl instance.
+*
+* @param curl The curl instance.
+* @param proxy The proxy setting.
+* @param no_proxy The no proxy setting.
+* @return CURLE_OK if success, curl error code otherwise.
+*/
+CURLcode set_curl_proxy(CURL *curl, const char* proxy, const char* no_proxy);
 
 #ifdef __cplusplus
 }

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -437,7 +437,7 @@ sf_bool STDCALL http_perform(CURL *curl, SF_REQUEST_TYPE request_type, char *url
                              int64 renew_timeout, int8 retry_max_count,
                              int64 *elapsed_time, int8 *retried_count,
                              sf_bool *is_renew, sf_bool renew_injection,
-                             char *proxy, char *no_proxy);
+                             const char *proxy, const char *no_proxy);
 
 /**
  * Returns true if HTTP code is retryable, false otherwise.

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -157,7 +157,9 @@ sf_bool STDCALL http_perform(CURL *curl,
                              int64 *elapsed_time,
                              int8 *retried_count,
                              sf_bool *is_renew,
-                             sf_bool renew_injection) {
+                             sf_bool renew_injection,
+                             char *proxy,
+                             char *no_proxy) {
     CURLcode res;
     sf_bool ret = SF_BOOLEAN_FALSE;
     sf_bool retry = SF_BOOLEAN_FALSE;
@@ -238,6 +240,13 @@ sf_bool STDCALL http_perform(CURL *curl,
                 log_error("Failed to set header [%s]", curl_easy_strerror(res));
                 break;
             }
+        }
+
+        // Set proxy
+        res = set_curl_proxy(curl, proxy, no_proxy);
+        if (res != CURLE_OK) {
+          log_error("Failed to set proxy [%s]", curl_easy_strerror(res));
+          break;
         }
 
         // Post type stuffs

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -158,8 +158,8 @@ sf_bool STDCALL http_perform(CURL *curl,
                              int8 *retried_count,
                              sf_bool *is_renew,
                              sf_bool renew_injection,
-                             char *proxy,
-                             char *no_proxy) {
+                             const char *proxy,
+                             const char *no_proxy) {
     CURLcode res;
     sf_bool ret = SF_BOOLEAN_FALSE;
     sf_bool retry = SF_BOOLEAN_FALSE;

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -72,6 +72,57 @@ void test_connect_with_full_parameters(void **unused) {
     snowflake_term(sf); // purge snowflake context
 }
 
+/**
+* Test connection with proxy parameter
+* We don't really test with proxy because that would need a proxy server to be
+* available in the test environment. Instead, set invalid proxy in environment
+* variables and disable the proxy through proxy parameter to ensure the settings
+* in parameter are being used.
+*/
+void test_connect_with_proxy(void **unused) {
+  if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
+    sf_getenv("http_proxy"))
+  {
+    // skip the test if the test evironment uses proxy already
+    return;
+  }
+
+  // set invalid proxy in environment variables
+  sf_setenv("https_proxy", "a.b.c");
+  sf_setenv("http_proxy", "a.b.c");
+  sf_unsetenv("no_proxy");
+  SF_CONNECT *sf = setup_snowflake_connection();
+
+  // ensure the connection fails with invalid proxy
+  SF_STATUS status = snowflake_connect(sf);
+  assert_int_not_equal(status, SF_STATUS_SUCCESS); // must fail
+  snowflake_term(sf);
+
+  // test proxy setting
+  sf = setup_snowflake_connection();
+  snowflake_set_attribute(sf, SF_CON_PROXY, "");
+  status = snowflake_connect(sf);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sf->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+  snowflake_term(sf);
+
+  // test no proxy setting
+  sf = setup_snowflake_connection();
+  snowflake_set_attribute(sf, SF_CON_PROXY, "a.b.c");
+  snowflake_set_attribute(sf, SF_CON_NO_PROXY, "*");
+  status = snowflake_connect(sf);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sf->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+  snowflake_term(sf);
+
+  sf_unsetenv("https_proxy");
+  sf_unsetenv("http_proxy");
+}
+
 int main(void) {
     initialize_test(SF_BOOLEAN_FALSE);
     const struct CMUnitTest tests[] = {
@@ -79,6 +130,7 @@ int main(void) {
       cmocka_unit_test(test_no_connection_parameters),
       cmocka_unit_test(test_connect_with_minimum_parameters),
       cmocka_unit_test(test_connect_with_full_parameters),
+      cmocka_unit_test(test_connect_with_proxy),
     };
     int ret = cmocka_run_group_tests(tests, NULL, NULL);
     snowflake_global_term();


### PR DESCRIPTION
Simba ticket 00402653
Support connection individual proxy settings for PHP connector.
Since PHP is using libsnowflakeclient we need to implement that in libsnowflakeclient first.