### PR TITLE
fix flaky test case

### DIFF
--- a/tests/test_unit_oob.cpp
+++ b/tests/test_unit_oob.cpp
@@ -174,7 +174,7 @@ void test_oob(void **) {
         free(oobevent);
         oobevent = nullptr;
         // take timeout as expected result as we reduce oob timeout to 5 seconds.
-        assert_true((rc = atoi(testcase[evnt].rc)) || (rc == 2));
+        assert_true((rc == atoi(testcase[evnt].rc)) || (rc == 2));
     }
 }
 
@@ -253,7 +253,7 @@ void test_dsn(void **) {
     free(oobevent);
     oobevent = nullptr;
     // take timeout as expected result as we reduce oob timeout to 5 seconds.
-    assert_true((rc = 0) || (rc == 2));
+    assert_true((rc == 0) || (rc == 2));
 }
 
 void test_simba(void **) {
@@ -309,7 +309,7 @@ void test_simba(void **) {
     free(oobevent);
     oobevent = nullptr;
     // take timeout as expected result as we reduce oob timeout to 5 seconds.
-    assert_true((rc = 0) || (rc == 2));
+    assert_true((rc == 0) || (rc == 2));
 }
 
 int main() {

--- a/tests/test_unit_oob.cpp
+++ b/tests/test_unit_oob.cpp
@@ -114,7 +114,7 @@ void test_oob(void **) {
                     "AccountAdmin",
                     "0",
                     "dev",
-                    "2" // ingore timeout as the test endpoint has quite long delay up to 20+ seconds and we reduce oob timeout to 5 seconds.
+                    "0"
             },
             // Should fail to send message.
             {
@@ -173,7 +173,8 @@ void test_oob(void **) {
         assert_string_equal(dep, testcase[evnt].deployment);
         free(oobevent);
         oobevent = nullptr;
-        assert_int_equal(rc, atoi(testcase[evnt].rc));
+        // take timeout as expected result as we reduce oob timeout to 5 seconds.
+        assert_true((rc = atoi(testcase[evnt].rc)) || (rc == 2));
     }
 }
 
@@ -251,7 +252,8 @@ void test_dsn(void **) {
     assert_true(oobevent);
     free(oobevent);
     oobevent = nullptr;
-    assert_int_equal(rc, 0);
+    // take timeout as expected result as we reduce oob timeout to 5 seconds.
+    assert_true((rc = 0) || (rc == 2));
 }
 
 void test_simba(void **) {
@@ -306,7 +308,8 @@ void test_simba(void **) {
     assert_true(oobevent);
     free(oobevent);
     oobevent = nullptr;
-    assert_int_equal(rc, 0);
+    // take timeout as expected result as we reduce oob timeout to 5 seconds.
+    assert_true((rc = 0) || (rc == 2));
 }
 
 int main() {


### PR DESCRIPTION
After changing oob timeout from 100 seconds to 5 seconds in https://github.com/snowflakedb/libsnowflakeclient/pull/547
sometime oob test case fails on timeout. Treat that as expected result as we don't want to increase the timeout which could block customer application longer on oob sending.