### PR TITLE
SNOW-918603: fix test hang issue on Jenkins Linux

### DIFF
--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -306,7 +306,7 @@ void Snowflake::Client::FileTransferAgent::upload(string *command)
 
   if (!m_failedTransfers.empty())
   {
-    CXX_LOG_DEBUG("%s command FAILED.", command);
+    CXX_LOG_DEBUG("%s command FAILED.", command->c_str());
     if (isPutFastFailEnabled())
     {
       throw SnowflakeTransferException(TransferError::FAST_FAIL_ENABLED_SKIP_UPLOADS, m_failedTransfers.c_str());
@@ -704,7 +704,7 @@ void Snowflake::Client::FileTransferAgent::download(string *command)
 
   if (!m_failedTransfers.empty())
   {
-    CXX_LOG_DEBUG("%s command FAILED.", command);
+    CXX_LOG_DEBUG("%s command FAILED.", command->c_str());
     if (isGetFastFailEnabled())
     {
       throw SnowflakeTransferException(TransferError::FAST_FAIL_ENABLED_SKIP_DOWNLOADS, m_failedTransfers.c_str());

--- a/tests/test_unit_cred_renew.cpp
+++ b/tests/test_unit_cred_renew.cpp
@@ -309,7 +309,8 @@ void test_token_renew_core(std::string fileName)
   MockedStatementPut mockedStatementPut(fileName);
 
   Snowflake::Client::FileTransferAgent agent(&mockedStatementPut);
-
+  // use urandom to avoid blocking
+  agent.setRandomDeviceAsUrand(true);
   ITransferResult * result = agent.execute(&cmd);
 
   std::string put_status;
@@ -355,7 +356,8 @@ void test_token_renew_get_remote_meta(void **unused)
   MockedStatementGet mockedStatementGet;
 
   Snowflake::Client::FileTransferAgent agent(&mockedStatementGet);
-
+  // use urandom to avoid blocking
+  agent.setRandomDeviceAsUrand(true);
   ITransferResult * result = agent.execute(&cmd);
 
   std::string get_status;
@@ -377,6 +379,8 @@ void test_parse_exception(void **unused)
   MockedFailedParseStmt failedParseStmt;
 
   Snowflake::Client::FileTransferAgent agent(&failedParseStmt);
+  // use urandom to avoid blocking
+  agent.setRandomDeviceAsUrand(true);
 
   try
   {
@@ -404,6 +408,8 @@ void test_transfer_exception_upload(void **unused)
   MockedStatementPut mockedStatementPut("small*");
 
   Snowflake::Client::FileTransferAgent agent(&mockedStatementPut);
+  // use urandom to avoid blocking
+  agent.setRandomDeviceAsUrand(true);
 
   try
   {
@@ -426,7 +432,8 @@ void test_transfer_exception_download(void **unused)
   MockedStatementGetSmall mockedStatementGetSmall;
 
   Snowflake::Client::FileTransferAgent agent(&mockedStatementGetSmall);
-
+  // use urandom to avoid blocking
+  agent.setRandomDeviceAsUrand(true);
   ITransferResult * result = agent.execute(&cmd);
 
   std::string get_status;
@@ -453,14 +460,6 @@ static int gr_setup(void **unused)
 }
 
 int main(void) {
-  // temporarily comment out test case could hang on Linux Jenkins run
-  // sdk issue 658, 340 to follow up
-  char *genv = getenv("GITHUB_ACTIONS");
-  if ((!genv) || (strlen(genv) == 0)) {
-#ifdef __linux__
-    return 0;
-#endif
-  }
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_parse_exception),
     cmocka_unit_test(test_token_renew_small_files),


### PR DESCRIPTION
sdk issue 340, 658
Another attempt to fix the hanging issue on Linux Jenkins

Not sure if that's the root cause but using DEV_RANDOM would spend up to 2 seconds each time on my local and that could be a blocker on Jenkins if no enough entropy can be collected there. Change to use URANDOM to avoid possible blocker.
Also reduced unnecessary sleep to make the test case faster.
