### PR TITLE
fix build issue on mac

### DIFF
--- a/cpp/StatementPutGet.hpp
+++ b/cpp/StatementPutGet.hpp
@@ -26,7 +26,7 @@ public:
   virtual bool parsePutGetCommand(std::string *sql,
                                   PutGetParseResponse *putGetParseResponse);
 
-  virtual Util::Proxy* get_proxy() override;
+  virtual Util::Proxy* get_proxy();
 
 private:
   SF_STMT *m_stmt;


### PR DESCRIPTION
the override keyword caused build issue on Mac so remove it.