### PR TITLE
fix test case failures on jenkins Windows run

### DIFF
--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -66,7 +66,8 @@ void Snowflake::Client::FileMetadataInitializer::populateSrcLocUploadMetadata(st
   if (hFind == INVALID_HANDLE_VALUE)
   {
     DWORD dwError = GetLastError();
-    if (dwError == ERROR_NO_MORE_FILES || dwError == ERROR_FILE_NOT_FOUND)
+    if (dwError == ERROR_NO_MORE_FILES || dwError == ERROR_FILE_NOT_FOUND ||
+        dwError == ERROR_PATH_NOT_FOUND)
     {
       CXX_LOG_ERROR("No file matching pattern %s has been found. Error: %d", 
         sourceLocation.c_str(), dwError);

--- a/include/snowflake/IStatementPutGet.hpp
+++ b/include/snowflake/IStatementPutGet.hpp
@@ -81,12 +81,12 @@ public:
   // from system locale. No coversion by default.
   virtual std::string UTF8ToPlatformString(const std::string& utf8_str)
   {
-    return utf8_str;
+    return std::string(utf8_str);
   }
 
   virtual std::string platformStringToUTF8(const std::string& platform_str)
   {
-    return platform_str;
+    return std::string(platform_str);
   }
 
   virtual ~IStatementPutGet()


### PR DESCRIPTION
On Windows test on Jenkins, FindFirstFile() returns unexpected error ERROR_PATH_NOT_FOUND and break some test cases.
We only handle ERROR_FILE_NOT_FOUND before but since ERROR_PATH_NOT_FOUND also seems to be a reasonable error handle it same as ERROR_FILE_NOT_FOUND.