### PR TITLE
SNOW-935778: Add support for unicode characters in file path in PUT/GET command

### DIFF
--- a/cpp/FileMetadataInitializer.hpp
+++ b/cpp/FileMetadataInitializer.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include "FileMetadata.hpp"
 #include "IStorageClient.hpp"
+#include "snowflake/IStatementPutGet.hpp"
 
 // used to decide whether to upload in sequence or in parallel
 #define DEFAULT_UPLOAD_DATA_SIZE_THRESHOLD 209715200 //200Mb
@@ -25,7 +26,8 @@ class FileMetadataInitializer
 {
 public:
   FileMetadataInitializer(std::vector<FileMetadata> &smallFileMetadata,
-                          std::vector<FileMetadata> &largeFileMetadata);
+                          std::vector<FileMetadata> &largeFileMetadata,
+                          IStatementPutGet *stmtPutGet);
 
   /**
    * Given a source locations, find all files that match the location pattern,
@@ -101,6 +103,9 @@ private:
 
   /// Random device for crytpo random num generator.
   Crypto::CryptoRandomDevice m_randDevice;
+
+  // statement which provides encoding conversion funcationality
+  IStatementPutGet *m_stmtPutGet;
 };
 }
 }

--- a/include/snowflake/IStatementPutGet.hpp
+++ b/include/snowflake/IStatementPutGet.hpp
@@ -77,6 +77,18 @@ public:
     return NULL;
   }
 
+  // Utility functions to convert enconding between UTF-8 to the encoding
+  // from system locale. No coversion by default.
+  virtual std::string UTF8ToPlatformString(const std::string& utf8_str)
+  {
+    return utf8_str;
+  }
+
+  virtual std::string platformStringToUTF8(const std::string& platform_str)
+  {
+    return platform_str;
+  }
+
   virtual ~IStatementPutGet()
   {
 

--- a/tests/test_simple_put.cpp
+++ b/tests/test_simple_put.cpp
@@ -30,7 +30,11 @@
 using namespace ::Snowflake::Client;
 using namespace boost::filesystem;
 
+#ifdef _WIN32
 static std::string PLATFORM_STR = "\xe9";
+#else
+static std::string  PLATFORM_STR = "é";
+#endif
 static std::string UTF8_STR = "\xc3\xa9";
 
 bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis ) {
@@ -150,15 +154,20 @@ void test_simple_put_core(const char * fileName,
 
   std::string dataDir = TestSetup::getDataDir();
   std::string file = dataDir + fileName;
-  replaceInPlace(file, "\\", "\\\\");
-  std::string putCommand = "put 'file://" + file + "' @%test_small_put";
+  std::string putCommand = "put file://" + file + " @%test_small_put";
+  if (testUnicode)
+  {
+    replaceInPlace(file, "\\", "\\\\");
+    putCommand = "put 'file://" + file + "' @%test_small_put";
+  }
+
   if(createDupTable)
   {
-      putCommand = "put 'file://" + std::string(fileName) + "' @%test_small_put_dup";
+      putCommand = "put file://" + std::string(fileName) + " @%test_small_put_dup";
   }
   else if (createSubfolder)
   {
-       putCommand = "put 'file://" + file + "' @%test_small_put/subfolder";
+       putCommand = "put file://" + file + " @%test_small_put/subfolder";
   }
 
   if (!autoCompress)
@@ -1630,7 +1639,6 @@ int main(void) {
   }
 
   const struct CMUnitTest tests[] = {
-    cmocka_unit_test_teardown(test_put_get_with_unicode, teardown),
     cmocka_unit_test_teardown(test_simple_put_auto_compress, teardown),
     cmocka_unit_test_teardown(test_simple_put_config_temp_dir, teardown),
     cmocka_unit_test_teardown(test_simple_put_auto_detect_gzip, teardown),
@@ -1661,6 +1669,7 @@ int main(void) {
     cmocka_unit_test_teardown(test_simple_put_with_proxy_fromenv, teardown),
     cmocka_unit_test_teardown(test_simple_put_with_noproxy_fromenv, teardown),
     cmocka_unit_test_teardown(test_upload_file_to_stage_using_stream, donothing),
+    cmocka_unit_test_teardown(test_put_get_with_unicode, teardown),
   };
   int ret = cmocka_run_group_tests(tests, gr_setup, gr_teardown);
   return ret;

--- a/tests/test_unit_file_metadata_init.cpp
+++ b/tests/test_unit_file_metadata_init.cpp
@@ -12,6 +12,10 @@
 #include <unordered_set>
 #include <iostream>
 #include <map>
+#include <vector>
+#include <memory>
+#include "snowflake/IStatementPutGet.hpp"
+#include "StatementPutGet.hpp"
 
 #define FILES_IN_DIR "file1.csv", "file2.csv", "file3.csv", "file4.csv", "file1.gz"
 
@@ -70,13 +74,18 @@ std::vector<std::string> getListOfTestFileMatchDir()
 void test_file_pattern_match_core(std::vector<std::string> *expectedFiles,
                                   const char *filePattern)
 {
+  SF_CONNECT *sf = snowflake_init();
+  SF_STMT *sfstmt = snowflake_stmt(sf);
+  std::unique_ptr<IStatementPutGet> stmtPutGet = std::unique_ptr
+      <StatementPutGet>(new Snowflake::Client::StatementPutGet(sfstmt));
+
   std::vector<std::string> listTestDir = getListOfTestFileMatchDir();
   for (auto testDir : listTestDir)
   {
     std::vector<FileMetadata> smallFileMetadata;
     std::vector<FileMetadata> largeFileMetadata;
 
-    FileMetadataInitializer initializer(smallFileMetadata, largeFileMetadata);
+    FileMetadataInitializer initializer(smallFileMetadata, largeFileMetadata, stmtPutGet.get());
     initializer.setSourceCompression((char *)"none");
 
     std::string fullFilePattern = testDir + filePattern;


### PR DESCRIPTION
libsnowflakeclient doesn't has the functionality for encoding conversion so it doesn't support Unicode characters by it's own.
Take the encoding conversion functionality from caller (.e.g ODBC driver) to support Unicode characters in file path for PUT/GET command.