### PR TITLE
SNOW-792806 disable flaky test on jenkins run

### DIFF
--- a/tests/test_unit_put_fast_fail.cpp
+++ b/tests/test_unit_put_fast_fail.cpp
@@ -235,6 +235,12 @@ private:
 
 void test_put_fast_fail_core(bool successWithRetry)
 {
+  // run test only on github as for some unknow reason
+  // this test case take too much time on jenkins
+  char *githubenv = getenv("GITHUB_ACTIONS");
+  if (!githubenv || (strlen(githubenv) == 0))
+    return;
+
   std::string matchDir = getTestFileMatchDir();
   matchDir += "*.csv";
   IStorageClient * client = new MockedStorageClient();
@@ -291,6 +297,12 @@ void test_put_fast_fail_core(bool successWithRetry)
 
 void test_get_fast_fail_core(bool successWithRetry)
 {
+  // run test only on github as for some unknow reason
+  // this test case take too much time on jenkins
+  char *githubenv = getenv("GITHUB_ACTIONS");
+  if (!githubenv || (strlen(githubenv) == 0))
+    return;
+
   std::string matchDir = getTestFileMatchDir();
   IStorageClient * client = new MockedStorageClient();
   StorageClientFactory::injectMockedClient(client);


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/340

Disable the flaky test case that takes too long time on jenkins run. It's still run on github though so should be able to catch any regression there.