### PR TITLE
Bug fix: only set proxy username and password options when specified

### DIFF
--- a/cpp/util/SnowflakeCommon.cpp
+++ b/cpp/util/SnowflakeCommon.cpp
@@ -108,10 +108,13 @@ CURLcode set_curl_proxy(CURL *curl, const char* proxy, const char* no_proxy)
     if (res != CURLE_OK) return res;
     res = curl_easy_setopt(curl, CURLOPT_PROXYPORT, (long)proxySettings.getPort());
     if (res != CURLE_OK) return res;
-    res = curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, proxySettings.getUser().c_str());
-    if (res != CURLE_OK) return res;
-    res = curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, proxySettings.getPwd().c_str());
-    if (res != CURLE_OK) return res;
+    if (!proxySettings.getUser().empty() || !proxySettings.getPwd().empty())
+    {
+      res = curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, proxySettings.getUser().c_str());
+      if (res != CURLE_OK) return res;
+      res = curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, proxySettings.getPwd().c_str());
+      if (res != CURLE_OK) return res;
+    }
     return curl_easy_setopt(curl, CURLOPT_NOPROXY, proxySettings.getNoProxy().c_str());
   }
 }

--- a/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/deps/aws-sdk-cpp-1.3.50/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -410,8 +410,11 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(HttpRequest& request, 
             ss << m_proxyScheme << "://" << m_proxyHost;
             curl_easy_setopt(connectionHandle, CURLOPT_PROXY, ss.str().c_str());
             curl_easy_setopt(connectionHandle, CURLOPT_PROXYPORT, (long) m_proxyPort);
-            curl_easy_setopt(connectionHandle, CURLOPT_PROXYUSERNAME, m_proxyUserName.c_str());
-            curl_easy_setopt(connectionHandle, CURLOPT_PROXYPASSWORD, m_proxyPassword.c_str());
+            if (!m_proxyUserName.empty() || !m_proxyPassword.empty())
+            {
+                curl_easy_setopt(connectionHandle, CURLOPT_PROXYUSERNAME, m_proxyUserName.c_str());
+                curl_easy_setopt(connectionHandle, CURLOPT_PROXYPASSWORD, m_proxyPassword.c_str());
+            }
             curl_easy_setopt(connectionHandle, CURLOPT_NOPROXY, m_noProxy.c_str());
         }
         else

--- a/deps/azure-storage-cpplite-0.1.20/include/http/libcurl_http_client.h
+++ b/deps/azure-storage-cpplite-0.1.20/include/http/libcurl_http_client.h
@@ -327,8 +327,11 @@ namespace azure {  namespace storage_lite {
                 {
                   curl_easy_setopt(h, CURLOPT_PROXY, proxy_host.c_str());
                   curl_easy_setopt(h, CURLOPT_PROXYPORT, (long) proxy_port);
-                  curl_easy_setopt(h, CURLOPT_PROXYUSERNAME, proxy_user.c_str());
-                  curl_easy_setopt(h, CURLOPT_PROXYPASSWORD, proxy_password.c_str());
+                  if (!proxy_user.empty() || !proxy_password.empty())
+                  {
+                    curl_easy_setopt(h, CURLOPT_PROXYUSERNAME, proxy_user.c_str());
+                    curl_easy_setopt(h, CURLOPT_PROXYPASSWORD, proxy_password.c_str());
+                  }
                   curl_easy_setopt(h, CURLOPT_NOPROXY, no_proxy.c_str());
                 }
                 m_handles.push(h);

--- a/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
+++ b/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
@@ -671,8 +671,11 @@ static OCSP_RESPONSE * queryResponderUsingCurl(char *url, OCSP_CERTID *certid, c
     // copy proxy settings from original curl handle if it's set
     curl_easy_setopt(ocsp_curl, CURLOPT_PROXY, data->set.str[STRING_PROXY]);
     curl_easy_setopt(ocsp_curl, CURLOPT_PROXYPORT, data->set.proxyport);
-    curl_easy_setopt(ocsp_curl, CURLOPT_PROXYUSERNAME, data->set.str[STRING_PROXYUSERNAME]);
-    curl_easy_setopt(ocsp_curl, CURLOPT_PROXYPASSWORD, data->set.str[STRING_PROXYPASSWORD]);
+    if (data->set.str[STRING_PROXYUSERNAME] || data->set.str[STRING_PROXYPASSWORD])
+    {
+        curl_easy_setopt(ocsp_curl, CURLOPT_PROXYUSERNAME, data->set.str[STRING_PROXYUSERNAME]);
+        curl_easy_setopt(ocsp_curl, CURLOPT_PROXYPASSWORD, data->set.str[STRING_PROXYPASSWORD]);
+    }
     curl_easy_setopt(ocsp_curl, CURLOPT_NOPROXY, data->set.str[STRING_NOPROXY]);
 
     if (ACTIVATE_SSD)
@@ -1346,6 +1349,16 @@ void downloadOCSPCache(struct Curl_easy *data, SF_OTD *ocsp_log_data)
   curl_easy_setopt(curlh, CURLOPT_HTTPHEADER, headers);
   curl_easy_setopt(curlh, CURLOPT_WRITEFUNCTION, write_callback);
   curl_easy_setopt(curlh, CURLOPT_WRITEDATA, &ocsp_response_cache_json_mem);
+
+  // copy proxy settings from original curl handle if it's set
+  curl_easy_setopt(curlh, CURLOPT_PROXY, data->set.str[STRING_PROXY]);
+  curl_easy_setopt(curlh, CURLOPT_PROXYPORT, data->set.proxyport);
+  if (data->set.str[STRING_PROXYUSERNAME] || data->set.str[STRING_PROXYPASSWORD])
+  {
+      curl_easy_setopt(curlh, CURLOPT_PROXYUSERNAME, data->set.str[STRING_PROXYUSERNAME]);
+      curl_easy_setopt(curlh, CURLOPT_PROXYPASSWORD, data->set.str[STRING_PROXYPASSWORD]);
+  }
+  curl_easy_setopt(curlh, CURLOPT_NOPROXY, data->set.str[STRING_NOPROXY]);
 
   res = CURLE_OK;
 

--- a/scripts/build_awssdk.bat
+++ b/scripts/build_awssdk.bat
@@ -3,7 +3,7 @@
 :: GitHub repo: https://github.com/aws/aws-sdk-cpp.git
 ::
 @echo off
-set aws_version=1.3.50.1
+set aws_version=1.3.50.2
 call %*
 goto :EOF
 

--- a/scripts/build_awssdk.sh
+++ b/scripts/build_awssdk.sh
@@ -13,7 +13,7 @@ function usage() {
 set -o pipefail
 
 AWS_DIR=aws-sdk-cpp-1.3.50
-AWS_VERSION=1.3.50.1
+AWS_VERSION=1.3.50.2
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh $@

--- a/scripts/build_azuresdk.bat
+++ b/scripts/build_azuresdk.bat
@@ -3,7 +3,7 @@
 :: GitHub repo: https://github.com/snowflakedb/azure-storage-cpplite.git
 ::
 @echo off
-set azure_version=0.1.20
+set azure_version=0.1.20.1
 call %*
 goto :EOF
 
@@ -13,6 +13,7 @@ goto :EOF
 
 :build
 setlocal
+set azure_dir=azure-storage-cpplite-0.1.20
 set platform=%1
 set build_type=%2
 set vs_version=%3
@@ -34,7 +35,7 @@ if "%platform%"=="x86" (
 )
 
 @echo off
-set AZURE_SOURCE_DIR=%scriptdir%..\deps\azure-storage-cpplite-%azure_version%
+set AZURE_SOURCE_DIR=%scriptdir%..\deps\%azure_dir%
 set AZURE_CMAKE_BUILD_DIR=%AZURE_SOURCE_DIR%\cmake-build-%arcdir%-%vs_version%-%build_type%
 set AZURE_INSTALL_DIR=%scriptdir%..\deps-build\%build_dir%\azure
 

--- a/scripts/build_azuresdk.sh
+++ b/scripts/build_azuresdk.sh
@@ -11,7 +11,8 @@ function usage() {
 }
 set -o pipefail
 
-AZURE_VERSION=0.1.20
+AZURE_DIR=azure-storage-cpplite-0.1.20
+AZURE_VERSION=0.1.20.1
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh $@
@@ -19,7 +20,7 @@ source $DIR/utils.sh
 
 [[ -n "$GET_VERSION" ]] && echo $AZURE_VERSION && exit 0
 
-AZURE_SOURCE_DIR=$DEPS_DIR/azure-storage-cpplite-$AZURE_VERSION
+AZURE_SOURCE_DIR=$DEPS_DIR/$AZURE_DIR
 AZURE_BUILD_DIR=$DEPENDENCY_DIR/azure
 AZURE_CMAKE_BUILD_DIR=$AZURE_SOURCE_DIR/cmake-build
 


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/294
ODBC driver sends empty Proxy-Authorization header to proxy server when no proxy username and password options in proxy settings which caused connection failure when using proxy.
The root cause is that when using proxy proxy username and password always been set without checking if they are empty.
Do the same fix [here](https://github.com/aws/aws-sdk-cpp/commit/59fe5b1b4d3cf9d26586a543376818e581f5aafc) for all the places need proxy settings.
No test case added as we don't have a proxy environment that doesn't need user/password authentication. But verify the fix with tcpdump as mentioned in the ticket, confirmed that
- without the fix Proxy-Authorization header was added with empty credentials
- with the fix Proxy-Authorization header was removed