### PR TITLE
SNOW-878098 retry strategy fix to match the design doc

### DIFF
--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -64,17 +64,19 @@ extern "C" {
 /**
  * Login timeout in seconds
  */
+// make the login timetout defaults to 300 to be inline with retry timeout
+// while customer can reduce it as needed
 #define SF_LOGIN_TIMEOUT 300
 
  /**
- * network timeout other than login requests
+ * retry timeout in seconds
  */
-#define SF_NETWORK_TIMEOUT 120
+#define SF_RETRY_TIMEOUT 300
 
  /**
- * max retry number for login reuests (login/authenticator/token)
+ * max retry number
  */
-#define SF_LOGIN_MAX_RETRY 7
+#define SF_MAX_RETRY 7
 
 /**
  * Default JWT timeout in seconds
@@ -244,6 +246,8 @@ typedef enum SF_ATTRIBUTE {
     SF_CON_NO_PROXY,
     SF_CON_DISABLE_QUERY_CONTEXT_CACHE,
     SF_CON_INCLUDE_RETRY_REASON,
+    SF_CON_RETRY_TIMEOUT,
+    SF_CON_MAX_RETRY,
     SF_DIR_QUERY_URL,
     SF_DIR_QUERY_URL_PARAM,
     SF_DIR_QUERY_TOKEN,
@@ -347,6 +351,8 @@ typedef struct SF_CONNECT {
 
     int64 login_timeout;
     int64 network_timeout;
+    // retry timeout for new retry strategy
+    int64 retry_timeout;
 
     // Session specific fields
     int64 sequence_counter;
@@ -362,6 +368,9 @@ typedef struct SF_CONNECT {
     int8 retry_on_curle_couldnt_connect_count;
 
     int8 retry_on_connect_count;
+
+    // max retry number for new retry strategy
+    int8 retry_count;
 
     // Error
     SF_ERROR_STRUCT error;

--- a/lib/client.c
+++ b/lib/client.c
@@ -1066,7 +1066,7 @@ SF_STATUS STDCALL snowflake_set_attribute(
             break;
         case SF_CON_RETRY_TIMEOUT:
           sf->retry_timeout = value ? *((int64 *)value) : SF_RETRY_TIMEOUT;
-          if (sf->retry_timeout < SF_RETRY_TIMEOUT)
+          if ((sf->retry_timeout < SF_RETRY_TIMEOUT) && (sf->retry_timeout != 0))
           {
             sf->retry_timeout = SF_RETRY_TIMEOUT;
           }
@@ -1106,7 +1106,7 @@ SF_STATUS STDCALL snowflake_set_attribute(
             break;
         case SF_CON_MAX_RETRY:
           sf->retry_count = value ? *((int8 *)value) : SF_MAX_RETRY;
-          if (sf->retry_count < SF_MAX_RETRY)
+          if ((sf->retry_count < SF_MAX_RETRY) && (sf->retry_count != 0))
           {
             sf->retry_count = SF_MAX_RETRY;
           }

--- a/lib/client.c
+++ b/lib/client.c
@@ -647,6 +647,8 @@ SF_CONNECT *STDCALL snowflake_init() {
 
     // Make sure memory was actually allocated
     if (sf) {
+        // seed the rand
+        srand(time(NULL));
         // Initialize object with default values
         sf->host = NULL;
         sf->port = NULL;

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -547,7 +547,7 @@ uint32
 get_next_sleep_with_jitter(DECORRELATE_JITTER_BACKOFF *djb, uint32 sleep, uint64 retry_count) {
   float cur_wait_time = sleep;
   cur_wait_time = choose_random(cur_wait_time + get_jitter(sleep),
-                                2 * retry_count + get_jitter(sleep));
+                                pow(2, retry_count) + get_jitter(sleep));
   // no cap for new retry strategy while keep the existing cap for other requests
   if ((djb->cap != SF_NEW_STRATEGY_BACKOFF_CAP) && (cur_wait_time > djb->cap))
   {

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -159,7 +159,7 @@ sf_bool STDCALL http_perform(CURL *curl,
                              const char *proxy,
                              const char *no_proxy,
                              sf_bool include_retry_reason,
-                             sf_bool is_login_request) {
+                             sf_bool is_new_strategy_request) {
     CURLcode res;
     sf_bool ret = SF_BOOLEAN_FALSE;
     sf_bool retry = SF_BOOLEAN_FALSE;
@@ -168,13 +168,12 @@ sf_bool STDCALL http_perform(CURL *curl,
       SF_BACKOFF_BASE,      //base
       SF_BACKOFF_CAP      //cap
     };
-    if (SF_BOOLEAN_TRUE == is_login_request)
+    if (SF_BOOLEAN_TRUE == is_new_strategy_request)
     {
-      djb.base = SF_LOGIN_BACKOFF_BASE;
-      djb.cap = SF_LOGIN_BACKOFF_CAP;
+      djb.cap = SF_NEW_STRATEGY_BACKOFF_CAP;
     }
 
-    network_timeout = (network_timeout > 0) ? network_timeout : SF_NETWORK_TIMEOUT;
+    network_timeout = (network_timeout > 0) ? network_timeout : SF_RETRY_TIMEOUT;
     if (elapsed_time) {
         network_timeout -= *elapsed_time;
         if (network_timeout <= 0) {

--- a/tests/test_unit_retry_context.c
+++ b/tests/test_unit_retry_context.c
@@ -194,6 +194,9 @@ void test_new_retry_strategy(void **unused) {
   uint32 next_sleep_in_secs = 0;
   uint32 total_backoff = 0;
   int retry_count = 0;
+
+  srand(time(NULL));
+
   for (;retry_count < SF_MAX_RETRY; retry_count++)
   {
     assert_int_equal(is_retryable_http_code(error_codes[retry_count]), SF_BOOLEAN_TRUE);

--- a/tests/test_unit_set_get_attributes.cpp
+++ b/tests/test_unit_set_get_attributes.cpp
@@ -66,8 +66,10 @@ std::vector<sf_int_attributes> intAttributes = {
     { SF_CON_JWT_CNXN_WAIT_TIME, 987 },
     { SF_CON_MAX_CON_RETRY, 6 },
     { SF_RETRY_ON_CURLE_COULDNT_CONNECT_COUNT, 5 },
-    { SF_CON_LOGIN_TIMEOUT, 456 },
-    { SF_CON_MAX_CON_RETRY, 8 },
+    { SF_CON_RETRY_TIMEOUT, 456 },
+    { SF_CON_MAX_RETRY, 8 },
+    { SF_CON_RETRY_TIMEOUT, 123 },
+    { SF_CON_MAX_RETRY, 6 },
 };
 
 // unit test for snowflake_set_attribute and snowflake_get_attribute for all SF_ATTRIBUTE
@@ -165,9 +167,10 @@ void test_set_get_all_attributes(void **unused)
         // for SF_CON_MAX_CON_RETRY and SF_CON_LOGIN_TIMEOUT application
         // can only increase the default value.
         if (attr.type == SF_CON_MAX_CON_RETRY ||
+            attr.type == SF_CON_MAX_RETRY ||
             attr.type == SF_RETRY_ON_CURLE_COULDNT_CONNECT_COUNT)
         {
-            if ((attr.type == SF_CON_MAX_CON_RETRY) && (attr.value < 7))
+            if ((attr.type == SF_CON_MAX_RETRY) && (attr.value < 7))
             {
                 assert_int_equal(*((int8 *)value), 7);
             }
@@ -178,7 +181,7 @@ void test_set_get_all_attributes(void **unused)
         }
         else
         {
-            if ((attr.type == SF_CON_LOGIN_TIMEOUT) && (attr.value < 300))
+            if ((attr.type == SF_CON_RETRY_TIMEOUT) && (attr.value < 300))
             {
                 assert_int_equal(*((int64 *)value), 300);
             }

--- a/tests/test_unit_set_get_attributes.cpp
+++ b/tests/test_unit_set_get_attributes.cpp
@@ -70,6 +70,8 @@ std::vector<sf_int_attributes> intAttributes = {
     { SF_CON_MAX_RETRY, 8 },
     { SF_CON_RETRY_TIMEOUT, 123 },
     { SF_CON_MAX_RETRY, 6 },
+    { SF_CON_RETRY_TIMEOUT, 0 },
+    { SF_CON_MAX_RETRY, 0 },
 };
 
 // unit test for snowflake_set_attribute and snowflake_get_attribute for all SF_ATTRIBUTE
@@ -170,7 +172,7 @@ void test_set_get_all_attributes(void **unused)
             attr.type == SF_CON_MAX_RETRY ||
             attr.type == SF_RETRY_ON_CURLE_COULDNT_CONNECT_COUNT)
         {
-            if ((attr.type == SF_CON_MAX_RETRY) && (attr.value < 7))
+            if ((attr.type == SF_CON_MAX_RETRY) && (attr.value < 7) && (attr.value != 0))
             {
                 assert_int_equal(*((int8 *)value), 7);
             }
@@ -181,7 +183,7 @@ void test_set_get_all_attributes(void **unused)
         }
         else
         {
-            if ((attr.type == SF_CON_RETRY_TIMEOUT) && (attr.value < 300))
+            if ((attr.type == SF_CON_RETRY_TIMEOUT) && (attr.value < 300) && (attr.value != 0))
             {
                 assert_int_equal(*((int64 *)value), 300);
             }


### PR DESCRIPTION
Add new connection attribute SF_CON_RETRY_TIMEOUT and SF_CON_MAX_RETRY for the new retry strategy.
SF_CON_RETRY_TIMEOUT: default to 300. 0 means unlimited. Can only be increased.
SF_CON_MAX_RETRY: default to 7. 0 means unlimited. Can only be increased.
