### PR TITLE
SNOW-871419 [HTAP] query context cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,8 @@ set(SOURCE_FILES_CPP_WRAPPER
         cpp/lib/ArrowChunkIterator.hpp
         cpp/lib/DataConversion.cpp
         cpp/lib/DataConversion.hpp
+        cpp/lib/QueryContextCache.cpp
+        cpp/lib/QueryContextCache.hpp
         cpp/lib/result_set.cpp
         cpp/lib/result_set_arrow.cpp
         cpp/lib/result_set_json.cpp

--- a/cpp/lib/QueryContextCache.cpp
+++ b/cpp/lib/QueryContextCache.cpp
@@ -1,0 +1,521 @@
+/*
+* File:   QueryContextCache.cpp
+* Author: harryx
+*
+* Copyright (c) 2023 Snowflake Computing
+*
+* Created on August 31, 2023, 4:05 PM
+*/
+
+#include "QueryContextCache.hpp"
+#include "../logger/SFLogger.hpp"
+
+// wrapper functions for C
+extern "C" {
+
+  void qcc_initialize(SF_CONNECT * conn)
+  {
+    if (!conn || conn->qcc_disable || conn->qcc)
+    {
+      return;
+    }
+
+    conn->qcc = (void *) new Snowflake::Client::QueryContextCache(conn->qcc_capacity);
+  }
+
+  void qcc_set_capacity(SF_CONNECT * conn, uint64 capacity)
+  {
+    if (!conn || conn->qcc_disable)
+    {
+      return;
+    }
+    if (!conn->qcc)
+    {
+      qcc_initialize(conn);
+    }
+    static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc)->setCapacity(capacity);
+  }
+
+  cJSON* qcc_serialize(SF_CONNECT * conn)
+  {
+    if (!conn || conn->qcc_disable || !conn->qcc)
+    {
+      return NULL;
+    }
+
+    return static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc)->serializeQueryContext();
+  }
+
+  void qcc_deserialize(SF_CONNECT * conn, cJSON* query_context)
+  {
+    if (!conn || conn->qcc_disable)
+    {
+      return;
+    }
+    if (!conn->qcc)
+    {
+      qcc_initialize(conn);
+    }
+
+    static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc)->deserializeQueryContext(query_context);
+  }
+
+  void qcc_terminate(SF_CONNECT * conn)
+  {
+    if (!conn || !conn->qcc)
+    {
+      return;
+    }
+
+    delete static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc);
+  }
+
+} // extern "C"
+
+namespace Snowflake
+{
+namespace Client
+{
+
+// Public ======================================================================
+void QueryContextCache::clearCache()
+{
+  CXX_LOG_TRACE("QueryContextCache: clearCache called");
+
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+  m_idMap.clear();
+  m_priorityMap.clear();
+  m_cacheSet.clear();
+}
+
+void QueryContextCache::setCapacity(size_t capacity)
+{
+  // check without locking first for performance reason
+  if (m_capacity == capacity)
+    return;
+
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+  // check again after locking to verify
+  if (m_capacity == capacity)
+  {
+    return;
+  }
+  m_capacity = capacity;
+  checkCacheCapacity();
+  logCacheEntries();
+  CXX_LOG_TRACE("QueryContextCache::setCapacity: set capacity from %d to %d", m_capacity, capacity);
+}
+
+void QueryContextCache::deserializeQueryContext(cJSON * data)
+{
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+  // Log existing cache entries
+  logCacheEntries();
+
+  if ((!data) || (data->type != cJSON_Object))
+  {
+    // Clear the cache
+    clearCache();
+    return;
+  }
+
+  // Deserialize the entries. The first entry with priority is the main entry.
+  // Save all entries into one list to simplify the logic. An example JSON is:
+  // {
+  //   "entries": [
+  //    {
+  //     "id": 0,
+  //     "read_timestamp": 123456789,
+  //     "priority": 0,
+  //     "context": "base64 encoded context"
+  //    },
+  //     {
+  //       "id": 1,
+  //       "read_timestamp": 123456789,
+  //       "priority": 1,
+  //       "context": "base64 encoded context"
+  //     },
+  //     {
+  //       "id": 2,
+  //       "read_timestamp": 123456789,
+  //       "priority": 2,
+  //       "context": "base64 encoded context"
+  //     }
+  //   ]
+  cJSON * entries = snowflake_cJSON_GetObjectItem(data, QCC_ENTRIES_KEY);
+  if ((entries) && (entries->type == cJSON_Array))
+  {
+    int arraySize = snowflake_cJSON_GetArraySize(entries);
+    for (int i = 0; i < arraySize; i++)
+    {
+      QueryContextElement entry;
+      if (deserializeQueryContextElement(snowflake_cJSON_GetArrayItem(entries, i), entry))
+      {
+        merge(entry.id, entry.readTimestamp, entry.priority, entry.context);
+      }
+      else
+      {
+        CXX_LOG_TRACE("QueryContextCache::deserializeQueryContext: "
+                      "meets mismatch field type. Clear the QueryContextCache.");
+        clearCache();
+        return;
+      }
+    }
+    // after merging all entries, sync the internal priority map to priority map. Because of priority swicth from GS side,
+    // there could be priority key conflict if we directly operating on the priorityMap during a round of merge.
+    syncPriorityMap();
+  }
+
+  // After merging all entries, truncate to capacity
+  checkCacheCapacity();
+
+  // Log existing cache entries
+  logCacheEntries();
+}
+
+void QueryContextCache::deserializeQueryContextReq(cJSON * data)
+{
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+  // Log existing cache entries
+  logCacheEntries();
+
+  if ((!data) || (data->type != cJSON_Object))
+  {
+    // Clear the cache
+    clearCache();
+    return;
+  }
+
+  cJSON * entries = snowflake_cJSON_GetObjectItem(data, QCC_ENTRIES_KEY);
+  int arraySize = snowflake_cJSON_GetArraySize(entries);
+  if ((entries) && (entries->type == cJSON_Array))
+  {
+    for (int i = 0; i < arraySize; i++)
+    {
+      QueryContextElement entry;
+      if (deserializeQueryContextElementReq(snowflake_cJSON_GetArrayItem(entries, i), entry))
+      {
+        merge(entry.id, entry.readTimestamp, entry.priority, entry.context);
+      }
+      else
+      {
+        CXX_LOG_TRACE("QueryContextCache::deserializeQueryContextReq: "
+          "meets mismatch field type. Clear the QueryContextCache.");
+        clearCache();
+        return;
+      }
+    }
+    // after merging all entries, sync the internal priority map to priority map. Because of priority swicth from GS side,
+    // there could be priority key conflict if we directly operating on the priorityMap during a round of merge.
+    syncPriorityMap();
+  }
+
+  // After merging all entries, truncate to capacity
+  checkCacheCapacity();
+
+  // Log existing cache entries
+  logCacheEntries();
+}
+
+cJSON *  QueryContextCache::serializeQueryContext()
+{
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+  // Log existing cache entries
+  logCacheEntries();
+
+  cJSON * queryContext = snowflake_cJSON_CreateObject();
+  cJSON * entries = snowflake_cJSON_CreateArray();
+  for (auto itr = m_cacheSet.begin(); itr != m_cacheSet.end(); itr++)
+  {
+    cJSON * entry = snowflake_cJSON_CreateObject();
+    snowflake_cJSON_AddUint64ToObject(entry, QCC_ID_KEY, itr->id);
+    snowflake_cJSON_AddUint64ToObject(entry, QCC_PRIORITY_KEY, itr->priority);
+    snowflake_cJSON_AddUint64ToObject(entry, QCC_TIMESTAMP_KEY, itr->readTimestamp);
+    cJSON * context = snowflake_cJSON_CreateObject();
+    if (!itr->context.empty())
+    {
+      snowflake_cJSON_AddStringToObject(context, QCC_CONTEXT_VALUE_KEY, itr->context.c_str());
+    }
+    snowflake_cJSON_AddItemToObject(entry, QCC_CONTEXT_KEY, context);
+    snowflake_cJSON_AddItemToArray(entries, entry);
+  }
+
+  snowflake_cJSON_AddItemToObject(queryContext, QCC_ENTRIES_KEY, entries);
+
+  return queryContext;
+}
+
+void QueryContextCache::merge(uint64 id, uint64 readTimestamp,
+                              uint64 priority, const std::string& context)
+{
+  if (m_idMap.find(id) != m_idMap.end())
+  {
+    CXX_LOG_TRACE("QueryContextCache: merge existing id: %lld with priority: %lld", id, priority)
+    // ID found in the cache
+    QueryContextElement qce = m_idMap[id];
+    if (readTimestamp > qce.readTimestamp)
+    {
+      if (qce.priority == priority)
+      {
+        // Same priority, overwrite new data at same place
+        updateQCE(qce, readTimestamp, context);
+      }
+      else
+      {
+        // Change in priority
+        QueryContextElement newQCE(id, readTimestamp, priority, context);
+
+        replaceQCE(qce, newQCE);
+      } // new priority
+    } // new data is recent
+    else if (readTimestamp == qce.readTimestamp && qce.priority != priority)
+    {
+      // Same read timestamp but change in priority
+      QueryContextElement newQCE(id, readTimestamp, priority, context);
+      replaceQCE(qce, newQCE);
+    }
+  } // id found
+  else
+  {
+    // new id
+    if (m_priorityMap.find(priority) != m_priorityMap.end())
+    {
+      CXX_LOG_TRACE("QueryContextCache: merge existing priority: %lld with new id: %lld", priority, id)
+      // Same priority with different id
+      QueryContextElement qce = m_priorityMap[priority];
+      // Replace with new data
+      QueryContextElement newQCE(id, readTimestamp, priority, context);
+      replaceQCE(qce, newQCE);
+    }
+    else
+    {
+      // new priority
+      // Add new element in the cache
+      CXX_LOG_TRACE("QueryContextCache: add new item id: %lld, priority: %lld", id, priority)
+      QueryContextElement newQCE(id, readTimestamp, priority, context);
+      addQCE(newQCE);
+    }
+  }
+}
+
+void QueryContextCache::syncPriorityMap()
+{
+  CXX_LOG_TRACE("QueryContextCache::syncPriorityMap called priorityMap size = %d, newPrioirtyMap size = %d",
+               m_priorityMap.size(), m_newPriorityMap.size());
+  m_priorityMap.insert(m_newPriorityMap.begin(), m_newPriorityMap.end());
+  // clear the newPriorityMap for next round of QCC merge(a round consists of multiple entries)
+  m_newPriorityMap.clear();
+}
+
+void QueryContextCache::checkCacheCapacity()
+{
+  CXX_LOG_TRACE("QueryContextCache::checkCacheCapacity called. cacheSet size %d cache capacity %d",
+               m_cacheSet.size(), m_capacity);
+  if (m_cacheSet.size() > m_capacity) {
+    // remove elements based on priority
+
+    while (m_cacheSet.size() > m_capacity) {
+      QueryContextElement qce = *(m_cacheSet.rbegin());
+      removeQCE(qce);
+    }
+  }
+
+  CXX_LOG_TRACE("QueryContextCache::checkCacheCapacity returns. cacheSet size %d cache capacity %d",
+               m_cacheSet.size(), m_capacity);
+}
+
+size_t QueryContextCache::getElements(std::vector<uint64>& ids,
+                                      std::vector<uint64>& readTimestamps,
+                                      std::vector<uint64>& priorities,
+                                      std::vector<std::string>& contexts)
+{
+  size_t count = 0;
+  ids.clear();
+  readTimestamps.clear();
+  priorities.clear();
+  contexts.clear();
+  for (auto itr = m_cacheSet.begin(); itr != m_cacheSet.end(); itr++)
+  {
+    ids.push_back(itr->id);
+    readTimestamps.push_back(itr->readTimestamp);
+    priorities.push_back(itr->priority);
+    contexts.push_back(itr->context);
+    count++;
+  }
+
+  return count;
+}
+
+// Private =====================================================================
+bool QueryContextCache::deserializeQueryContextElement(cJSON * entryNode,
+                                                       QueryContextElement & contextElement)
+{
+  cJSON * id = snowflake_cJSON_GetObjectItem(entryNode, QCC_ID_KEY);
+  if (id && (id->type == cJSON_Number))
+  {
+    contextElement.id = snowflake_cJSON_GetUint64Value(id);
+  }
+  else
+  {
+    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `id` field is not integer type");
+    return false;
+  }
+
+  cJSON * timestamp = snowflake_cJSON_GetObjectItem(entryNode, QCC_TIMESTAMP_KEY);
+  if (timestamp && (timestamp->type == cJSON_Number))
+  {
+    contextElement.readTimestamp = snowflake_cJSON_GetUint64Value(timestamp);
+  }
+  else
+  {
+    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `timestamp` field is not integer type");
+    return false;
+  }
+
+  cJSON * priority = snowflake_cJSON_GetObjectItem(entryNode, QCC_PRIORITY_KEY);
+  if (priority && (priority->type == cJSON_Number))
+  {
+    contextElement.priority = snowflake_cJSON_GetUint64Value(priority);
+  }
+  else
+  {
+    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `priority` field is not integer type");
+    return false;
+  }
+
+  cJSON * context = snowflake_cJSON_GetObjectItem(entryNode, QCC_CONTEXT_KEY);
+  if (!context || context->type == cJSON_NULL)
+  {
+    return true;
+  }
+  if (context->type == cJSON_String)
+  {
+    contextElement.context = snowflake_cJSON_GetStringValue(context);
+  }
+  else
+  {
+    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `context` field is not string type");
+    return false;
+  }
+
+  return true;
+}
+
+bool QueryContextCache::deserializeQueryContextElementReq(cJSON * entryNode,
+                                                          QueryContextElement & contextElement)
+{
+  cJSON * id = snowflake_cJSON_GetObjectItem(entryNode, QCC_ID_KEY);
+  if (id && (id->type == cJSON_Number))
+  {
+    contextElement.id = snowflake_cJSON_GetUint64Value(id);
+  }
+  else
+  {
+    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `id` field is not integer type");
+    return false;
+  }
+
+  cJSON * timestamp = snowflake_cJSON_GetObjectItem(entryNode, QCC_TIMESTAMP_KEY);
+  if (timestamp && (timestamp->type == cJSON_Number))
+  {
+    contextElement.readTimestamp = snowflake_cJSON_GetUint64Value(timestamp);
+  }
+  else
+  {
+    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `timestamp` field is not integer type");
+    return false;
+  }
+
+  cJSON * priority = snowflake_cJSON_GetObjectItem(entryNode, QCC_PRIORITY_KEY);
+  if (priority && (priority->type == cJSON_Number))
+  {
+    contextElement.priority = snowflake_cJSON_GetUint64Value(priority);
+  }
+  else
+  {
+    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `priority` field is not integer type");
+    return false;
+  }
+
+  cJSON * context = snowflake_cJSON_GetObjectItem(entryNode, QCC_CONTEXT_KEY);
+  if (!context || context->type == cJSON_NULL)
+  {
+    return true;
+  }
+  if (context->type != cJSON_Object)
+  {
+    return false;
+  }
+
+  cJSON * contextValue = snowflake_cJSON_GetObjectItem(context, QCC_CONTEXT_VALUE_KEY);
+  if (!contextValue || contextValue->type == cJSON_NULL)
+  {
+    return true;
+  }
+
+  if (contextValue->type == cJSON_String)
+  {
+    contextElement.context = snowflake_cJSON_GetStringValue(contextValue);
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
+}
+
+void QueryContextCache::addQCE(const QueryContextElement& qce)
+{
+  m_idMap[qce.id] = qce;
+  // In a round of merge operations, we should save the new priority->qce mapping in an additional map
+  // and sync `newPriorityMap` to `priorityMap` at the end of a for loop of `merge` operations
+  m_newPriorityMap[qce.priority] = qce;
+  m_cacheSet.insert(qce);
+}
+
+void QueryContextCache::removeQCE(const QueryContextElement& qce)
+{
+  m_cacheSet.erase(qce);
+  m_priorityMap.erase(qce.priority);
+  m_idMap.erase(qce.id);
+}
+
+void QueryContextCache::updateQCE(const QueryContextElement& qce,
+                                  uint64 timestamp,
+                                  const std::string& context)
+{
+  QueryContextElement qceUpdate = qce;
+  qceUpdate.readTimestamp = timestamp;
+  qceUpdate.context = context;
+  m_cacheSet.erase(qce);
+  m_cacheSet.insert(qceUpdate);
+  m_idMap[qce.id] = qceUpdate;
+  m_priorityMap[qce.priority] = qceUpdate;
+}
+
+void QueryContextCache::replaceQCE(const QueryContextElement& oldQCE,
+                                   const QueryContextElement& newQCE)
+{
+  // Remove old element from the cache
+  removeQCE(oldQCE);
+  // Add new element in the cache
+  addQCE(newQCE);
+}
+
+void QueryContextCache::logCacheEntries()
+{
+#ifdef _DEBUG
+  for (auto itr = m_cacheSet.begin(); itr != m_cacheSet.end(); itr++)
+  {
+    CXX_LOG_TRACE("QueryContextCache: Cache Entry: id: %ld readTimestamp: %ld priority: %ld",
+                 itr->id, itr->readTimestamp, itr->priority);
+  }
+#endif
+}
+
+} // namespace Client
+} // namespace Snowflake

--- a/cpp/lib/QueryContextCache.hpp
+++ b/cpp/lib/QueryContextCache.hpp
@@ -1,0 +1,170 @@
+/*
+* File:   QueryContextCache.hpp
+* Author: harryx
+*
+* Copyright (c) 2023 Snowflake Computing
+*
+* Created on August 31, 2023, 4:05 PM
+*/
+
+#pragma once
+#ifndef QUERY_CONTEXT_CACHE_HPP
+#define QUERY_CONTEXT_CACHE_HPP
+
+#include "query_context_cache.h"
+#include <mutex>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace Snowflake
+{
+namespace Client
+{
+
+struct QueryContextElement
+{
+  uint64 id; // database id as key. (bigint)
+  uint64 readTimestamp; // When the query context read (bigint). Compare for same id.
+  uint64 priority; // Priority of the query context (bigint). Compare for different ids.
+  std::string context; // Opaque information (varbinary).
+
+  // constructors
+  QueryContextElement() : id(0), readTimestamp(0), priority(0)
+  {}
+
+  QueryContextElement(uint64 in_id, uint64 in_timestamp,
+                      uint64 in_pri, const std::string& in_context) :
+    id(in_id), readTimestamp(in_timestamp), priority(in_pri), context(in_context)
+  {}
+};
+
+struct QueryContextComparator {
+  bool operator() (const QueryContextElement& lhs, const QueryContextElement& rhs) const {
+    if (lhs.priority != rhs.priority)
+      return lhs.priority < rhs.priority;
+    else if (lhs.id != rhs.id)
+      return lhs.id < rhs.id;
+    else
+      return lhs.readTimestamp < rhs.readTimestamp;
+  }
+};
+
+class QueryContextCache
+{
+public:
+  // constructor
+  QueryContextCache(size_t capacity) : m_capacity(capacity) {}
+
+  void clearCache();
+
+  void setCapacity(size_t capacity);
+
+  /**
+  * @param data: the JSON value of QueryContext Object
+  */
+  void deserializeQueryContext(cJSON * data);
+
+  cJSON * serializeQueryContext();
+
+  /**
+  * for test purpose only, deserialize from JSON value serialized from cache
+  * for sending request
+  * @param data: the JSON value of QueryContext Object
+  */
+  void deserializeQueryContextReq(cJSON * data);
+
+  /**
+  * Merge a new element comes from the server with the existing cache. Merge is based on read time
+  * stamp for the same id and based on priority for two different ids.
+  *
+  * @param id Database id.
+  * @param readTimestamp Last time read metadata from FDB.
+  * @param priority 0 to N number, where 0 is the highest priority. Eviction policy is based on
+  *     priority.
+  * @param context Opaque query context.
+  */
+  void merge(uint64 id, uint64 readTimestamp, uint64 priority, const std::string& context);
+
+  /**
+  * Sync the newPriorityMap with the priorityMap at the end of current round of merge
+  */
+  void syncPriorityMap();
+
+  /**
+  * After the merge, loop through priority list and make sure cache is at most capacity. Remove all
+  * other elements from the list based on priority.
+  */
+  void checkCacheCapacity();
+
+  size_t getSize()
+  {
+    return m_cacheSet.size();
+  }
+
+  /*For unit test purpose only, get all elements in cache*/
+  size_t getElements(std::vector<uint64>& ids,
+                     std::vector<uint64>& readTimestamps,
+                     std::vector<uint64>& priorities,
+                     std::vector<std::string>& contexts);
+
+private:
+  bool deserializeQueryContextElement(cJSON * entryNode,
+                                      QueryContextElement & contextElement);
+
+  // for test purpose only, deserializeQueryContextElement from serialized
+  // JSON value for request
+  bool deserializeQueryContextElementReq(cJSON * entryNode,
+                                         QueryContextElement & contextElement);
+
+  /**
+  * Add an element in the cache.
+  *
+  * @param qce element to add
+  */
+  void addQCE(const QueryContextElement& qce);
+
+  /**
+  * Remove an element from the cache.
+  *
+  * @param qce element to remove.
+  */
+  void removeQCE(const QueryContextElement& qce);
+
+  /**
+  * Update timstamp and context of an existing qce.
+  *
+  * @param qce an element exist in the cache
+  * @param timestamp timestamp to be updated
+  * @param context query context to be updated
+  */
+  void updateQCE(const QueryContextElement& qce, uint64 timestamp,
+                 const std::string& context);
+
+  /**
+  * Replace the cache element with a new response element. Remove old element exist in the cache
+  * and add a new element received.
+  *
+  * @param oldQCE an element exist in the cache
+  * @param newQCE a new element just received.
+  */
+  void replaceQCE(const QueryContextElement& oldQCE, const QueryContextElement& newQCE);
+
+  /** Debugging purpose, log the all entries in the cache. */
+  void logCacheEntries();
+
+  // The mutex protecting access to the query context cache
+  std::recursive_mutex m_mutex;
+
+  size_t m_capacity;
+  // the query context cache mapped by id
+  std::map<uint64, QueryContextElement> m_idMap; // Map for id and QCC
+  std::map<uint64, QueryContextElement> m_priorityMap; // Map for priority and id
+  std::map<uint64, QueryContextElement> m_newPriorityMap; // Intermediate map for priority and id for current round of merging
+  std::set<QueryContextElement, QueryContextComparator> m_cacheSet; // Order data as per priority
+};
+
+} // namespace Client
+} // namespace Snowflake
+
+#endif  // QUERY_CONTEXT_CACHE_HPP

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -232,6 +232,7 @@ typedef enum SF_ATTRIBUTE {
     SF_CON_MAX_CON_RETRY,
     SF_CON_PROXY,
     SF_CON_NO_PROXY,
+    SF_CON_DISABLE_QUERY_CONTEXT_CACHE,
     SF_DIR_QUERY_URL,
     SF_DIR_QUERY_URL_PARAM,
     SF_DIR_QUERY_TOKEN,
@@ -317,6 +318,14 @@ typedef struct SF_CONNECT {
     // Proxy
     char * proxy;
     char * no_proxy;
+
+    // Query Context Cache
+    // the flag of whether to disable qcc, false by default
+    sf_bool qcc_disable;
+    // the cache capacity
+    uint64 qcc_capacity;
+    // the pointer of qcc instance
+    void * qcc;
 
     // Session info
     char *token;

--- a/lib/cJSON.h
+++ b/lib/cJSON.h
@@ -84,6 +84,7 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #define CJSON_VERSION_PATCH 15
 
 #include <stddef.h>
+#include "snowflake/basic_types.h"
 
 /* cJSON Types: */
 #define cJSON_Invalid (0)
@@ -115,6 +116,8 @@ typedef struct cJSON
     char *valuestring;
     /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
     int valueint;
+    /* The item's number as uint64, if type==cJSON_Number */
+    uint64 valueuint64;
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
 
@@ -180,6 +183,7 @@ CJSON_PUBLIC(const char *) snowflake_cJSON_GetErrorPtr(void);
 /* Check item type and return its value */
 CJSON_PUBLIC(char *) snowflake_cJSON_GetStringValue(const cJSON * const item);
 CJSON_PUBLIC(double) snowflake_cJSON_GetNumberValue(const cJSON * const item);
+CJSON_PUBLIC(uint64) snowflake_cJSON_GetUint64Value(const cJSON * const item);
 
 /* These functions check the type of an item */
 CJSON_PUBLIC(cJSON_bool) snowflake_cJSON_IsInvalid(const cJSON * const item);
@@ -199,6 +203,7 @@ CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateTrue(void);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateFalse(void);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateBool(cJSON_bool boolean);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateNumber(double num);
+CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateUint64(uint64 num);
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateString(const char *string);
 /* raw json */
 CJSON_PUBLIC(cJSON *) snowflake_cJSON_CreateRaw(const char *raw);
@@ -268,13 +273,15 @@ CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddTrueToObject(cJSON * const object, const
 CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddFalseToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
 CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddUint64ToObject(cJSON * const object, const char * const name, const uint64 number);
 CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
 CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
 CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddObjectToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) snowflake_cJSON_AddArrayToObject(cJSON * const object, const char * const name);
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
-#define snowflake_cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
+#define snowflake_cJSON_SetIntValue(object, number) ((object) ? (object)->valueuint64 = (object)->valueint = (object)->valuedouble = (number) : (number))
+#define snowflake_cJSON_SetUint64Value(object, number) ((object) ? ((object)->valuedouble = (number), (object)->valueuint64 = (number)) : (number))
 /* helper for the snowflake_cJSON_SetNumberValue macro */
 CJSON_PUBLIC(double) snowflake_cJSON_SetNumberHelper(cJSON *object, double number);
 #define snowflake_cJSON_SetNumberValue(object, number) ((object != NULL) ? snowflake_cJSON_SetNumberHelper(object, (double)number) : (number))

--- a/lib/query_context_cache.h
+++ b/lib/query_context_cache.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKE_QUERY_CONTEXT_CACHE_H
+#define SNOWFLAKE_QUERY_CONTEXT_CACHE_H
+
+#include "snowflake/client.h"
+#include "cJSON.h"
+
+#define QCC_CAPACITY_DEF        5
+#define QCC_RSP_KEY             "queryContext"
+#define QCC_REQ_KEY             "queryContextDTO"
+#define QCC_ENTRIES_KEY         "entries"
+#define QCC_ID_KEY              "id"
+#define QCC_PRIORITY_KEY        "priority"
+#define QCC_TIMESTAMP_KEY       "timestamp"
+#define QCC_CONTEXT_KEY         "context"
+#define QCC_CONTEXT_VALUE_KEY   "base64Data"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /**
+     * Initialize query context cache
+     *
+     * @param conn                 The connection
+     *
+     */
+    void qcc_initialize(SF_CONNECT * conn);
+
+    /**
+    * set query context cache capacity
+    *
+    * @param capacity              The max size of query context cache
+    *
+    */
+    void qcc_set_capacity(SF_CONNECT * conn, uint64 capacity);
+
+    /**
+     * Retrieve serialized query context cache for sending in query request
+     *
+     * @param conn                 The connection
+     *
+     * @return serialized query context cache in JSON
+     */
+    cJSON* qcc_serialize(SF_CONNECT * conn);
+
+    /**
+     * Deserialize query context from query response and merge into cache
+     *
+     * @param conn                 The connection
+     * @param query_context        The JSON node of query context from query response
+     *
+     */
+    void qcc_deserialize(SF_CONNECT * conn, cJSON* query_context);
+
+    /**
+    * Terminate query context cache
+    *
+    * @param conn                 The connection
+    */
+    void qcc_terminate(SF_CONNECT * conn);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // SNOWFLAKE_QUERY_CONTEXT_CACHE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,8 @@ SET(TESTS_CXX
         test_unit_oob
         test_unit_set_get_attributes
         test_unit_snowflake_types_to_string
-        test_unit_azure_client)
+        test_unit_azure_client
+        test_unit_query_context_cache)
 
 SET(TESTS_PUTGET
         test_include_aws

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -72,6 +72,28 @@ void test_connect_with_full_parameters(void **unused) {
     snowflake_term(sf); // purge snowflake context
 }
 
+/**
+* Test connection with disableQueryContextCache
+*/
+void test_connect_with_disable_qcc(void **unused) {
+  SF_CONNECT *sf = setup_snowflake_connection();
+
+  sf_bool disable_qcc = SF_BOOLEAN_TRUE;
+  void* value = NULL;
+  snowflake_set_attribute(sf, SF_CON_DISABLE_QUERY_CONTEXT_CACHE, &disable_qcc);
+
+  SF_STATUS status = snowflake_connect(sf);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sf->error));
+    }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+
+  snowflake_get_attribute(sf, SF_CON_DISABLE_QUERY_CONTEXT_CACHE, &value);
+  assert_true(*((sf_bool *)value) == SF_BOOLEAN_TRUE);
+
+  snowflake_term(sf); // purge snowflake context
+}
+
 void setCacheFile(char *cache_file)
 {
 #ifdef __linux__

--- a/tests/test_unit_query_context_cache.cpp
+++ b/tests/test_unit_query_context_cache.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <string>
+#include "./lib/QueryContextCache.hpp"
+#include "utils/test_setup.h"
+#include "utils/TestSetup.hpp"
+
+using namespace Snowflake::Client;
+
+static const int MAX_CAPACITY = 5;
+static const uint64 BASE_READ_TIMESTAMP = 1668727958;
+static const std::string SOME_CONTEXT = "Some query context";
+static const uint64 BASE_ID = 0;
+static const uint64 BASE_PRIORITY = 0;
+
+// test helper so make everything public
+class QueryContextCacheTestHelper
+{
+public:
+  Snowflake::Client::QueryContextCache qcc;
+  std::vector<uint64> expectedIDs;
+  std::vector<uint64> expectedReadTimestamp;
+  std::vector<uint64> expectedPriority;
+
+  QueryContextCacheTestHelper() : qcc(MAX_CAPACITY) {}
+
+  void initCache()
+  {
+    qcc.clearCache();
+    qcc.setCapacity(MAX_CAPACITY);
+  }
+
+  void initCacheWithDataWithContext(const std::string& context)
+  {
+    initCache();
+    expectedIDs.resize(MAX_CAPACITY);
+    expectedReadTimestamp.resize(MAX_CAPACITY);
+    expectedPriority.resize(MAX_CAPACITY);
+    for (int i = 0; i < MAX_CAPACITY; i++) {
+      expectedIDs[i] = BASE_ID + i;
+      expectedReadTimestamp[i] = BASE_READ_TIMESTAMP + i;
+      expectedPriority[i] = BASE_PRIORITY + i;
+      qcc.merge(expectedIDs[i], expectedReadTimestamp[i], expectedPriority[i], context);
+    }
+    qcc.syncPriorityMap();
+  }
+
+  void initCacheWithData()
+  {
+    initCacheWithDataWithContext(SOME_CONTEXT);
+  }
+
+  void initCacheWithDataInRandomOrder()
+  {
+    initCache();
+    expectedIDs.resize(MAX_CAPACITY);
+    expectedReadTimestamp.resize(MAX_CAPACITY);
+    expectedPriority.resize(MAX_CAPACITY);
+    for (int i = 0; i < MAX_CAPACITY; i++) {
+      expectedIDs[i] = BASE_ID + i;
+      expectedReadTimestamp[i] = BASE_READ_TIMESTAMP + i;
+      expectedPriority[i] = BASE_PRIORITY + i;
+    }
+
+    qcc.merge(expectedIDs[3], expectedReadTimestamp[3], expectedPriority[3], SOME_CONTEXT);
+    qcc.merge(expectedIDs[2], expectedReadTimestamp[2], expectedPriority[2], SOME_CONTEXT);
+    qcc.merge(expectedIDs[4], expectedReadTimestamp[4], expectedPriority[4], SOME_CONTEXT);
+    qcc.merge(expectedIDs[0], expectedReadTimestamp[0], expectedPriority[0], SOME_CONTEXT);
+    qcc.merge(expectedIDs[1], expectedReadTimestamp[1], expectedPriority[1], SOME_CONTEXT);
+    qcc.syncPriorityMap();
+  }
+
+  void assertCacheDataWithContext(const std::string& context)
+  {
+    std::vector<uint64> ids;
+    std::vector<uint64> readTimestamps;
+    std::vector<uint64> priorities;
+    std::vector<std::string> contexts;
+
+    // Compare elements
+    size_t size = qcc.getElements(ids, readTimestamps, priorities, contexts);
+    assert_int_equal(size, MAX_CAPACITY);
+    for (size_t i = 0; i < size; i++) {
+      assert_int_equal(expectedIDs[i], ids[i]);
+      assert_int_equal(expectedReadTimestamp[i], readTimestamps[i]);
+      assert_int_equal(expectedPriority[i], priorities[i]);
+      assert_string_equal(context.c_str(), contexts[i].c_str());
+    }
+  }
+
+  void assertCacheData()
+  {
+    assertCacheDataWithContext(SOME_CONTEXT);
+  }
+};
+
+void test_is_empty(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCache();
+  assert_int_equal(helper.qcc.getSize(), 0);
+}
+
+void test_with_some_data(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_with_some_data_in_random_order(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithDataInRandomOrder();
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_more_than_capacity(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+
+  // Add one more element at the end
+  int i = MAX_CAPACITY;
+  helper.qcc.merge(BASE_ID + i, BASE_READ_TIMESTAMP + i, BASE_PRIORITY + i, SOME_CONTEXT);
+  helper.qcc.syncPriorityMap();
+  helper.qcc.checkCacheCapacity();
+
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_update_timestamp(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+
+  // Add one more element with new TS with existing id
+  int updatedID = 1;
+  helper.expectedReadTimestamp[updatedID] = BASE_READ_TIMESTAMP + updatedID + 10;
+  helper.qcc.merge(BASE_ID + updatedID,
+                   helper.expectedReadTimestamp[updatedID],
+                   BASE_PRIORITY + updatedID,
+                   SOME_CONTEXT);
+  helper.qcc.syncPriorityMap();
+  helper.qcc.checkCacheCapacity();
+
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_update_priority(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+
+  // Add one more element with new priority with existing id
+  int updatedID = 3;
+  uint64 updatedPriority = BASE_PRIORITY + updatedID + 7;
+
+  helper.expectedPriority[updatedID] = updatedPriority;
+  helper.qcc.merge(BASE_ID + updatedID,
+                   BASE_READ_TIMESTAMP + updatedID,
+                   helper.expectedPriority[updatedID],
+                   SOME_CONTEXT);
+  helper.qcc.syncPriorityMap();
+  helper.qcc.checkCacheCapacity();
+
+  for (int i = updatedID; i < MAX_CAPACITY - 1; i++) {
+    helper.expectedIDs[i] = helper.expectedIDs[i + 1];
+    helper.expectedReadTimestamp[i] = helper.expectedReadTimestamp[i + 1];
+    helper.expectedPriority[i] = helper.expectedPriority[i + 1];
+  }
+
+  helper.expectedIDs[MAX_CAPACITY - 1] = BASE_ID + updatedID;
+  helper.expectedReadTimestamp[MAX_CAPACITY - 1] = BASE_READ_TIMESTAMP + updatedID;
+  helper.expectedPriority[MAX_CAPACITY - 1] = updatedPriority;
+
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_add_same_priority(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+
+  // Add one more element with same priority
+  int i = MAX_CAPACITY;
+  uint64 UpdatedPriority = BASE_PRIORITY + 1;
+  helper.qcc.merge(BASE_ID + i, BASE_READ_TIMESTAMP + i, UpdatedPriority, SOME_CONTEXT);
+  helper.qcc.syncPriorityMap();
+  helper.qcc.checkCacheCapacity();
+  helper.expectedIDs[1] = BASE_ID + i;
+  helper.expectedReadTimestamp[1] = BASE_READ_TIMESTAMP + i;
+
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_add_same_id_but_stale_timestamp(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+
+  // Add one more element with same id
+  int i = 2;
+  helper.qcc.merge(BASE_ID + i, BASE_READ_TIMESTAMP + i - 10, BASE_PRIORITY + i, SOME_CONTEXT);
+  helper.qcc.syncPriorityMap();
+  helper.qcc.checkCacheCapacity();
+
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_empty_cache_with_null_data(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+
+  cJSON * nullData = NULL;
+  helper.qcc.deserializeQueryContext(nullData);
+
+  assert_int_equal(helper.qcc.getSize(), 0);
+}
+
+void test_empty_cache_with_empty_response_data(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+
+  cJSON * emptyData = snowflake_cJSON_Parse("");
+  helper.qcc.deserializeQueryContext(emptyData);
+
+  assert_int_equal(helper.qcc.getSize(), 0);
+}
+
+void test_serialize_request_and_deserialize_response_data(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  helper.initCacheWithData();
+  helper.assertCacheData();
+
+  cJSON* cacheData = helper.qcc.serializeQueryContext();
+
+  // Clear qcc
+  helper.qcc.clearCache();
+  assert_int_equal(helper.qcc.getSize(), 0);
+
+  helper.qcc.deserializeQueryContextReq(cacheData);
+
+  // Compare elements
+  helper.assertCacheData();
+}
+
+void test_serialize_request_and_deserialize_response_data_with_empty_context(void ** unused)
+{
+  QueryContextCacheTestHelper helper;
+  // Init qcc
+  helper.initCacheWithDataWithContext("");
+  helper.assertCacheDataWithContext("");
+
+  cJSON * cacheData = helper.qcc.serializeQueryContext();
+
+  // Clear qcc
+  helper.qcc.clearCache();
+  assert_int_equal(helper.qcc.getSize(), 0);
+
+  helper.qcc.deserializeQueryContextReq(cacheData);
+  helper.assertCacheDataWithContext("");
+}
+
+static int gr_setup(void **unused)
+{
+  initialize_test(SF_BOOLEAN_FALSE);
+  return 0;
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_is_empty),
+    cmocka_unit_test(test_with_some_data),
+    cmocka_unit_test(test_with_some_data_in_random_order),
+    cmocka_unit_test(test_more_than_capacity),
+    cmocka_unit_test(test_update_timestamp),
+    cmocka_unit_test(test_update_priority),
+    cmocka_unit_test(test_add_same_priority),
+    cmocka_unit_test(test_add_same_id_but_stale_timestamp),
+    cmocka_unit_test(test_empty_cache_with_null_data),
+    cmocka_unit_test(test_empty_cache_with_empty_response_data),
+    cmocka_unit_test(test_serialize_request_and_deserialize_response_data),
+    cmocka_unit_test(test_serialize_request_and_deserialize_response_data_with_empty_context),
+  };
+  int ret = cmocka_run_group_tests(tests, gr_setup, NULL);
+  return ret;
+}


### PR DESCRIPTION
e2e test with queries mentioned in ODBC ticket (sdk issue 21) and the qcc content in log looks good.
[snowflake_20230906153320.txt](https://github.com/snowflakedb/libsnowflakeclient/files/12543069/snowflake_20230906153320.txt)

Currently the ODBC keep it's own implementation. Follow up ticket created to refactor implementation in libsnowflakeclient and reuse it in ODBC. https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/643
