### PR TITLE
SNOW-871471: [HTAP] add retry context in retry for query request

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -233,7 +233,7 @@ typedef enum SF_ATTRIBUTE {
     SF_CON_PROXY,
     SF_CON_NO_PROXY,
     SF_CON_DISABLE_QUERY_CONTEXT_CACHE,
-    SF_CON_INCLUDE_RETRY_CONTEXT,
+    SF_CON_INCLUDE_RETRY_REASON,
     SF_DIR_QUERY_URL,
     SF_DIR_QUERY_URL_PARAM,
     SF_DIR_QUERY_TOKEN,
@@ -328,8 +328,8 @@ typedef struct SF_CONNECT {
     // the pointer of qcc instance
     void * qcc;
 
-    // retry context
-    sf_bool include_retry_context;
+    // whether to include retry reason in retry for query request
+    sf_bool include_retry_reason;
 
     // Session info
     char *token;

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -233,6 +233,7 @@ typedef enum SF_ATTRIBUTE {
     SF_CON_PROXY,
     SF_CON_NO_PROXY,
     SF_CON_DISABLE_QUERY_CONTEXT_CACHE,
+    SF_CON_INCLUDE_RETRY_CONTEXT,
     SF_DIR_QUERY_URL,
     SF_DIR_QUERY_URL_PARAM,
     SF_DIR_QUERY_TOKEN,
@@ -326,6 +327,9 @@ typedef struct SF_CONNECT {
     uint64 qcc_capacity;
     // the pointer of qcc instance
     void * qcc;
+
+    // retry context
+    sf_bool include_retry_context;
 
     // Session info
     char *token;

--- a/lib/chunk_downloader.c
+++ b/lib/chunk_downloader.c
@@ -217,7 +217,7 @@ sf_bool STDCALL download_chunk(char *url, SF_HEADER *headers,
                       non_json_resp, DEFAULT_SNOWFLAKE_REQUEST_TIMEOUT,
                       SF_BOOLEAN_TRUE, error, insecure_mode, 0,
                       0, 0, NULL, NULL, NULL, SF_BOOLEAN_FALSE,
-                      proxy, no_proxy)) {
+                      proxy, no_proxy, SF_BOOLEAN_FALSE)) {
         // Error set in perform function
         goto cleanup;
     }

--- a/lib/client.c
+++ b/lib/client.c
@@ -516,6 +516,7 @@ _snowflake_check_connection_parameters(SF_CONNECT *sf) {
     log_debug("login_timeout: %d", sf->login_timeout);
     log_debug("network_timeout: %d", sf->network_timeout);
     log_debug("qcc_disable: %s", sf->qcc_disable ? "true" : "false");
+    log_debug("include_retry_context: %s", sf->include_retry_context ? "true" : "false");
 
     return SF_STATUS_SUCCESS;
 }
@@ -660,6 +661,8 @@ SF_CONNECT *STDCALL snowflake_init() {
         sf->passcode_in_password = SF_BOOLEAN_FALSE;
         sf->insecure_mode = SF_BOOLEAN_FALSE;
         sf->autocommit = SF_BOOLEAN_TRUE;
+        sf->qcc_disable = SF_BOOLEAN_FALSE;
+        sf->include_retry_context = SF_BOOLEAN_TRUE;
         sf->timezone = NULL;
         sf->service_name = NULL;
         sf->query_result_format = NULL;
@@ -1097,6 +1100,9 @@ SF_STATUS STDCALL snowflake_set_attribute(
         case SF_CON_DISABLE_QUERY_CONTEXT_CACHE:
             sf->qcc_disable = value ? *((sf_bool *)value) : SF_BOOLEAN_FALSE;
             break;
+        case SF_CON_INCLUDE_RETRY_CONTEXT:
+            sf->include_retry_context = value ? *((sf_bool *)value) : SF_BOOLEAN_TRUE;
+            break;
         default:
             SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_ATTRIBUTE_TYPE,
                                 "Invalid attribute type",
@@ -1221,6 +1227,9 @@ SF_STATUS STDCALL snowflake_get_attribute(
             break;
         case SF_CON_DISABLE_QUERY_CONTEXT_CACHE:
             *value = &sf->qcc_disable;
+            break;
+        case SF_CON_INCLUDE_RETRY_CONTEXT:
+            *value = &sf->include_retry_context;
             break;
         default:
             SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_ATTRIBUTE_TYPE,

--- a/lib/client.c
+++ b/lib/client.c
@@ -516,7 +516,7 @@ _snowflake_check_connection_parameters(SF_CONNECT *sf) {
     log_debug("login_timeout: %d", sf->login_timeout);
     log_debug("network_timeout: %d", sf->network_timeout);
     log_debug("qcc_disable: %s", sf->qcc_disable ? "true" : "false");
-    log_debug("include_retry_context: %s", sf->include_retry_context ? "true" : "false");
+    log_debug("include_retry_reason: %s", sf->include_retry_reason ? "true" : "false");
 
     return SF_STATUS_SUCCESS;
 }
@@ -662,7 +662,7 @@ SF_CONNECT *STDCALL snowflake_init() {
         sf->insecure_mode = SF_BOOLEAN_FALSE;
         sf->autocommit = SF_BOOLEAN_TRUE;
         sf->qcc_disable = SF_BOOLEAN_FALSE;
-        sf->include_retry_context = SF_BOOLEAN_TRUE;
+        sf->include_retry_reason = SF_BOOLEAN_TRUE;
         sf->timezone = NULL;
         sf->service_name = NULL;
         sf->query_result_format = NULL;
@@ -1100,8 +1100,8 @@ SF_STATUS STDCALL snowflake_set_attribute(
         case SF_CON_DISABLE_QUERY_CONTEXT_CACHE:
             sf->qcc_disable = value ? *((sf_bool *)value) : SF_BOOLEAN_FALSE;
             break;
-        case SF_CON_INCLUDE_RETRY_CONTEXT:
-            sf->include_retry_context = value ? *((sf_bool *)value) : SF_BOOLEAN_TRUE;
+        case SF_CON_INCLUDE_RETRY_REASON:
+            sf->include_retry_reason = value ? *((sf_bool *)value) : SF_BOOLEAN_TRUE;
             break;
         default:
             SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_ATTRIBUTE_TYPE,
@@ -1228,8 +1228,8 @@ SF_STATUS STDCALL snowflake_get_attribute(
         case SF_CON_DISABLE_QUERY_CONTEXT_CACHE:
             *value = &sf->qcc_disable;
             break;
-        case SF_CON_INCLUDE_RETRY_CONTEXT:
-            *value = &sf->include_retry_context;
+        case SF_CON_INCLUDE_RETRY_REASON:
+            *value = &sf->include_retry_reason;
             break;
         default:
             SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_ATTRIBUTE_TYPE,

--- a/lib/client_int.h
+++ b/lib/client_int.h
@@ -27,6 +27,13 @@
 #define RENEW_SESSION_URL "/session/token-request"
 #define DELETE_SESSION_URL "/session"
 
+#define URL_PARAM_REQEST_GUID "request_guid="
+#define URL_PARAM_RETRY_COUNT "retryCount="
+#define URL_PARAM_RETRY_REASON "retryReason="
+// having extra size in url buffer for retry context or something else could
+// be added in the future.
+#define URL_EXTRA_SIZE 256
+
 #define URL_QUERY_DELIMITER "?"
 #define URL_PARAM_DELIM "&"
 

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -337,7 +337,7 @@ sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
                           sf->retry_on_curle_couldnt_connect_count,
                           renew_timeout, retry_max_count, elapsed_time,
                           retried_count, is_renew, renew_injection,
-                          sf->proxy, sf->no_proxy, sf->include_retry_context) ||
+                          sf->proxy, sf->no_proxy, sf->include_retry_reason) ||
             !*json) {
             // Error is set in the perform function
             break;
@@ -1082,7 +1082,7 @@ uint32 STDCALL retry_ctx_next_sleep(RETRY_CONTEXT *retry_ctx) {
 
 sf_bool STDCALL retry_ctx_update_url(RETRY_CONTEXT *retry_ctx,
                                      char* url,
-                                     sf_bool include_retry_context) {
+                                     sf_bool include_retry_reason) {
     char *request_guid_ptr = strstr(url, URL_PARAM_REQEST_GUID);
     if (!request_guid_ptr)
     {
@@ -1113,30 +1113,30 @@ sf_bool STDCALL retry_ctx_update_url(RETRY_CONTEXT *retry_ctx,
       return SF_BOOLEAN_TRUE;
     }
 
-    if (include_retry_context == SF_BOOLEAN_TRUE)
+    char * retry_context_ptr = strstr(url, URL_PARAM_RETRY_COUNT);
+    if (!retry_context_ptr)
     {
-      char * retry_context_ptr = strstr(url, URL_PARAM_RETRY_COUNT);
-      if (!retry_context_ptr)
-      {
-        // original url that doesn't have retry context yet, replace start from guid
-        retry_context_ptr = request_guid_ptr;
-      }
+      // original url that doesn't have retry context yet, replace start from guid
+      retry_context_ptr = request_guid_ptr;
+    }
 
-      // retry count
-      SPRINT_TO_BUFFER(retry_context_ptr, "%s", URL_PARAM_RETRY_COUNT);
-      SPRINT_TO_BUFFER(retry_context_ptr, "%llu", retry_ctx->retry_count);
-      SPRINT_TO_BUFFER(retry_context_ptr, "%s", URL_PARAM_DELIM);
+    // retry count
+    SPRINT_TO_BUFFER(retry_context_ptr, "%s", URL_PARAM_RETRY_COUNT);
+    SPRINT_TO_BUFFER(retry_context_ptr, "%llu", retry_ctx->retry_count);
+    SPRINT_TO_BUFFER(retry_context_ptr, "%s", URL_PARAM_DELIM);
 
+    if (include_retry_reason == SF_BOOLEAN_TRUE)
+    {
       // retry reason
       SPRINT_TO_BUFFER(retry_context_ptr, "%s", URL_PARAM_RETRY_REASON);
       SPRINT_TO_BUFFER(retry_context_ptr, "%lu", retry_ctx->retry_reason);
       SPRINT_TO_BUFFER(retry_context_ptr, "%s", URL_PARAM_DELIM);
       // clear retry reason for the next retry attempt
       retry_ctx->retry_reason = 0;
-
-      // add request guid after retry context
-      request_guid_ptr = retry_context_ptr;
     }
+
+    // add request guid after retry context
+    request_guid_ptr = retry_context_ptr;
 
     SPRINT_TO_BUFFER(request_guid_ptr, "%s", URL_PARAM_REQEST_GUID);
     if (uuid4_generate(request_guid_ptr)) {

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -441,7 +441,7 @@ sf_bool STDCALL http_perform(CURL *curl, SF_REQUEST_TYPE request_type, char *url
                              int64 *elapsed_time, int8 *retried_count,
                              sf_bool *is_renew, sf_bool renew_injection,
                              const char *proxy, const char *no_proxy,
-                             sf_bool include_retry_context);
+                             sf_bool include_retry_reason);
 
 /**
  * Returns true if HTTP code is retryable, false otherwise.
@@ -540,7 +540,7 @@ uint32 STDCALL retry_ctx_next_sleep(RETRY_CONTEXT *retry_ctx);
 * @return SF_BOOLEAN_TRUE if succeeded, otherwise SF_BOOLEAN_FALSE.
 */
 sf_bool STDCALL retry_ctx_update_url(RETRY_CONTEXT *retry_ctx, char* url,
-                                     sf_bool include_retry_context);
+                                     sf_bool include_retry_reason);
 
 /**
  * Convenience function to set tokens in Snowflake Connect object from cJSON blob. Returns success/failure.

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -158,7 +158,7 @@ sf_bool STDCALL http_perform(CURL *curl,
                              sf_bool renew_injection,
                              const char *proxy,
                              const char *no_proxy,
-                             sf_bool include_retry_context) {
+                             sf_bool include_retry_reason) {
     CURLcode res;
     sf_bool ret = SF_BOOLEAN_FALSE;
     sf_bool retry = SF_BOOLEAN_FALSE;
@@ -198,7 +198,7 @@ sf_bool STDCALL http_perform(CURL *curl,
         buffer.size = 0;
 
         // Generate new request guid, if request guid exists in url
-        if (SF_BOOLEAN_TRUE != retry_ctx_update_url(&curl_retry_ctx, url, include_retry_context)) {
+        if (SF_BOOLEAN_TRUE != retry_ctx_update_url(&curl_retry_ctx, url, include_retry_reason)) {
             log_error("Failed to update request url");
             break;
         }

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -29,8 +29,6 @@
 #include "constants.h"
 #include "client_int.h"
 
-#define REQUEST_GUID_KEY_SIZE 13
-
 static void
 dump(const char *text, FILE *stream, unsigned char *ptr, size_t size,
      char nohex);
@@ -159,7 +157,8 @@ sf_bool STDCALL http_perform(CURL *curl,
                              sf_bool *is_renew,
                              sf_bool renew_injection,
                              const char *proxy,
-                             const char *no_proxy) {
+                             const char *no_proxy,
+                             sf_bool include_retry_context) {
     CURLcode res;
     sf_bool ret = SF_BOOLEAN_FALSE;
     sf_bool retry = SF_BOOLEAN_FALSE;
@@ -177,6 +176,7 @@ sf_bool STDCALL http_perform(CURL *curl,
     }
     RETRY_CONTEXT curl_retry_ctx = {
             retried_count ? *retried_count : 0,      //retry_count
+            0,      // retry reason
             network_timeout,
             1,      // time to sleep
             &djb    // Decorrelate jitter
@@ -192,21 +192,14 @@ sf_bool STDCALL http_perform(CURL *curl,
 
     //TODO set error buffer
 
-    // Find request GUID in the supplied URL
-    char *request_guid_ptr = strstr(url, "request_guid=");
-    // Set pointer to the beginning of the UUID string if request GUID exists
-    if (request_guid_ptr) {
-        request_guid_ptr = request_guid_ptr + REQUEST_GUID_KEY_SIZE;
-    }
-
     do {
         // Reset buffer since this may not be our first rodeo
         SF_FREE(buffer.buffer);
         buffer.size = 0;
 
         // Generate new request guid, if request guid exists in url
-        if (request_guid_ptr && uuid4_generate_non_terminated(request_guid_ptr)) {
-            log_error("Failed to generate new request GUID");
+        if (SF_BOOLEAN_TRUE != retry_ctx_update_url(&curl_retry_ctx, url, include_retry_context)) {
+            log_error("Failed to update request url");
             break;
         }
 
@@ -418,6 +411,8 @@ sf_bool STDCALL http_perform(CURL *curl,
                                     SF_STATUS_ERROR_RETRY,
                                     msg,
                                     SF_SQLSTATE_UNABLE_TO_CONNECT);
+              } else {
+                curl_retry_ctx.retry_reason = (uint32)http_code;
               }
               if (retry &&
                   ((time(NULL) - elapsedRetryTime) < curl_retry_ctx.retry_timeout) &&

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(
 SET(TESTS_C
         test_unit_connect_parameters
         test_unit_logger
+        test_unit_retry_context
         test_connect
         test_connect_negative
         test_bind_params

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -94,6 +94,28 @@ void test_connect_with_disable_qcc(void **unused) {
   snowflake_term(sf); // purge snowflake context
 }
 
+/**
+* Test connection with includeRetryContext
+*/
+void test_connect_with_include_retry_context(void **unused) {
+  SF_CONNECT *sf = setup_snowflake_connection();
+
+  sf_bool include_retry_context = SF_BOOLEAN_FALSE;
+  void* value = NULL;
+  snowflake_set_attribute(sf, SF_CON_INCLUDE_RETRY_CONTEXT, &include_retry_context);
+
+  SF_STATUS status = snowflake_connect(sf);
+  if (status != SF_STATUS_SUCCESS) {
+    dump_error(&(sf->error));
+  }
+  assert_int_equal(status, SF_STATUS_SUCCESS);
+
+  snowflake_get_attribute(sf, SF_CON_INCLUDE_RETRY_CONTEXT, &value);
+  assert_true(*((sf_bool *)value) == SF_BOOLEAN_FALSE);
+
+  snowflake_term(sf); // purge snowflake context
+}
+
 void setCacheFile(char *cache_file)
 {
 #ifdef __linux__

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -95,14 +95,14 @@ void test_connect_with_disable_qcc(void **unused) {
 }
 
 /**
-* Test connection with includeRetryContext
+* Test connection with includeRetryReason
 */
 void test_connect_with_include_retry_context(void **unused) {
   SF_CONNECT *sf = setup_snowflake_connection();
 
-  sf_bool include_retry_context = SF_BOOLEAN_FALSE;
+  sf_bool include_retry_reason = SF_BOOLEAN_FALSE;
   void* value = NULL;
-  snowflake_set_attribute(sf, SF_CON_INCLUDE_RETRY_CONTEXT, &include_retry_context);
+  snowflake_set_attribute(sf, SF_CON_INCLUDE_RETRY_REASON, &include_retry_reason);
 
   SF_STATUS status = snowflake_connect(sf);
   if (status != SF_STATUS_SUCCESS) {
@@ -110,7 +110,7 @@ void test_connect_with_include_retry_context(void **unused) {
   }
   assert_int_equal(status, SF_STATUS_SUCCESS);
 
-  snowflake_get_attribute(sf, SF_CON_INCLUDE_RETRY_CONTEXT, &value);
+  snowflake_get_attribute(sf, SF_CON_INCLUDE_RETRY_REASON, &value);
   assert_true(*((sf_bool *)value) == SF_BOOLEAN_FALSE);
 
   snowflake_term(sf); // purge snowflake context

--- a/tests/test_unit_retry_context.c
+++ b/tests/test_unit_retry_context.c
@@ -55,7 +55,7 @@ void test_update_other_url_with_guid(void **unused) {
   assert_int_equal(strncmp(URL_NON_QUERY_WITH_GUID, urlbuf, strlen(urlbuf)), 0);
 }
 
-void test_update_query_url_with_retry_context_disabled(void **unused) {
+void test_update_query_url_with_retry_reason_disabled(void **unused) {
   char urlbuf[512];
   sb_sprintf(urlbuf, sizeof(urlbuf), "%s", URL_QUERY);
   RETRY_CONTEXT retry_ctx = {
@@ -69,18 +69,55 @@ void test_update_query_url_with_retry_context_disabled(void **unused) {
   sf_bool ret = retry_ctx_update_url(&retry_ctx, urlbuf, SF_BOOLEAN_FALSE);
   assert_int_equal(ret, SF_BOOLEAN_TRUE);
 
-  // should only replace the guid and no retry count/reason added
-  assert_int_equal(strlen(urlbuf), strlen(URL_QUERY));
-  assert_null(strstr(urlbuf, URL_PARAM_RETRY_COUNT));
-  assert_null(strstr(urlbuf, URL_PARAM_RETRY_REASON));
+  // ended with guid
   char* guid_ptr = strstr(urlbuf, URL_PARAM_REQEST_GUID);
   assert_non_null(guid_ptr);
   assert_int_equal(strlen(guid_ptr), GUID_LENGTH);
   *guid_ptr = '\0';
+
+  // should not have retry reason added
+  char* retryreason_ptr = strstr(urlbuf, URL_PARAM_RETRY_REASON);
+  assert_null(retryreason_ptr);
+
+  // should have retry count added
+  char* retrycount_ptr = strstr(urlbuf, URL_PARAM_RETRY_COUNT);
+  assert_non_null(retrycount_ptr);
+  assert_string_equal(retrycount_ptr, "retryCount=1&");
+  *retrycount_ptr = '\0';
+
+  // rest part should be unchanged
+  assert_int_equal(strncmp(URL_QUERY, urlbuf, strlen(urlbuf)), 0);
+
+  // recover the updated URL for testing next retry
+  *guid_ptr = 'r';
+  *retrycount_ptr = 'r';
+  retry_ctx.retry_count = 2;
+  retry_ctx.retry_reason = 503;
+
+  ret = retry_ctx_update_url(&retry_ctx, urlbuf, SF_BOOLEAN_FALSE);
+  assert_int_equal(ret, SF_BOOLEAN_TRUE);
+
+  // ended with guid
+  guid_ptr = strstr(urlbuf, URL_PARAM_REQEST_GUID);
+  assert_non_null(guid_ptr);
+  assert_int_equal(strlen(guid_ptr), GUID_LENGTH);
+  *guid_ptr = '\0';
+
+  // should not have retry reason added
+  retryreason_ptr = strstr(urlbuf, URL_PARAM_RETRY_REASON);
+  assert_null(retryreason_ptr);
+
+  // should have retry count/reason updated
+  retrycount_ptr = strstr(urlbuf, URL_PARAM_RETRY_COUNT);
+  assert_non_null(retrycount_ptr);
+  assert_string_equal(retrycount_ptr, "retryCount=2&");
+  *retrycount_ptr = '\0';
+
+  // rest part should be unchanged
   assert_int_equal(strncmp(URL_QUERY, urlbuf, strlen(urlbuf)), 0);
 }
 
-void test_update_query_url_with_retry_context_enabled(void **unused) {
+void test_update_query_url_with_retry_reason_enabled(void **unused) {
   char urlbuf[512];
   sb_sprintf(urlbuf, sizeof(urlbuf), "%s", URL_QUERY);
   RETRY_CONTEXT retry_ctx = {
@@ -138,8 +175,8 @@ int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_update_url_no_guid),
         cmocka_unit_test(test_update_other_url_with_guid),
-        cmocka_unit_test(test_update_query_url_with_retry_context_disabled),
-        cmocka_unit_test(test_update_query_url_with_retry_context_enabled),
+        cmocka_unit_test(test_update_query_url_with_retry_reason_disabled),
+        cmocka_unit_test(test_update_query_url_with_retry_reason_enabled),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/test_unit_retry_context.c
+++ b/tests/test_unit_retry_context.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2018-2019 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include "connection.h"
+#include "client_int.h"
+#include "utils/test_setup.h"
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#define URL_QUERY "http://snowflake.com/queries/v1/query-request?request_guid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+#define URL_NON_QUERY_WITH_GUID "http://snowflake.com/other-path?request_guid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+#define URL_NO_GUID "http://snowflake.com/other-path"
+#define GUID_LENGTH strlen("request_guid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+
+void test_update_url_no_guid(void **unused) {
+    char urlbuf[512];
+    sb_sprintf(urlbuf, sizeof(urlbuf), "%s", URL_NO_GUID);
+    RETRY_CONTEXT retry_ctx = {
+      1,      //retry_count
+      0,      // retry reason
+      0,      // network_timeout
+      1,      // time to sleep
+      NULL    // Decorrelate jitter
+    };
+
+    sf_bool ret = retry_ctx_update_url(&retry_ctx, urlbuf, SF_BOOLEAN_TRUE);
+    assert_int_equal(ret, SF_BOOLEAN_TRUE);
+    assert_string_equal(urlbuf, URL_NO_GUID);
+}
+
+void test_update_other_url_with_guid(void **unused) {
+  char urlbuf[512];
+  sb_sprintf(urlbuf, sizeof(urlbuf), "%s", URL_NON_QUERY_WITH_GUID);
+  RETRY_CONTEXT retry_ctx = {
+    1,      //retry_count
+    0,      // retry reason
+    0,      // network_timeout
+    1,      // time to sleep
+    NULL    // Decorrelate jitter
+  };
+
+  sf_bool ret = retry_ctx_update_url(&retry_ctx, urlbuf, SF_BOOLEAN_TRUE);
+  assert_int_equal(ret, SF_BOOLEAN_TRUE);
+
+  // should only replace the guid and no retry count/reason added
+  assert_int_equal(strlen(urlbuf), strlen(URL_NON_QUERY_WITH_GUID));
+  assert_null(strstr(urlbuf, URL_PARAM_RETRY_COUNT));
+  assert_null(strstr(urlbuf, URL_PARAM_RETRY_REASON));
+  char* guid_ptr = strstr(urlbuf, URL_PARAM_REQEST_GUID);
+  assert_non_null(guid_ptr);
+  assert_int_equal(strlen(guid_ptr), GUID_LENGTH);
+  *guid_ptr = '\0';
+  assert_int_equal(strncmp(URL_NON_QUERY_WITH_GUID, urlbuf, strlen(urlbuf)), 0);
+}
+
+void test_update_query_url_with_retry_context_disabled(void **unused) {
+  char urlbuf[512];
+  sb_sprintf(urlbuf, sizeof(urlbuf), "%s", URL_QUERY);
+  RETRY_CONTEXT retry_ctx = {
+    1,      //retry_count
+    429,    // retry reason
+    0,      // network_timeout
+    1,      // time to sleep
+    NULL    // Decorrelate jitter
+  };
+
+  sf_bool ret = retry_ctx_update_url(&retry_ctx, urlbuf, SF_BOOLEAN_FALSE);
+  assert_int_equal(ret, SF_BOOLEAN_TRUE);
+
+  // should only replace the guid and no retry count/reason added
+  assert_int_equal(strlen(urlbuf), strlen(URL_QUERY));
+  assert_null(strstr(urlbuf, URL_PARAM_RETRY_COUNT));
+  assert_null(strstr(urlbuf, URL_PARAM_RETRY_REASON));
+  char* guid_ptr = strstr(urlbuf, URL_PARAM_REQEST_GUID);
+  assert_non_null(guid_ptr);
+  assert_int_equal(strlen(guid_ptr), GUID_LENGTH);
+  *guid_ptr = '\0';
+  assert_int_equal(strncmp(URL_QUERY, urlbuf, strlen(urlbuf)), 0);
+}
+
+void test_update_query_url_with_retry_context_enabled(void **unused) {
+  char urlbuf[512];
+  sb_sprintf(urlbuf, sizeof(urlbuf), "%s", URL_QUERY);
+  RETRY_CONTEXT retry_ctx = {
+    1,      //retry_count
+    429,    // retry reason
+    0,      // network_timeout
+    1,      // time to sleep
+    NULL    // Decorrelate jitter
+  };
+
+  sf_bool ret = retry_ctx_update_url(&retry_ctx, urlbuf, SF_BOOLEAN_TRUE);
+  assert_int_equal(ret, SF_BOOLEAN_TRUE);
+
+  // ended with guid
+  char* guid_ptr = strstr(urlbuf, URL_PARAM_REQEST_GUID);
+  assert_non_null(guid_ptr);
+  assert_int_equal(strlen(guid_ptr), GUID_LENGTH);
+  *guid_ptr = '\0';
+  
+  // should have retry count/reason added
+  char* retrycount_ptr = strstr(urlbuf, URL_PARAM_RETRY_COUNT);
+  assert_non_null(retrycount_ptr);
+  assert_string_equal(retrycount_ptr, "retryCount=1&retryReason=429&");
+  *retrycount_ptr = '\0';
+
+  // rest part should be unchanged
+  assert_int_equal(strncmp(URL_QUERY, urlbuf, strlen(urlbuf)), 0);
+
+  // recover the updated URL for testing next retry
+  *guid_ptr = 'r';
+  *retrycount_ptr = 'r';
+  retry_ctx.retry_count = 2;
+  retry_ctx.retry_reason = 503;
+
+  ret = retry_ctx_update_url(&retry_ctx, urlbuf, SF_BOOLEAN_TRUE);
+  assert_int_equal(ret, SF_BOOLEAN_TRUE);
+
+  // ended with guid
+  guid_ptr = strstr(urlbuf, URL_PARAM_REQEST_GUID);
+  assert_non_null(guid_ptr);
+  assert_int_equal(strlen(guid_ptr), GUID_LENGTH);
+  *guid_ptr = '\0';
+
+  // should have retry count/reason updated
+  retrycount_ptr = strstr(urlbuf, URL_PARAM_RETRY_COUNT);
+  assert_non_null(retrycount_ptr);
+  assert_string_equal(retrycount_ptr, "retryCount=2&retryReason=503&");
+  *retrycount_ptr = '\0';
+
+  // rest part should be unchanged
+  assert_int_equal(strncmp(URL_QUERY, urlbuf, strlen(urlbuf)), 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_update_url_no_guid),
+        cmocka_unit_test(test_update_other_url_with_guid),
+        cmocka_unit_test(test_update_query_url_with_retry_context_disabled),
+        cmocka_unit_test(test_update_query_url_with_retry_context_enabled),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
sdk issue 550

Currently the new connection parameter SF_CON_INCLUDE_RETRY_CONTEXT controls both retryCount and retryReason as for libsnowflakeclient both of them are newly added while for other drivers retryCount already exist so the new connection parameter (like in ODBC) includeRetryReason only control retryReason.

@sfc-gh-igarish Please confirm whether to keep the current implementation or change to be inline with other drivers (always have retryCount and have a connection parameter to control retryReason)