### PR TITLE
[SNOW-480523] use gcs downscoped token for GET/PUT

### DIFF
--- a/cpp/SnowflakeGCSClient.cpp
+++ b/cpp/SnowflakeGCSClient.cpp
@@ -36,6 +36,11 @@ SnowflakeGCSClient::SnowflakeGCSClient(StageInfo *stageInfo, unsigned int parall
   m_statement(statement),
   m_gcsAccessToken(stageInfo ? stageInfo->credentials[GCS_TOKEN_KEY] : "")
 {
+  if (!m_gcsAccessToken.empty())
+  {
+    CXX_LOG_INFO("Using GCS down scoped token.");
+  }
+
   //Ensure the stage location ended with /
   if ((!m_stageInfo->location.empty()) && (m_stageInfo->location.back() != '/'))
   {
@@ -249,6 +254,7 @@ void SnowflakeGCSClient::buildGcsRequest(const std::string& filePathFull,
 
   // https://storage.googleapis.com//BUCKET_NAME/OBJECT_NAME
   url = GCS_ENDPOINT + "/" + bucket + "/" + object;
+  CXX_LOG_DEBUG("Build GCS request for file %s as URL: %s", filePathFull.c_str(), url.c_str());
 
   return;
 }

--- a/cpp/SnowflakeGCSClient.hpp
+++ b/cpp/SnowflakeGCSClient.hpp
@@ -54,7 +54,7 @@ public:
 
   virtual bool requirePresignedUrl() override
   {
-    return true;
+    return m_gcsAccessToken.empty();
   }
 
 private:
@@ -82,9 +82,36 @@ private:
   void parseHttpRespHeaders(std::string const& headerString,
                             std::map<std::string, std::string>& headers);
 
+  /**
+  * build gcs request.
+  * @param filePathFull the full path of the object (input)
+  * @param url request url (output)
+  * @param reqHeaders request headers (output)
+  */
+  void buildGcsRequest(const std::string &filePathFull,
+                       std::string &url, std::vector<std::string>& reqHeaders);
+
+  /**
+  * Compose bucket and object value used for gcs request.
+  * @param fileMetadata (input)
+  * @param bucket (output)
+  * @param object (output)
+  */
+  void extractBucketAndObject(const std::string &fileFullPath,
+                              std::string &bucket, std::string &object);
+
+  /**
+  * Encode name to be a part of URL
+  * @param srcName The source name to be encoded
+  * @return The encode name
+  */
+  std::string encodeUrlName(const std::string &srcName);
+
   StageInfo * m_stageInfo;
 
   IStatementPutGet* m_statement;
+
+  std::string m_gcsAccessToken;
 };
 }
 }


### PR DESCRIPTION
for feature request: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/91

The changes on libsnowflakeclient side to use down scoped token. Since libsnowflakeclient doesn't support GET/PUT for GCS by it's own no test cases added in this PR.
More changes and test cases are added on ODBC side here: https://github.com/snowflakedb/snowflake-odbc/tree/SNOW-480523-gcp-downscoped-token. Will make ODBC PR from there when this PR is merged and can be picked up from ODBC side.