### PR TITLE
more banned function replacement

### DIFF
--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -614,15 +614,13 @@ void Snowflake::Client::FileTransferAgent::compressSourceFile(
   std::string stagingFile(tempDir);
   stagingFile += fileMetadata->destFileName;
 
-  FILE *sourceFile;
-  sb_fopen(&sourceFile, fileMetadata->srcFileName.c_str(), "r");
-  if( !sourceFile ){
+  FILE *sourceFile = NULL;
+  if (sb_fopen(&sourceFile, fileMetadata->srcFileName.c_str(), "r") == NULL) {
     CXX_LOG_ERROR("Failed to open srcFileName %s. Errno: %d", fileMetadata->srcFileName.c_str(), errno);
     throw SnowflakeTransferException(TransferError::FILE_OPEN_ERROR, fileMetadata->srcFileName.c_str(), -1);
   }
-  FILE *destFile;
-  sb_fopen(&destFile, stagingFile.c_str(), "w");
-  if ( !destFile) {
+  FILE *destFile = NULL;
+  if (sb_fopen(&destFile, stagingFile.c_str(), "w") == NULL) {
     CXX_LOG_ERROR("Failed to open srcFileToUpload file %s. Errno: %d", stagingFile.c_str(), errno);
     throw SnowflakeTransferException(TransferError::FILE_OPEN_ERROR, stagingFile.c_str(), -1);
   }
@@ -845,16 +843,20 @@ RemoteStorageRequestOutcome Snowflake::Client::FileTransferAgent::downloadSingle
      }
      catch (...) {
        std::string err = "Could not open file " + fileMetadata->destPath + " to downoad";
+       char* str_error = sf_strerror(errno);
        CXX_LOG_DEBUG("Could not open file %s to downoad: %s",
-                     fileMetadata->destPath.c_str(), sf_strerror(errno));
+                     fileMetadata->destPath.c_str(), str_error);
+       sf_free_s(str_error);
        m_executionResults->SetTransferOutCome(outcome, resultIndex);
        break;
      }
      if (!dstFile.is_open())
      {
        std::string err = "Could not open file " + fileMetadata->destPath + " to downoad";
+       char* str_error = sf_strerror(errno);
        CXX_LOG_DEBUG("Could not open file %s to downoad: %s",
-                     fileMetadata->destPath.c_str(), sf_strerror(errno));
+                     fileMetadata->destPath.c_str(), str_error);
+       sf_free_s(str_error);
        m_executionResults->SetTransferOutCome(outcome, resultIndex);
        break;
      }

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -19,6 +19,7 @@
 #include "EncryptionProvider.hpp"
 #include "logger/SFLogger.hpp"
 #include "snowflake/platform.h"
+#include "snowflake/Simba_CRTFunctionSafe.h"
 #include <chrono>
 #ifdef _WIN32
 #include <windows.h>
@@ -613,12 +614,14 @@ void Snowflake::Client::FileTransferAgent::compressSourceFile(
   std::string stagingFile(tempDir);
   stagingFile += fileMetadata->destFileName;
 
-  FILE *sourceFile = fopen(fileMetadata->srcFileName.c_str(), "r");
+  FILE *sourceFile;
+  sb_fopen(&sourceFile, fileMetadata->srcFileName.c_str(), "r");
   if( !sourceFile ){
     CXX_LOG_ERROR("Failed to open srcFileName %s. Errno: %d", fileMetadata->srcFileName.c_str(), errno);
     throw SnowflakeTransferException(TransferError::FILE_OPEN_ERROR, fileMetadata->srcFileName.c_str(), -1);
   }
-  FILE *destFile = fopen(stagingFile.c_str(), "w");
+  FILE *destFile;
+  sb_fopen(&destFile, stagingFile.c_str(), "w");
   if ( !destFile) {
     CXX_LOG_ERROR("Failed to open srcFileToUpload file %s. Errno: %d", stagingFile.c_str(), errno);
     throw SnowflakeTransferException(TransferError::FILE_OPEN_ERROR, stagingFile.c_str(), -1);
@@ -843,7 +846,7 @@ RemoteStorageRequestOutcome Snowflake::Client::FileTransferAgent::downloadSingle
      catch (...) {
        std::string err = "Could not open file " + fileMetadata->destPath + " to downoad";
        CXX_LOG_DEBUG("Could not open file %s to downoad: %s",
-                     fileMetadata->destPath.c_str(), std::strerror(errno));
+                     fileMetadata->destPath.c_str(), sf_strerror(errno));
        m_executionResults->SetTransferOutCome(outcome, resultIndex);
        break;
      }
@@ -851,7 +854,7 @@ RemoteStorageRequestOutcome Snowflake::Client::FileTransferAgent::downloadSingle
      {
        std::string err = "Could not open file " + fileMetadata->destPath + " to downoad";
        CXX_LOG_DEBUG("Could not open file %s to downoad: %s",
-                     fileMetadata->destPath.c_str(), std::strerror(errno));
+                     fileMetadata->destPath.c_str(), sf_strerror(errno));
        m_executionResults->SetTransferOutCome(outcome, resultIndex);
        break;
      }

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -61,15 +61,17 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
       CXX_LOG_TRACE("ca bundle file from SF_GLOBAL_CA_BUNDLE_FILE *%s*", caBundleFile);
   }
   if( caBundleFile[0] == 0 ) {
-      const char* capath = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+      char* capath = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
       if (capath) {
           if (strlen(capath) > MAX_PATH - 1) {
+              sf_free_s(capath);
               throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,
                   "CA bundle file path too long.");
           }
           if (!sb_strcpy(caBundleFile, (size_t)MAX_PATH, capath)) {
               caBundleFile[0] = 0;
           }
+          sf_free_s(capath);
           CXX_LOG_TRACE("ca bundle file from SNOWFLAKE_TEST_CA_BUNDLE_FILE *%s*", caBundleFile);
       }
   }

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2019 Snowflake Computing, Inc. All rights reserved.
  */
 
+#include "snowflake/Simba_CRTFunctionSafe.h"
 #include "SnowflakeAzureClient.hpp"
 #include "FileMetadataInitializer.hpp"
 #include "snowflake/client.h"
@@ -60,7 +61,7 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
       CXX_LOG_TRACE("ca bundle file from SF_GLOBAL_CA_BUNDLE_FILE *%s*", caBundleFile);
   }
   if( caBundleFile[0] == 0 ) {
-      const char* capath = std::getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+      const char* capath = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
       if (capath) {
           if (strlen(capath) > MAX_PATH - 1) {
               throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,

--- a/cpp/crypto/CipherContext.cpp
+++ b/cpp/crypto/CipherContext.cpp
@@ -307,7 +307,7 @@ size_t CipherContext::finalize(void *const out)
       //             EXTERNAL_DECRYPT_ERROR_MSG);
     else
     {
-      printf("Finialize failed, op %d", static_cast<int>(impl.op));
+      sb_printf("Finialize failed, op %d", static_cast<int>(impl.op));
       throw;
     }
     //SF_THROW_CRYPTO(static_cast<int>(impl.op));

--- a/cpp/lib/Authenticator.cpp
+++ b/cpp/lib/Authenticator.cpp
@@ -201,7 +201,7 @@ namespace Client
                                         const std::string &passcode)
   {
     FILE *file;
-    file = fopen(privateKeyFile.c_str(), "r");
+    file = sb_fopen(&file, privateKeyFile.c_str(), "r");
     if (file == nullptr)
     {
       CXX_LOG_ERROR("Failed to open private key file. Errno: %d", errno);

--- a/cpp/lib/Authenticator.cpp
+++ b/cpp/lib/Authenticator.cpp
@@ -200,9 +200,8 @@ namespace Client
   void AuthenticatorJWT::loadPrivateKey(const std::string &privateKeyFile,
                                         const std::string &passcode)
   {
-    FILE *file;
-    file = sb_fopen(&file, privateKeyFile.c_str(), "r");
-    if (file == nullptr)
+    FILE *file = nullptr;
+    if (sb_fopen(&file, privateKeyFile.c_str(), "r") == NULL)
     {
       CXX_LOG_ERROR("Failed to open private key file. Errno: %d", errno);
       JWT_THROW("Failed to open private key file");

--- a/cpp/util/Proxy.cpp
+++ b/cpp/util/Proxy.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "snowflake/Proxy.hpp"
+#include "snowflake/Simba_CRTFunctionSafe.h"
 
 Snowflake::Client::Util::Proxy::Proxy(const std::string &proxy_str)
 {
@@ -71,12 +72,12 @@ void Snowflake::Client::Util::Proxy::setProxyFromEnv() {
     std::string proxy;
 
     // Get proxy string and set scheme
-    if (std::getenv("all_proxy")) {
-        proxy = std::getenv("all_proxy");
-    } else if (std::getenv("https_proxy")) {
-        proxy = std::getenv("https_proxy");
-    } else if (std::getenv("http_proxy")) {
-        proxy = std::getenv("http_proxy");
+    if (sf_getenv("all_proxy")) {
+        proxy = sf_getenv("all_proxy");
+    } else if (sf_getenv("https_proxy")) {
+        proxy = sf_getenv("https_proxy");
+    } else if (sf_getenv("http_proxy")) {
+        proxy = sf_getenv("http_proxy");
     }
 
     if (!proxy.empty())
@@ -85,10 +86,10 @@ void Snowflake::Client::Util::Proxy::setProxyFromEnv() {
     }
 
     // Get noproxy string
-    if (std::getenv("no_proxy")) {
-        m_noProxy = std::getenv("no_proxy");
-    } else if (std::getenv("NO_PROXY")) {
-        m_noProxy = std::getenv("NO_PROXY");
+    if (sf_getenv("no_proxy")) {
+        m_noProxy = sf_getenv("no_proxy");
+    } else if (sf_getenv("NO_PROXY")) {
+        m_noProxy = sf_getenv("NO_PROXY");
     }
 }
 

--- a/include/snowflake/Simba_CRTFunctionSafe.h
+++ b/include/snowflake/Simba_CRTFunctionSafe.h
@@ -35,6 +35,8 @@ extern char* STDCALL sf_strerror(int);
 
 #if defined(WIN32) || defined(_WIN64)   // For Windows
 
+    #define sf_free_s(x)        free(x)
+
     /// @brief Copy a string.
     /// 
     /// @param out_dest         Destination string buffer. (NOT OWN)
@@ -244,10 +246,13 @@ extern char* STDCALL sf_strerror(int);
     }
 
 
-#define sb_getenv   sf_getenv
-#define sb_strerror sf_strerror
+    #define sb_getenv sf_getenv
+    #define sb_strerror sf_strerror
+
 
 #else   // For all other platforms except Windows
+
+    #define sf_free_s(x)
 
     /// @brief Copy a string.
     /// 
@@ -404,12 +409,14 @@ extern char* STDCALL sf_strerror(int);
     static inline FILE* sb_fopen(FILE** out_file, const char* in_filename, const char* in_mode)
     {
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)
-        return fopen_s(out_file, in_filename, in_mode) ? NULL : *out_file;
+        // to simulate fopen, *out_file is guaranteed to be set, fopen_s don't change out_file on error
+        return fopen_s(out_file, in_filename, in_mode) ? (*out_file = NULL) : *out_file;
 #else
         return *out_file = fopen(in_filename, in_mode);
 #endif
     }
 
+#define sb_free_s       sf_free_s
 
 
 #ifdef __cplusplus

--- a/include/snowflake/platform.h
+++ b/include/snowflake/platform.h
@@ -62,6 +62,7 @@ int STDCALL sf_unsetenv(const char *name);
 
 int STDCALL sf_mkdir(const char *path);
 
+char* STDCALL sf_strerror(int errnum);
 
 int STDCALL
 _thread_init(SF_THREAD_HANDLE *thread, void *(*proc)(void *), void *arg);

--- a/include/snowflake/platform.h
+++ b/include/snowflake/platform.h
@@ -56,13 +56,21 @@ void STDCALL sf_tzset(void);
 
 int STDCALL sf_setenv(const char *name, const char *value);
 
+/* on Windows, this function allocate new memory, caller should free it */
 char *STDCALL sf_getenv(const char *name);
 
 int STDCALL sf_unsetenv(const char *name);
 
 int STDCALL sf_mkdir(const char *path);
 
+/* on Windows, this function allocate new memory, caller should free it */
 char* STDCALL sf_strerror(int errnum);
+
+#ifdef _WIN32
+#define sf_free_s(x)       free(x)
+#else
+#define sf_free_s(x)
+#endif
 
 int STDCALL
 _thread_init(SF_THREAD_HANDLE *thread, void *(*proc)(void *), void *arg);

--- a/lib/client.c
+++ b/lib/client.c
@@ -349,8 +349,9 @@ static sf_bool STDCALL log_init(const char *log_path, SF_LOG_LEVEL log_level) {
     if (LOG_PATH != NULL) {
         // Create log file path (if it already doesn't exist)
         if (mkpath(LOG_PATH) == -1) {
-            sb_fprintf(stderr, "Error creating log directory. Error code: %s\n",
-                    sf_strerror(errno));
+            char* str_error = sf_strerror(errno);
+            sb_fprintf(stderr, "Error creating log directory. Error code: %s\n", str_error);
+            sf_free_s(str_error);
             goto cleanup;
         }
         // Set the log path only, the log file will be created when actual log output is needed.
@@ -364,6 +365,10 @@ static sf_bool STDCALL log_init(const char *log_path, SF_LOG_LEVEL log_level) {
     ret = SF_BOOLEAN_TRUE;
 
 cleanup:
+    if (sf_log_path != log_path) {
+        sf_free_s((char*) sf_log_path);
+    }
+    sf_free_s((char*) sf_log_level_str);
     return ret;
 }
 

--- a/lib/client.c
+++ b/lib/client.c
@@ -349,14 +349,14 @@ static sf_bool STDCALL log_init(const char *log_path, SF_LOG_LEVEL log_level) {
     if (LOG_PATH != NULL) {
         // Create log file path (if it already doesn't exist)
         if (mkpath(LOG_PATH) == -1) {
-            fprintf(stderr, "Error creating log directory. Error code: %s\n",
-                    strerror(errno));
+            sb_fprintf(stderr, "Error creating log directory. Error code: %s\n",
+                    sf_strerror(errno));
             goto cleanup;
         }
         // Set the log path only, the log file will be created when actual log output is needed.
         log_set_path(LOG_PATH);
     } else {
-        fprintf(stderr,
+        sb_fprintf(stderr,
                 "Log path is NULL. Was there an error during path construction?\n");
         goto cleanup;
     }
@@ -539,7 +539,7 @@ SF_STATUS STDCALL snowflake_global_init(
     sf_error_init();
     if (!log_init(log_path, log_level)) {
         // no way to log error because log_init failed.
-        fprintf(stderr, "Error during log initialization");
+        sb_fprintf(stderr, "Error during log initialization");
         goto cleanup;
     }
     CURLcode curl_ret = curl_global_init(CURL_GLOBAL_DEFAULT);

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -39,18 +39,18 @@ void dump(const char *text,
         /* without the hex output, we can fit more on screen */
         width = 0x40;
 
-    fprintf(stream, "%s, %10.10ld bytes (0x%8.8lx)\n",
+    sb_fprintf(stream, "%s, %10.10ld bytes (0x%8.8lx)\n",
             text, (long) size, (long) size);
 
     for (i = 0; i < size; i += width) {
 
-        fprintf(stream, "%4.4lx: ", (long) i);
+        sb_fprintf(stream, "%4.4lx: ", (long) i);
 
         if (!nohex) {
             /* hex not disabled, show it */
             for (c = 0; c < width; c++)
                 if (i + c < size)
-                    fprintf(stream, "%02x ", ptr[i + c]);
+                    sb_fprintf(stream, "%02x ", ptr[i + c]);
                 else
                     fputs("   ", stream);
         }
@@ -62,7 +62,7 @@ void dump(const char *text,
                 i += (c + 2 - width);
                 break;
             }
-            fprintf(stream, "%c",
+            sb_fprintf(stream, "%c",
                     (ptr[i + c] >= 0x20) && (ptr[i + c] < 0x80) ? ptr[i + c]
                                                                 : '.');
             /* check again for 0D0A, to avoid an extra \n if it's at width */
@@ -87,7 +87,7 @@ int my_trace(CURL *handle, curl_infotype type,
 
     switch (type) {
         case CURLINFO_TEXT:
-            fprintf(stderr, "== Info: %s", data);
+            sb_fprintf(stderr, "== Info: %s", data);
             /* FALLTHROUGH */
         default: /* in case a new one is introduced to shock us */
             return 0;

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -51,18 +51,18 @@ void dump(const char *text,
         /* without the hex output, we can fit more on screen */
         width = 0x40;
 
-    fprintf(stream, "%s, %10.10ld bytes (0x%8.8lx)\n",
+    sb_fprintf(stream, "%s, %10.10ld bytes (0x%8.8lx)\n",
             text, (long) size, (long) size);
 
     for (i = 0; i < size; i += width) {
 
-        fprintf(stream, "%4.4lx: ", (long) i);
+        sb_fprintf(stream, "%4.4lx: ", (long) i);
 
         if (!nohex) {
             /* hex not disabled, show it */
             for (c = 0; c < width; c++)
                 if (i + c < size)
-                    fprintf(stream, "%02x ", ptr[i + c]);
+                    sb_fprintf(stream, "%02x ", ptr[i + c]);
                 else
                     fputs("   ", stream);
         }
@@ -74,7 +74,7 @@ void dump(const char *text,
                 i += (c + 2 - width);
                 break;
             }
-            fprintf(stream, "%c",
+            sb_fprintf(stream, "%c",
                     (ptr[i + c] >= 0x20) && (ptr[i + c] < 0x80) ? ptr[i + c]
                                                                 : '.');
             /* check again for 0D0A, to avoid an extra \n if it's at width */
@@ -99,7 +99,7 @@ int my_trace(CURL *handle, curl_infotype type,
 
     switch (type) {
         case CURLINFO_TEXT:
-            fprintf(stderr, "== Info: %s", data);
+            sb_fprintf(stderr, "== Info: %s", data);
             /* FALLTHROUGH */
         default: /* in case a new one is introduced to shock us */
             return 0;

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -120,12 +120,12 @@ log_log_va_list(int level, const char *file, int line, const char *ns,
     /* Log to stderr */
     if (!L.quiet) {
 #ifdef LOG_USE_COLOR
-        fprintf(
+        sb_fprintf(
             stderr, SF_LOG_TIMESTAMP_FORMAT_COLOR,
             tsbuf, level_colors[level], level_names[level], ns, basename,
             line);
 #else
-        fprintf(
+        sb_fprintf(
             stderr, SF_LOG_TIMESTAMP_FORMAT,
              buf, level_names[level], namespace, basename, line);
 #endif
@@ -135,7 +135,7 @@ log_log_va_list(int level, const char *file, int line, const char *ns,
         va_copy(copy, args);
         log_masked_va_list(stderr, fmt, copy);
         va_end(copy);
-        fprintf(stderr, "\n");
+        sb_fprintf(stderr, "\n");
         fflush(stderr);
     }
 
@@ -145,22 +145,22 @@ log_log_va_list(int level, const char *file, int line, const char *ns,
      */
     if (!(L.fp) && L.path)
     {
-        L.fp = fopen(L.path, "w+");
+        sb_fopen(&L.fp, L.path, "w+");
         if (!(L.fp))
         {
-            fprintf(stderr,
+            sb_fprintf(stderr,
                 "Error opening file from file path: %s\nError code: %s\n",
-                L.path, strerror(errno));
+                L.path, sf_strerror(errno));
             L.path = NULL;
         }
     }
 
     if (L.fp) {
-        fprintf(
+        sb_fprintf(
             L.fp, SF_LOG_TIMESTAMP_FORMAT,
             tsbuf, level_names[level], ns, basename, line);
         log_masked_va_list(L.fp, fmt, args);
-        fprintf(L.fp, "\n");
+        sb_fprintf(L.fp, "\n");
         fflush(L.fp);
     }
 

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -145,12 +145,13 @@ log_log_va_list(int level, const char *file, int line, const char *ns,
      */
     if (!(L.fp) && L.path)
     {
-        sb_fopen(&L.fp, L.path, "w+");
-        if (!(L.fp))
+        if (sb_fopen(&L.fp, L.path, "w+") == NULL)
         {
+            char* str_error = sf_strerror(errno);
             sb_fprintf(stderr,
                 "Error opening file from file path: %s\nError code: %s\n",
-                L.path, sf_strerror(errno));
+                L.path, str_error);
+            sf_free_s(str_error);
             L.path = NULL;
         }
     }

--- a/lib/platform.c
+++ b/lib/platform.c
@@ -266,9 +266,11 @@ int STDCALL sf_setenv(const char *name, const char *value) {
 #endif
 }
 
-char *STDCALL sf_getenv(const char *name) {
+char * STDCALL sf_getenv(const char *name) {
 #ifdef _WIN32
-    return getenv(name);
+    static char buf[BUFSIZ];
+    size_t len = 0;    // We don't use it, but Windows version doesn't like to pass NULL as lenght pointer. It crashes.
+    return getenv_s(&len, buf, sizeof(buf) - 1, name) ? NULL : buf;
 #else
     return getenv(name);
 #endif
@@ -289,6 +291,18 @@ int STDCALL sf_mkdir(const char *path) {
     return mkdir(path, 0755);
 #endif
 }
+
+char* STDCALL sf_strerror(int in_errNumber)
+{
+#ifdef _WIN32
+    static char    errStr[256];
+    strerror_s(errStr, sizeof(errStr), in_errNumber);
+    return errStr;
+#else
+    return strerror(in_errNumber);
+#endif
+}
+
 
 
 int STDCALL

--- a/lib/platform.c
+++ b/lib/platform.c
@@ -266,14 +266,14 @@ int STDCALL sf_setenv(const char *name, const char *value) {
 #endif
 }
 
+/* on Windows, this function allocate new memory, caller should free it */
 char * STDCALL sf_getenv(const char *name) {
 #ifdef _WIN32
-    static char buf[BUFSIZ];
-    size_t len = 0;    // We don't use it, but Windows version doesn't like to pass NULL as lenght pointer. It crashes.
-    return getenv_s(&len, buf, sizeof(buf) - 1, name) ? NULL : buf;
-#else
+    char* result = NULL;
+    return _dupenv_s(&result, NULL, name) ? NULL : result;
+#   else
     return getenv(name);
-#endif
+#   endif
 }
 
 int STDCALL sf_unsetenv(const char *name) {
@@ -292,12 +292,15 @@ int STDCALL sf_mkdir(const char *path) {
 #endif
 }
 
+/* on Windows, this function allocate new memory, caller should free it */
 char* STDCALL sf_strerror(int in_errNumber)
 {
 #ifdef _WIN32
-    static char    errStr[256];
-    strerror_s(errStr, sizeof(errStr), in_errNumber);
-    return errStr;
+    char* buf = (char*)malloc(BUFSIZ);
+    if (buf && 0 == strerror_s(buf, BUFSIZ, in_errNumber))
+        return buf;
+    free(buf);
+    return NULL;
 #else
     return strerror(in_errNumber);
 #endif


### PR DESCRIPTION
getenv and strerror are banned functions. The replacement allocates extra memory that should be released later.