### PR TITLE
SNOW-871482: [HTAP] add test case for snowflake_sfqid

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(TESTS_C
         test_native_timestamp
         test_get_query_result_response
         test_get_describe_only_query_result
+        test_stmt_functions
 #        test_stats
         )
 

--- a/tests/test_stmt_functions.c
+++ b/tests/test_stmt_functions.c
@@ -7,7 +7,7 @@
 #include "utils/test_setup.h"
 
 void test_sfqid(void **unused) {
-	char qid[SF_UUID4_LEN] = '\0';
+    char qid[SF_UUID4_LEN] = '\0';
     SF_CONNECT *sf = setup_snowflake_connection();
     SF_STATUS status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
@@ -23,17 +23,17 @@ void test_sfqid(void **unused) {
     }
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
-	// returns valid query in success case
-	sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);
-	assert_int_equal(strlen(qid), SF_UUID4_LEN - 1);
+    // returns valid query in success case
+    sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);
+    assert_int_equal(strlen(qid), SF_UUID4_LEN - 1);
 
     SF_STMT *sfstmt = snowflake_stmt(sf);
     status = snowflake_query(sfstmt, "select * from table_not_exists;", 0);
     assert_int_equal(status, SF_STATUS_SUCCESS);
 
-	// returns valid query in fail case
-	sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);
-	assert_int_equal(strlen(qid), SF_UUID4_LEN - 1);
+    // returns valid query in fail case
+    sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);
+    assert_int_equal(strlen(qid), SF_UUID4_LEN - 1);
 
     snowflake_stmt_term(sfstmt);
     snowflake_term(sf);

--- a/tests/test_stmt_functions.c
+++ b/tests/test_stmt_functions.c
@@ -7,7 +7,7 @@
 #include "utils/test_setup.h"
 
 void test_sfqid(void **unused) {
-    char qid[SF_UUID4_LEN] = '\0';
+    char qid[SF_UUID4_LEN] = { '\0' };
     SF_CONNECT *sf = setup_snowflake_connection();
     SF_STATUS status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
@@ -27,9 +27,12 @@ void test_sfqid(void **unused) {
     sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);
     assert_int_equal(strlen(qid), SF_UUID4_LEN - 1);
 
-    SF_STMT *sfstmt = snowflake_stmt(sf);
+    sfstmt = snowflake_stmt(sf);
     status = snowflake_query(sfstmt, "select * from table_not_exists;", 0);
-    assert_int_equal(status, SF_STATUS_SUCCESS);
+    assert_int_equal(status, SF_STATUS_ERROR_GENERAL);
+
+    // ensure the failed query overwrites query id
+    assert_string_not_equal(qid, snowflake_sfqid(sfstmt));
 
     // returns valid query in fail case
     sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);

--- a/tests/test_stmt_functions.c
+++ b/tests/test_stmt_functions.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing, Inc. All rights reserved.
+ * Test case for snowflake_sfqid() for now but we could add more test cases for
+ * other functions on SF_STMT if anything missing.
+ */
+#include <string.h>
+#include "utils/test_setup.h"
+
+void test_sfqid(void **unused) {
+	char qid[SF_UUID4_LEN] = '\0';
+    SF_CONNECT *sf = setup_snowflake_connection();
+    SF_STATUS status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sf->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    /* query */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    status = snowflake_query(sfstmt, "select 1;", 0);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sfstmt->error));
+    }
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+	// returns valid query in success case
+	sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);
+	assert_int_equal(strlen(qid), SF_UUID4_LEN - 1);
+
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    status = snowflake_query(sfstmt, "select * from table_not_exists;", 0);
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+	// returns valid query in fail case
+	sb_strncpy(qid, SF_UUID4_LEN, snowflake_sfqid(sfstmt), SF_UUID4_LEN);
+	assert_int_equal(strlen(qid), SF_UUID4_LEN - 1);
+
+    snowflake_stmt_term(sfstmt);
+    snowflake_term(sf);
+}
+
+int main(void) {
+    initialize_test(SF_BOOLEAN_FALSE);
+    const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_sfqid),
+    };
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    snowflake_global_term();
+    return ret;
+}


### PR DESCRIPTION
sdk issue 551
last query id for libsnowflakeclient

We have existing function snowflake_sfqid() returns last query id on statement level already while no test case cover it.
Add test case to ensure it works for both success and fail cases.