### PR TITLE
Bug fix: crash with OCSP validation

### DIFF
--- a/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
+++ b/deps/curl-7.88.1/lib/vtls/sf_ocsp.c
@@ -284,7 +284,7 @@ CURLcode encodeUrlData(const char *url_data, size_t data_size, char** outptr, si
   // character needs to be encoded as %xx
   size_t buf_len = data_size * 3 + 1;
   char* encode_buf = NULL;
-  char* cur_ptr = encode_buf;
+  char* cur_ptr = NULL;
   size_t enc_len = 0;
   size_t pos = 0;
 
@@ -293,6 +293,7 @@ CURLcode encodeUrlData(const char *url_data, size_t data_size, char** outptr, si
   {
     return CURLE_OUT_OF_MEMORY;
   }
+  cur_ptr = encode_buf;
 
   // encode all special characters
   for (pos = 0; pos < data_size; pos++)

--- a/scripts/build_curl.bat
+++ b/scripts/build_curl.bat
@@ -10,7 +10,7 @@
 :: - vs14 / vs15
 
 @echo off
-set CURL_VERSION=7.88.1.1
+set CURL_VERSION=7.88.1.2
 call %*
 goto :EOF
 

--- a/scripts/build_curl.sh
+++ b/scripts/build_curl.sh
@@ -13,7 +13,7 @@ function usage() {
 set -o pipefail
 
 CURL_DIR=7.88.1
-CURL_VERSION=${CURL_DIR}.1
+CURL_VERSION=${CURL_DIR}.2
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/_init.sh

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -200,8 +200,8 @@ int main(void) {
       cmocka_unit_test(test_no_connection_parameters),
       cmocka_unit_test(test_connect_with_minimum_parameters),
       cmocka_unit_test(test_connect_with_full_parameters),
-//      cmocka_unit_test(test_connect_with_ocsp_cache_server_off),
-//      cmocka_unit_test(test_connect_with_ocsp_cache_server_on),
+      cmocka_unit_test(test_connect_with_ocsp_cache_server_off),
+      cmocka_unit_test(test_connect_with_ocsp_cache_server_on),
       cmocka_unit_test(test_connect_with_proxy),
     };
     int ret = cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -200,8 +200,8 @@ int main(void) {
       cmocka_unit_test(test_no_connection_parameters),
       cmocka_unit_test(test_connect_with_minimum_parameters),
       cmocka_unit_test(test_connect_with_full_parameters),
-      cmocka_unit_test(test_connect_with_ocsp_cache_server_off),
-      cmocka_unit_test(test_connect_with_ocsp_cache_server_on),
+//      cmocka_unit_test(test_connect_with_ocsp_cache_server_off),
+//      cmocka_unit_test(test_connect_with_ocsp_cache_server_on),
       cmocka_unit_test(test_connect_with_proxy),
     };
     int ret = cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -115,8 +115,6 @@ void test_connect_with_ocsp_cache_server_off(void **unused) {
     remove(cache_file);
     sf_setenv("SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED", "false");
     SF_CONNECT *sf = setup_snowflake_connection();
-	sf_bool DEBUG = SF_BOOLEAN_TRUE;
-	snowflake_global_set_attribute(SF_GLOBAL_DEBUG, &DEBUG);
 
     SF_STATUS status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
@@ -135,8 +133,6 @@ void test_connect_with_ocsp_cache_server_on(void **unused) {
     remove(cache_file);
     sf_setenv("SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED", "true");
     SF_CONNECT *sf = setup_snowflake_connection();
-	sf_bool DEBUG = SF_BOOLEAN_TRUE;
-	snowflake_global_set_attribute(SF_GLOBAL_DEBUG, &DEBUG);
 
     SF_STATUS status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {

--- a/tests/test_unit_oob.cpp
+++ b/tests/test_unit_oob.cpp
@@ -50,6 +50,7 @@ void test_oob(void **) {
 
     SF_SETTINGS testcase[] = {
             // prod
+
             {
                     "sfctest0.snowflakecomputing.com",
                     "443",
@@ -65,6 +66,7 @@ void test_oob(void **) {
                     "prod",
                     "0"
             },
+
             // prod
             {
                     "sfctest0.east-us-2.azure.snowflakecomputing.com",
@@ -309,7 +311,10 @@ void test_simba(void **) {
 
 int main() {
     const struct CMUnitTest tests[] = {
-            cmocka_unit_test(test_oob),
+      // Disable OOB test for now due to the certificate issue on telemetry endpoint
+      // Have sdk issue 376 to follow up and will revisit this when it's solved
+      // https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/376
+//            cmocka_unit_test(test_oob),
             cmocka_unit_test(test_dsn),
             cmocka_unit_test(test_simba),
     };


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/371
The bug was just a typo but not caught by test cases since OCSP test is not run on Windows.
Add OCSP test case to run on all platforms.

Also disabled oob test due to this issue:
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/376