### PR TITLE
fix build issue on Jenkins Windows

### DIFF
--- a/ci/test_win.bat
+++ b/ci/test_win.bat
@@ -91,6 +91,10 @@ exit /b 0
     call venv\scripts\activate
     python -m pip install -U pip > nul 2>&1
     if %ERRORLEVEL% NEQ 0 goto :error
+    pip install --upgrade --user awscli > nul 2>&1
+    if %ERRORLEVEL% NEQ 0 goto :error
+    pip install awscli > nul 2>&1
+    if %ERRORLEVEL% NEQ 0 goto :error
     pip install snowflake-connector-python > nul 2>&1
     if %ERRORLEVEL% NEQ 0 goto :error
     exit /b 0


### PR DESCRIPTION
Sometime awscli could be missing on Jenkins node. Install it in test script as what we did before in build script.
https://github.com/snowflakedb/libsnowflakeclient/pull/489