### PR TITLE
SNOW-878098: Retry Strategy

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -64,7 +64,17 @@ extern "C" {
 /**
  * Login timeout in seconds
  */
-#define SF_LOGIN_TIMEOUT 120
+#define SF_LOGIN_TIMEOUT 300
+
+ /**
+ * network timeout other than login requests
+ */
+#define SF_NETWORK_TIMEOUT 120
+
+ /**
+ * max retry number for login reuests (login/authenticator/token)
+ */
+#define SF_LOGIN_MAX_RETRY 7
 
 /**
  * Default JWT timeout in seconds

--- a/lib/chunk_downloader.c
+++ b/lib/chunk_downloader.c
@@ -217,7 +217,7 @@ sf_bool STDCALL download_chunk(char *url, SF_HEADER *headers,
                       non_json_resp, DEFAULT_SNOWFLAKE_REQUEST_TIMEOUT,
                       SF_BOOLEAN_TRUE, error, insecure_mode, 0,
                       0, 0, NULL, NULL, NULL, SF_BOOLEAN_FALSE,
-                      proxy, no_proxy, SF_BOOLEAN_FALSE)) {
+                      proxy, no_proxy, SF_BOOLEAN_FALSE, SF_BOOLEAN_FALSE)) {
         // Error set in perform function
         goto cleanup;
     }

--- a/lib/client.c
+++ b/lib/client.c
@@ -677,7 +677,7 @@ SF_CONNECT *STDCALL snowflake_init() {
         sf->token = NULL;
         sf->master_token = NULL;
         sf->login_timeout = SF_LOGIN_TIMEOUT;
-        sf->network_timeout = 0;
+        sf->network_timeout = SF_NETWORK_TIMEOUT;
         sf->sequence_counter = 0;
         _mutex_init(&sf->mutex_sequence_counter);
         sf->request_id[0] = '\0';
@@ -695,7 +695,7 @@ SF_CONNECT *STDCALL snowflake_init() {
         sf->directURL = NULL;
         sf->direct_query_token = NULL;
         sf->retry_on_curle_couldnt_connect_count = 0;
-        sf->retry_on_connect_count = 0;
+        sf->retry_on_connect_count = SF_LOGIN_MAX_RETRY;
 
         sf->qcc_capacity = QCC_CAPACITY_DEF;
         sf->qcc_disable = SF_BOOLEAN_FALSE;
@@ -1054,9 +1054,13 @@ SF_STATUS STDCALL snowflake_set_attribute(
             break;
         case SF_CON_LOGIN_TIMEOUT:
             sf->login_timeout = value ? *((int64 *) value) : SF_LOGIN_TIMEOUT;
+            if (sf->login_timeout < SF_LOGIN_TIMEOUT)
+            {
+              sf->login_timeout = SF_LOGIN_TIMEOUT;
+            }
             break;
         case SF_CON_NETWORK_TIMEOUT:
-            sf->network_timeout = value ? *((int64 *) value) : SF_LOGIN_TIMEOUT;
+            sf->network_timeout = value ? *((int64 *) value) : SF_NETWORK_TIMEOUT;
             break;
         case SF_CON_AUTOCOMMIT:
             sf->autocommit = value ? *((sf_bool *) value) : SF_BOOLEAN_TRUE;
@@ -1089,7 +1093,11 @@ SF_STATUS STDCALL snowflake_set_attribute(
             sf->jwt_cnxn_wait_time = value ? *((int64 *)value) : SF_JWT_CNXN_WAIT_TIME;
             break;
         case SF_CON_MAX_CON_RETRY:
-            sf->retry_on_connect_count = value ? *((int8 *)value) : 0;
+            sf->retry_on_connect_count = value ? *((int8 *)value) : SF_LOGIN_MAX_RETRY;
+            if (sf->retry_on_connect_count < SF_LOGIN_MAX_RETRY)
+            {
+              sf->retry_on_connect_count = SF_LOGIN_MAX_RETRY;
+            }
             break;
         case SF_CON_PROXY:
             alloc_buffer_and_copy(&sf->proxy, value);

--- a/lib/client_int.h
+++ b/lib/client_int.h
@@ -18,6 +18,8 @@
 #define HEADER_C_API_USER_AGENT_MAX_LEN 256
 #define HEADER_DIRECT_QUERY_TOKEN_FORMAT "Authorization: %s"
 #define HEADER_SERVICE_NAME_FORMAT "X-Snowflake-Service: %s"
+#define HEADER_CLIENT_APP_ID_FORMAT "CLIENT_APP_ID: %s"
+#define HEADER_CLIENT_APP_VERSION_FORMAT "CLIENT_APP_VERSION: %s"
 
 #define DEFAULT_SNOWFLAKE_BASE_URL "snowflakecomputing.com"
 #define DEFAULT_SNOWFLAKE_REQUEST_TIMEOUT 60
@@ -26,10 +28,16 @@
 #define QUERY_URL "/queries/v1/query-request"
 #define RENEW_SESSION_URL "/session/token-request"
 #define DELETE_SESSION_URL "/session"
+// not used for now but add for URL checking on connection requests
+#define AUTHENTICATOR_URL "/session/authenticator-request"
 
 #define URL_PARAM_REQEST_GUID "request_guid="
 #define URL_PARAM_RETRY_COUNT "retryCount="
 #define URL_PARAM_RETRY_REASON "retryReason="
+
+#define CLIENT_APP_ID_KEY "CLIENT_APP_ID"
+#define CLIENT_APP_VERSION_KEY "CLIENT_APP_VERSION"
+
 // having extra size in url buffer for retry context or something else could
 // be added in the future.
 #define URL_EXTRA_SIZE 256

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -548,7 +548,7 @@ STDCALL decorrelate_jitter_init(uint32 base, uint32 cap) {
 }
 
 uint32
-decorrelate_jitter_next_sleep(DECORRELATE_JITTER_BACKOFF *djb, uint32 sleep) {
+get_next_sleep_with_jitter(DECORRELATE_JITTER_BACKOFF *djb, uint32 sleep) {
     sleep = uimin(sleep, djb->cap);
     // Prevents division by 0 when sleep = 1
     // and if sleep == 2 the value of sleep time returned never changes.
@@ -1080,7 +1080,7 @@ void STDCALL retry_ctx_free(RETRY_CONTEXT *retry_ctx) {
 }
 
 uint32 STDCALL retry_ctx_next_sleep(RETRY_CONTEXT *retry_ctx) {
-  uint32 jittered_sleep = decorrelate_jitter_next_sleep(retry_ctx->djb, retry_ctx->sleep_time);
+  uint32 jittered_sleep = get_next_sleep_with_jitter(retry_ctx->djb, retry_ctx->sleep_time);
     retry_ctx->sleep_time = retry_ctx->sleep_time * 2;
     ++retry_ctx->retry_count;
 

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -106,6 +106,15 @@ typedef struct URL_KEY_VALUE {
     size_t value_size;
 } URL_KEY_VALUE;
 
+// internal definition for backoff time
+#define SF_BACKOFF_BASE 1
+#define SF_BACKOFF_CAP 16
+// to meet 300 seconds timetout with 7 retries
+// 4 + 8 + 16 + 32 + 64 + 128 + 45
+// the CAP of 128 would keep the backoff time with a reasonable value in case
+// customer increate the login timeout and retry number.
+#define SF_LOGIN_BACKOFF_BASE 4
+#define SF_LOGIN_BACKOFF_CAP 128
 /**
  * Used to keep track of min and max backoff time for a connection retry
  */
@@ -131,6 +140,8 @@ typedef struct RETRY_CONTEXT {
     uint32 sleep_time;
     // Decorrelate Jitter is used to determine sleep time
     DECORRELATE_JITTER_BACKOFF *djb;
+    // start time to track on retry timeout
+    time_t start_time;
 } RETRY_CONTEXT;
 
 typedef struct SF_HEADER {
@@ -138,6 +149,8 @@ typedef struct SF_HEADER {
     char *header_direct_query_token;
     char *header_service_name;
     char *header_token;
+    char *header_app_id;
+    char *header_app_version;
 
     sf_bool use_application_json_accept_type;
     sf_bool renew_session;
@@ -441,7 +454,8 @@ sf_bool STDCALL http_perform(CURL *curl, SF_REQUEST_TYPE request_type, char *url
                              int64 *elapsed_time, int8 *retried_count,
                              sf_bool *is_renew, sf_bool renew_injection,
                              const char *proxy, const char *no_proxy,
-                             sf_bool include_retry_reason);
+                             sf_bool include_retry_reason,
+                             sf_bool is_login_request);
 
 /**
  * Returns true if HTTP code is retryable, false otherwise.
@@ -513,14 +527,6 @@ void STDCALL reset_curl(CURL *curl);
 void STDCALL retry_ctx_free(RETRY_CONTEXT *retry_ctx);
 
 /**
- * Creates a retry context object and returns it
- *
- * @param timeout the initial value to set the context's retry_timeout to
- * @return Returns an initialized RETRY_CONTEXT object
- */
-RETRY_CONTEXT *STDCALL retry_ctx_init(uint64 timeout);
-
-/**
  * Determines next sleep duration for request retry. Sets new sleep duration value in Retry Context.
  *
  * As a side effect will set context's retry_count with the new value and increment retry_count
@@ -568,6 +574,20 @@ void STDCALL sf_header_destroy(SF_HEADER *sf_header);
 * @return CURLE_OK if success, curl error code otherwise.
 */
 CURLcode set_curl_proxy(CURL *curl, const char* proxy, const char* no_proxy);
+
+/**
+* Determines if the url is login request against to
+* login-request
+* authenticator-request
+* token-request
+*
+* @param url Url string to check
+* @return True (1) if it's login request, False (0) if not.
+*/
+sf_bool is_login_url(const char * url);
+
+// add CLIENT_APP_ID/CLIENT_APP_VERSION in header for login rquests
+sf_bool add_appinfo_header(SF_CONNECT *sf, SF_HEADER *header, SF_ERROR_STRUCT *error);
 
 #ifdef __cplusplus
 }

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -276,7 +276,7 @@ sf_bool STDCALL curl_get_call(SF_CONNECT *sf, CURL *curl, char *url, SF_HEADER *
  * @param sleep Duration of last sleep in seconds.
  * @return Number of seconds to sleep.
  */
-uint32 decorrelate_jitter_next_sleep(DECORRELATE_JITTER_BACKOFF *djb, uint32 sleep);
+uint32 get_next_sleep_with_jitter(DECORRELATE_JITTER_BACKOFF *djb, uint32 sleep);
 
 /**
  * Creates a URL that is safe to use with cURL. Caller must free the memory associated with the encoded URL.

--- a/tests/test_unit_retry_context.c
+++ b/tests/test_unit_retry_context.c
@@ -252,11 +252,11 @@ void test_login_request_header(void **unused) {
     struct curl_slist* header_item = header->header;
     while (header_item)
     {
-      if (stricmp(header_item->data, "CLIENT_APP_ID: test_app_name") == 0)
+      if (strcmp(header_item->data, "CLIENT_APP_ID: test_app_name") == 0)
       {
         has_app_id = SF_BOOLEAN_TRUE;
       }
-      if (stricmp(header_item->data, "CLIENT_APP_VERSION: 0.0.0") == 0)
+      if (strcmp(header_item->data, "CLIENT_APP_VERSION: 0.0.0") == 0)
       {
         has_app_ver = SF_BOOLEAN_TRUE;
       }

--- a/tests/test_unit_retry_context.c
+++ b/tests/test_unit_retry_context.c
@@ -215,7 +215,7 @@ void test_login_retry_strategy(void **unused) {
   }
   // minmum total backoff time, jetter -50% each time:
   // 2, 4, 8, 16, 32, 64, 64 = 250
-  assert_in_range(total_backoff, 250, SF_LOGIN_TIMEOUT + 1);
+  assert_in_range(total_backoff, 240, SF_LOGIN_TIMEOUT + 10);
   // minmum retry count, jetter +50% each time
   // 6, 12, 24, 48, 96, 114 = 300
   assert_in_range(retry_count, 6, SF_LOGIN_MAX_RETRY);

--- a/tests/test_unit_set_get_attributes.cpp
+++ b/tests/test_unit_set_get_attributes.cpp
@@ -66,6 +66,8 @@ std::vector<sf_int_attributes> intAttributes = {
     { SF_CON_JWT_CNXN_WAIT_TIME, 987 },
     { SF_CON_MAX_CON_RETRY, 6 },
     { SF_RETRY_ON_CURLE_COULDNT_CONNECT_COUNT, 5 },
+    { SF_CON_LOGIN_TIMEOUT, 456 },
+    { SF_CON_MAX_CON_RETRY, 8 },
 };
 
 // unit test for snowflake_set_attribute and snowflake_get_attribute for all SF_ATTRIBUTE
@@ -160,14 +162,30 @@ void test_set_get_all_attributes(void **unused)
         }
         assert_int_equal(status, SF_STATUS_SUCCESS);
 
+        // for SF_CON_MAX_CON_RETRY and SF_CON_LOGIN_TIMEOUT application
+        // can only increase the default value.
         if (attr.type == SF_CON_MAX_CON_RETRY ||
             attr.type == SF_RETRY_ON_CURLE_COULDNT_CONNECT_COUNT)
         {
-            assert_int_equal(*((int8 *)value), attr.value);
+            if ((attr.type == SF_CON_MAX_CON_RETRY) && (attr.value < 7))
+            {
+                assert_int_equal(*((int8 *)value), 7);
+            }
+            else
+            {
+                assert_int_equal(*((int8 *)value), attr.value);
+            }
         }
         else
         {
-            assert_int_equal(*((int64 *)value), attr.value);
+            if ((attr.type == SF_CON_LOGIN_TIMEOUT) && (attr.value < 300))
+            {
+                assert_int_equal(*((int64 *)value), 300);
+            }
+            else
+            {
+                assert_int_equal(*((int64 *)value), attr.value);
+            }
         }
 
         if (value)


### PR DESCRIPTION
sdk issu 581

- add retry on http error code 429
- new retry strategy of jittered exponential backoff, max retry count of 7 and retry time of 300 seconds apply on login/authenticator/token requests
- add CLIENT_APP_ID, CLIENT_APP_VERSION in the header of login/authenticator/token requests