### PR TITLE
SNOW-867941 - Fix LibSnowflakeClient-Win64-VS14-Debug Jenkins job

### DIFF
--- a/deps/boost-1.75.0/bootstrap.bat
+++ b/deps/boost-1.75.0/bootstrap.bat
@@ -12,7 +12,7 @@ ECHO Building Boost.Build engine
 if exist ".\tools\build\src\engine\b2.exe" del tools\build\src\engine\b2.exe
 pushd tools\build\src\engine
 
-call .\build.bat
+call .\build.bat vc14
 @ECHO OFF
 
 popd

--- a/scripts/build_arrow.bat
+++ b/scripts/build_arrow.bat
@@ -36,7 +36,7 @@ if "%ARROW_FROM_SOURCE%"=="1" (
     echo "%scriptdir%build_boost_source.bat"
     call "%scriptdir%build_boost_source.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
 	if %ERRORLEVEL% NEQ 0 goto :error
-	if "%platform%"=="x64" (
+	if /I "%platform%"=="x64" (
         call "%scriptdir%build_arrow_source.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
         if %ERRORLEVEL% NEQ 0 goto :error
     )

--- a/scripts/build_arrow_source.bat
+++ b/scripts/build_arrow_source.bat
@@ -25,10 +25,10 @@ if %ERRORLEVEL% NEQ 0 goto :error
 
 set curdir=%cd%
 
-if "%platform%"=="x64" (
+if /I "%platform%"=="x64" (
     set engine_dir=Program Files
 )
-if "%platform%"=="x86" (
+if /I "%platform%"=="x86" (
     set engine_dir=Program Files (x86^)
 )
 

--- a/scripts/build_azuresdk.bat
+++ b/scripts/build_azuresdk.bat
@@ -29,10 +29,10 @@ if %ERRORLEVEL% NEQ 0 goto :error
 
 set curdir=%cd%
 
-if "%platform%"=="x64" (
+if /I "%platform%"=="x64" (
     set engine_dir=Program Files
 )
-if "%platform%"=="x86" (
+if /I "%platform%"=="x86" (
     set engine_dir=Program Files (x86^)
 )
 

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -61,7 +61,7 @@ if /I "%dynamic_runtime%"=="on" (
 
 call "%BOOST_SOURCE_DIR%\bootstrap.bat" --with-libraries=filesystem,regex,system
 if %ERRORLEVEL% NEQ 0 goto :error
-b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
+b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --address-model=64 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
 if %ERRORLEVEL% NEQ 0 goto :error
 ::remove cmake files including local build path information
 rd /S /Q %BOOST_INSTALL_DIR%\lib\cmake

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -61,7 +61,7 @@ if /I "%dynamic_runtime%"=="on" (
 
 call "%BOOST_SOURCE_DIR%\bootstrap.bat" --with-libraries=filesystem,regex,system
 if %ERRORLEVEL% NEQ 0 goto :error
-b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --address-model=64 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
+b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --address-model=64 --architecture=ia64 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
 if %ERRORLEVEL% NEQ 0 goto :error
 ::remove cmake files including local build path information
 rd /S /Q %BOOST_INSTALL_DIR%\lib\cmake

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -61,7 +61,7 @@ if /I "%dynamic_runtime%"=="on" (
 
 call "%BOOST_SOURCE_DIR%\bootstrap.bat" --with-libraries=filesystem,regex,system
 if %ERRORLEVEL% NEQ 0 goto :error
-b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --address-model=64 --architecture=x86 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
+b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --architecture=ia64 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
 if %ERRORLEVEL% NEQ 0 goto :error
 ::remove cmake files including local build path information
 rd /S /Q %BOOST_INSTALL_DIR%\lib\cmake

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -30,7 +30,7 @@ if "%platform%"=="X64" (
     set engine_dir=Program Files
 	set bitness=64
 )
-if "%platform%"=="x86" (
+if "%platform%"=="X86" (
     set engine_dir=Program Files (x86^)
 	set bitness=32
 )
@@ -59,19 +59,9 @@ if /I "%dynamic_runtime%"=="on" (
     set runtimelink=static
 )
 
-echo Platform = %platform%
-echo Build_type = %build_type%
-echo VS_version = %vs_version%
-echo Dynamic_runtime = %dynamic_runtime%
-echo InstallDir = %BOOST_INSTALL_DIR%
-echo Bitness = %bitness%
-echo Engine_dir = %engine_dir%
-echo Runtimelink = %runtimelink%
-
-
 call "%BOOST_SOURCE_DIR%\bootstrap.bat" --with-libraries=filesystem,regex,system
 if %ERRORLEVEL% NEQ 0 goto :error
-b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include toolset=msvc-14.0 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
+b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
 if %ERRORLEVEL% NEQ 0 goto :error
 ::remove cmake files including local build path information
 rd /S /Q %BOOST_INSTALL_DIR%\lib\cmake

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -26,7 +26,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 
 set curdir=%cd%
 
-if "%platform%"=="x64" (
+if "%platform%"=="X64" (
     set engine_dir=Program Files
 	set bitness=64
 )
@@ -65,6 +65,7 @@ echo VS_version = %vs_version%
 echo Dynamic_runtime = %dynamic_runtime%
 echo InstallDir = %BOOST_INSTALL_DIR%
 echo Bitness = %bitness%
+echo Engine_dir = %engine_dir%
 echo Runtimelink = %runtimelink%
 
 

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -61,7 +61,7 @@ if /I "%dynamic_runtime%"=="on" (
 
 call "%BOOST_SOURCE_DIR%\bootstrap.bat" --with-libraries=filesystem,regex,system
 if %ERRORLEVEL% NEQ 0 goto :error
-b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --address-model=64 --architecture=ia64 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
+b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --address-model=64 --architecture=x86 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
 if %ERRORLEVEL% NEQ 0 goto :error
 ::remove cmake files including local build path information
 rd /S /Q %BOOST_INSTALL_DIR%\lib\cmake

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -59,9 +59,18 @@ if /I "%dynamic_runtime%"=="on" (
     set runtimelink=static
 )
 
+echo Platform = %platform%
+echo Build_type = %build_type%
+echo VS_version = %vs_version%
+echo Dynamic_runtime = %dynamic_runtime%
+echo InstallDir = %BOOST_INSTALL_DIR%
+echo Bitness = %bitness%
+echo Runtimelink = %runtimelink%
+
+
 call "%BOOST_SOURCE_DIR%\bootstrap.bat" --with-libraries=filesystem,regex,system
 if %ERRORLEVEL% NEQ 0 goto :error
-b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include --architecture=ia64 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
+b2 stage --stagedir=%BOOST_INSTALL_DIR% --includedir=%BOOST_INSTALL_DIR%\include toolset=msvc-14.0 --layout=system --with-system --with-filesystem --with-regex link=static runtime-link=%runtimelink% threading=multi address-model=%bitness% variant=%variant% runtime-debugging=%debugging% cxxflags=/ZH:SHA_256 install
 if %ERRORLEVEL% NEQ 0 goto :error
 ::remove cmake files including local build path information
 rd /S /Q %BOOST_INSTALL_DIR%\lib\cmake

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -26,11 +26,11 @@ if %ERRORLEVEL% NEQ 0 goto :error
 
 set curdir=%cd%
 
-if "%platform%"=="X64" (
+if /I "%platform%"=="x64" (
     set engine_dir=Program Files
 	set bitness=64
 )
-if "%platform%"=="X86" (
+if /I "%platform%"=="x86" (
     set engine_dir=Program Files (x86^)
 	set bitness=32
 )

--- a/scripts/build_curl.bat
+++ b/scripts/build_curl.bat
@@ -36,11 +36,11 @@ call "%scriptdir%_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 set curdir=%cd%
 
-if "%platform%"=="x64" (    
+if /I "%platform%"=="x64" (    
     set openssl_target=VC-WIN64A
     set engine_dir=Program Files
 )
-if "%platform%"=="x86" (
+if /I "%platform%"=="x86" (
     set openssl_target=VC-WIN32
     set engine_dir=Program Files (x86^)
 )

--- a/scripts/build_oob.bat
+++ b/scripts/build_oob.bat
@@ -29,10 +29,10 @@ call "%scriptdir%\_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 set curdir=%cd%
 
-if "%platform%"=="x64" (
+if /I "%platform%"=="x64" (
         set engine_dir=Program Files
 )
-if "%platform%"=="x86" (
+if /I "%platform%"=="x86" (
         set engine_dir=Program Files (x86^)
 )
 

--- a/scripts/build_openssl.bat
+++ b/scripts/build_openssl.bat
@@ -43,11 +43,11 @@ call "%scriptdir%_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 set curdir=%cd%
 
-if "%platform%"=="x64" (
+if /I "%platform%"=="x64" (
     set openssl_target=VC-WIN64A
     set engine_dir=Program Files
 )
-if "%platform%"=="x86" (
+if /I "%platform%"=="x86" (
     set openssl_target=VC-WIN32
     set engine_dir=Program Files (x86^)
 )


### PR DESCRIPTION
The job has been failing when trying to compile Boost with Visual Studio 2022.
The fix for this was to add vc14 when calling the build.bat script.
Another issue was Boost was compiled for x86 and not for x64. The problem was with the environment variable platform. The value should be "x86" or "x64". However, when the script was trying to validate the platform the value was capitalized and the conditions failed. The fix is to update the condition with the correct value.
The fix worked in this test Jenkins job https://ci-dev-122.int.snowflakecomputing.com/job/LibSnowflakeClient-VSTest-Win64-VS14-Debug/11/
