### PR TITLE
bug fix: curl to use proxy for ocsp

### DIFF
--- a/deps/curl-7.84.0/lib/vtls/sf_ocsp.c
+++ b/deps/curl-7.84.0/lib/vtls/sf_ocsp.c
@@ -668,6 +668,13 @@ static OCSP_RESPONSE * queryResponderUsingCurl(char *url, OCSP_CERTID *certid, c
     curl_easy_setopt(ocsp_curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(ocsp_curl, CURLOPT_WRITEDATA, &ocsp_response_raw);
 
+    // copy proxy settings from original curl handle if it's set
+    curl_easy_setopt(ocsp_curl, CURLOPT_PROXY, data->set.str[STRING_PROXY]);
+    curl_easy_setopt(ocsp_curl, CURLOPT_PROXYPORT, data->set.proxyport);
+    curl_easy_setopt(ocsp_curl, CURLOPT_PROXYUSERNAME, data->set.str[STRING_PROXYUSERNAME]);
+    curl_easy_setopt(ocsp_curl, CURLOPT_PROXYPASSWORD, data->set.str[STRING_PROXYPASSWORD]);
+    curl_easy_setopt(ocsp_curl, CURLOPT_NOPROXY, data->set.str[STRING_NOPROXY]);
+
     if (ACTIVATE_SSD)
     {
         curl_easy_setopt(ocsp_curl, CURLOPT_POST, 1L);

--- a/scripts/build_curl.bat
+++ b/scripts/build_curl.bat
@@ -9,7 +9,7 @@
 :: - vs14 / vs15
 
 @echo off
-set CURL_VERSION=7.84.0.1
+set CURL_VERSION=7.84.0.2
 call %*
 goto :EOF
 

--- a/scripts/build_curl.sh
+++ b/scripts/build_curl.sh
@@ -12,7 +12,7 @@ function usage() {
 set -o pipefail
 
 CURL_DIR=7.84.0
-CURL_VERSION=${CURL_DIR}.1
+CURL_VERSION=${CURL_DIR}.2
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh


### PR DESCRIPTION
OCSP check is not using proxy being set through CURLOPT_PROXY and CURLOPT_NOPROXY so if connection individual proxy settings are set from there the OCSP check could fail.