### PR TITLE
SNOW-761229 Bug fix: encoding ocsp request data in URL to avoid invalid URL issue

### DIFF
--- a/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
+++ b/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
@@ -190,7 +190,7 @@ static void printOCSPFailOpenWarning(SF_OTD *ocsp_log, struct Curl_easy *data);
 static char * generateOCSPTelemetryData(SF_OTD *ocsp_log);
 static void clearOSCPLogData(SF_OTD *ocsp_log);
 static SF_TESTMODE_STATUS getTestStatus(SF_OCSP_TEST test_name);
-// Intentially make it global for test purpose.
+/* Intentially make it global for test purpose */
 size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr);
 
 static int _mutex_init(SF_MUTEX_HANDLE *lock);
@@ -283,9 +283,10 @@ size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr)
   char* encode_buf = (char*)malloc(buf_len);
   char* cur_ptr = encode_buf;
   size_t enc_len = 0;
+  size_t pos = 0;
 
   // encode all special characters
-  for (size_t pos = 0; pos < data_size; pos++)
+  for (pos = 0; pos < data_size; pos++)
   {
     // if unreserved, put as is
     // RFC 3986 section 2.3 Unreserved Characters

--- a/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
+++ b/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
@@ -190,7 +190,8 @@ static void printOCSPFailOpenWarning(SF_OTD *ocsp_log, struct Curl_easy *data);
 static char * generateOCSPTelemetryData(SF_OTD *ocsp_log);
 static void clearOSCPLogData(SF_OTD *ocsp_log);
 static SF_TESTMODE_STATUS getTestStatus(SF_OCSP_TEST test_name);
-static size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr);
+// Intentially make it global for test purpose.
+size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr);
 
 static int _mutex_init(SF_MUTEX_HANDLE *lock);
 static int _mutex_lock(SF_MUTEX_HANDLE *lock);
@@ -274,7 +275,7 @@ static const int MAX_RETRY = 1;
  * @param encoded_ptr The allocated buffer filled with encoded data, need to be freed by caller
  * return the size of encoded data
  */
-static size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr)
+size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr)
 {
   // allocate buffer 3 times larger than source data in case every single, add 1 for '\0'
   // character needs to be encoded as %xx
@@ -301,7 +302,7 @@ static size_t encodeUrlData(const char *url_data, size_t data_size, char** encod
     }
     else
     {
-      sb_sprintf(cur_ptr, buf_len - 1, "%%%.2X", car);
+      snprintf(cur_ptr, buf_len, "%%%.2X", car);
       cur_ptr += 3;
       enc_len += 3;
       buf_len -= 3;
@@ -309,6 +310,7 @@ static size_t encodeUrlData(const char *url_data, size_t data_size, char** encod
   }
 
   *cur_ptr = '\0';
+  *encoded_ptr = encode_buf;
   return enc_len;
 }
 
@@ -685,7 +687,7 @@ static OCSP_RESPONSE * queryResponderUsingCurl(char *url, OCSP_CERTID *certid, c
   {
     if (!ACTIVATE_SSD)
     {
-      encodeUrlData(ocsp_req_base64, ocsp_req_base64_len, encoded_ocsp_req_base64);
+      encodeUrlData(ocsp_req_base64, ocsp_req_base64_len, &encoded_ocsp_req_base64);
       snprintf(urlbuf, sizeof(urlbuf),
                ocsp_cache_server_retry_url_pattern,
                host, encoded_ocsp_req_base64);

--- a/tests/unit_test_ocsp/test_ocsp.c
+++ b/tests/unit_test_ocsp/test_ocsp.c
@@ -12,7 +12,7 @@
 #include <unistd.h>
 #include <curl/curl.h>
 
-extern size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr);
+extern CURLcode encodeUrlData(const char *url_data, size_t data_size, char** outptr, size_t *outlen);
 
 struct configData
 {
@@ -192,7 +192,7 @@ checkUrlEncoding(char *urlData, char *expectedEncoding)
 {
     char *encodedData;
 
-    encodeUrlData(urlData, strlen(urlData), &encodedData);
+    encodeUrlData(urlData, strlen(urlData), &encodedData, NULL);
     if (strcmp(encodedData, expectedEncoding) != 0)
     {
         fprintf(stderr, "checkUrlEncoding FAILED! expected %s but actually returned %s\n",

--- a/tests/unit_test_ocsp/test_ocsp.c
+++ b/tests/unit_test_ocsp/test_ocsp.c
@@ -12,6 +12,8 @@
 #include <unistd.h>
 #include <curl/curl.h>
 
+extern size_t encodeUrlData(const char *url_data, size_t data_size, char** encoded_ptr);
+
 struct configData
 {
     char trace_ascii;
@@ -185,6 +187,24 @@ checkCertificateRevocationStatus(char *host, char *port, char *cacert, char *pro
     fprintf(stderr, "OK\n");
 }
 
+static void
+checkUrlEncoding(char *urlData, char *expectedEncoding)
+{
+    char *encodedData;
+
+    encodeUrlData(urlData, strlen(urlData), &encodedData);
+    if (strcmp(encodedData, expectedEncoding) != 0)
+    {
+        fprintf(stderr, "checkUrlEncoding FAILED! expected %s but actually returned %s\n",
+                expectedEncoding, encodedData);
+        free(encodedData);
+        exit(1);
+    }
+
+    free(encodedData);
+    fprintf(stderr, "OK\n");
+}
+
 int main(int argc, char **argv)
 {
     char cacert[4096];
@@ -267,6 +287,10 @@ int main(int argc, char **argv)
 
     unsetenv("http_proxy");
     unsetenv("https_proxy");
+
+    printf("===> Case 8: Check URL encoding for OCSP request\n");
+    checkUrlEncoding("Hello @World", "Hello%20%40World");
+    checkUrlEncoding("Test//String", "Test%2F%2FString");
 
     return 0;
 }


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/259
Encode Base64 OCSP Request data in URL for some corner cases that it might have characters that are not URL safe.
Unit test only as it's for for some corner cases that not easy to reproduce.