### PR TITLE
key pair auth bug fix

### DIFF
--- a/cpp/lib/Authenticator.cpp
+++ b/cpp/lib/Authenticator.cpp
@@ -121,7 +121,7 @@ extern "C" {
     return SF_STATUS_SUCCESS;
   }
 
-  void auth_update_json(SF_CONNECT * conn, cJSON* body)
+  void auth_update_json_body(SF_CONNECT * conn, cJSON* body)
   {
     if (!conn || !conn->auth_object)
     {
@@ -141,7 +141,7 @@ extern "C" {
     return;
   }
 
-  void auth_renew_json(SF_CONNECT * conn, cJSON* body)
+  void auth_renew_json_body(SF_CONNECT * conn, cJSON* body)
   {
     if (!conn || !conn->auth_object)
     {

--- a/lib/authenticator.h
+++ b/lib/authenticator.h
@@ -67,7 +67,7 @@ typedef enum authenticator_type
      * @param conn                 The connection
      * @param body                 The json body for connection request
      */
-    void auth_update_json(SF_CONNECT * conn, cJSON* body);
+    void auth_update_json_body(SF_CONNECT * conn, cJSON* body);
 
     /**
      * renew autentication information in json body when renew timeout reached
@@ -75,7 +75,7 @@ typedef enum authenticator_type
      * @param conn                 The connection
      * @param body                 The json body for connection request
      */
-    void auth_renew_json(SF_CONNECT * conn, cJSON* body);
+    void auth_renew_json_body(SF_CONNECT * conn, cJSON* body);
 
     /**
     * Terminate authenticator

--- a/lib/client.c
+++ b/lib/client.c
@@ -902,7 +902,8 @@ SF_STATUS STDCALL snowflake_connect(SF_CONNECT *sf) {
             }
         } else {
             if (is_renew && (renew_timeout > 0)) {
-                auth_renew_json(sf, body);
+                // renew authentication information in body
+                auth_renew_json_body(sf, body);
                 s_body = snowflake_cJSON_Print(body);
                 continue;
             }

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -181,7 +181,7 @@ cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
     snowflake_cJSON_AddItemToObject(body, "data", data);
 
     // update authentication information
-    auth_update_json(sf, data);
+    auth_update_json(sf, body);
 
     return body;
 }

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -180,8 +180,8 @@ cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
     body = snowflake_cJSON_CreateObject();
     snowflake_cJSON_AddItemToObject(body, "data", data);
 
-    // update authentication information
-    auth_update_json(sf, body);
+    // update authentication information to body
+    auth_update_json_body(sf, body);
 
     return body;
 }

--- a/tests/test_jwt.cpp
+++ b/tests/test_jwt.cpp
@@ -202,6 +202,8 @@ void test_unencrypted_pem(void **unused) {
 
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
+  // explicitly unset password to esure we are using key pair auth
+  snowflake_set_attribute(sf, SF_CON_PASSWORD, "");
 
   SF_STATUS status = snowflake_connect(sf);
   if (status != SF_STATUS_SUCCESS) {
@@ -227,6 +229,8 @@ void test_encrypted_pem(void **unused) {
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE_PWD, "test");
+  // explicitly unset password to esure we are using key pair auth
+  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   SF_STATUS status = snowflake_connect(sf);
   if (status != SF_STATUS_SUCCESS) {
@@ -238,6 +242,8 @@ void test_encrypted_pem(void **unused) {
   sf = setup_snowflake_connection();
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
+  // explicitly unset password to esure we are using key pair auth
+  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   status = snowflake_connect(sf);
   assert_int_not_equal(status, SF_STATUS_SUCCESS);
@@ -250,6 +256,8 @@ void test_encrypted_pem(void **unused) {
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE_PWD, "");
+  // explicitly unset password to esure we are using key pair auth
+  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   status = snowflake_connect(sf);
   assert_int_not_equal(status, SF_STATUS_SUCCESS);
@@ -262,6 +270,8 @@ void test_encrypted_pem(void **unused) {
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE_PWD, "invalid pwd");
+  // explicitly unset password to esure we are using key pair auth
+  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   status = snowflake_connect(sf);
   assert_int_not_equal(status, SF_STATUS_SUCCESS);
@@ -288,6 +298,8 @@ void test_renew(void **unused) {
   int64 renew_timeout = 5;
   snowflake_set_attribute(sf, SF_CON_JWT_CNXN_WAIT_TIME, &renew_timeout);
   snowflake_set_attribute(sf, SF_CON_PASSWORD, "renew injection");
+  // explicitly unset password to esure we are using key pair auth
+  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   SF_STATUS status = snowflake_connect(sf);
   if (status != SF_STATUS_SUCCESS) {

--- a/tests/test_jwt.cpp
+++ b/tests/test_jwt.cpp
@@ -298,8 +298,6 @@ void test_renew(void **unused) {
   int64 renew_timeout = 5;
   snowflake_set_attribute(sf, SF_CON_JWT_CNXN_WAIT_TIME, &renew_timeout);
   snowflake_set_attribute(sf, SF_CON_PASSWORD, "renew injection");
-  // explicitly unset password to esure we are using key pair auth
-  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   SF_STATUS status = snowflake_connect(sf);
   if (status != SF_STATUS_SUCCESS) {

--- a/tests/test_jwt.cpp
+++ b/tests/test_jwt.cpp
@@ -202,7 +202,7 @@ void test_unencrypted_pem(void **unused) {
 
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
-  // explicitly unset password to esure we are using key pair auth
+  // explicitly unset password to esure we are using key pair auth, not user/pwd
   snowflake_set_attribute(sf, SF_CON_PASSWORD, "");
 
   SF_STATUS status = snowflake_connect(sf);
@@ -229,7 +229,7 @@ void test_encrypted_pem(void **unused) {
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE_PWD, "test");
-  // explicitly unset password to esure we are using key pair auth
+  // explicitly unset password to esure we are using key pair auth, not user/pwd
   snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   SF_STATUS status = snowflake_connect(sf);
@@ -242,8 +242,6 @@ void test_encrypted_pem(void **unused) {
   sf = setup_snowflake_connection();
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
-  // explicitly unset password to esure we are using key pair auth
-  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   status = snowflake_connect(sf);
   assert_int_not_equal(status, SF_STATUS_SUCCESS);
@@ -256,8 +254,6 @@ void test_encrypted_pem(void **unused) {
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE_PWD, "");
-  // explicitly unset password to esure we are using key pair auth
-  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   status = snowflake_connect(sf);
   assert_int_not_equal(status, SF_STATUS_SUCCESS);
@@ -270,8 +266,6 @@ void test_encrypted_pem(void **unused) {
   snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_JWT);
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE, keyFilePath.c_str());
   snowflake_set_attribute(sf, SF_CON_PRIV_KEY_FILE_PWD, "invalid pwd");
-  // explicitly unset password to esure we are using key pair auth
-  snowflake_set_attribute(sf, SF_CON_PASSWORD, NULL);
 
   status = snowflake_connect(sf);
   assert_int_not_equal(status, SF_STATUS_SUCCESS);
@@ -298,6 +292,8 @@ void test_renew(void **unused) {
   int64 renew_timeout = 5;
   snowflake_set_attribute(sf, SF_CON_JWT_CNXN_WAIT_TIME, &renew_timeout);
   snowflake_set_attribute(sf, SF_CON_PASSWORD, "renew injection");
+  // explicitly unset password to esure we are using key pair auth, not user/pwd
+  snowflake_set_attribute(sf, SF_CON_PASSWORD, "invalid pwd");
 
   SF_STATUS status = snowflake_connect(sf);
   if (status != SF_STATUS_SUCCESS) {


### PR DESCRIPTION
simba ticket 00404349
Key pair authentication doesn't work.
The bug itself is a simple typo and the problem is the test case didn't catch it. The reason is that setup_snowflake_connection() is called by all test cases to setup connection attributes from environments while password is set there. The jwt test cases were actually using user/password authentication to make the connection.
Unset password in test cases to ensure key pair auth is actually being used. Same test case issue on PHP side as well will make same fix there.