### PR TITLE
SNOW-910807: refactoring to reuse query context cache implementation in ODBC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ set(SOURCE_FILES_CPP_WRAPPER
         include/snowflake/Param.hpp
         include/snowflake/Exceptions.hpp
         include/snowflake/jwtWrapper.h
+        include/snowflake/QueryContextCache.hpp
         cpp/lib/Exceptions.cpp
         cpp/lib/Connection.cpp
         cpp/lib/Statement.cpp
@@ -219,7 +220,8 @@ set(SOURCE_FILES_CPP_WRAPPER
         cpp/lib/DataConversion.cpp
         cpp/lib/DataConversion.hpp
         cpp/lib/QueryContextCache.cpp
-        cpp/lib/QueryContextCache.hpp
+        cpp/lib/ClientQueryContextCache.cpp
+        cpp/lib/ClientQueryContextCache.hpp
         cpp/lib/result_set.cpp
         cpp/lib/result_set_arrow.cpp
         cpp/lib/result_set_json.cpp

--- a/cpp/lib/ClientQueryContextCache.cpp
+++ b/cpp/lib/ClientQueryContextCache.cpp
@@ -1,0 +1,320 @@
+/*
+* File:   ClientQueryContextCache.cpp
+* Author: harryx
+*
+* Copyright (c) 2023 Snowflake Computing
+*
+* Created on November 29, 2023, 12:40 PM
+*/
+
+#include "ClientQueryContextCache.hpp"
+#include "../logger/SFLogger.hpp"
+#include "query_context_cache.h"
+
+// wrapper functions for C
+extern "C" {
+
+  void qcc_initialize(SF_CONNECT * conn)
+  {
+    if (!conn || conn->qcc_disable || conn->qcc)
+    {
+      return;
+    }
+
+    conn->qcc = (void *) new Snowflake::Client::ClientQueryContextCache(conn->qcc_capacity);
+  }
+
+  void qcc_set_capacity(SF_CONNECT * conn, uint64 capacity)
+  {
+    if (!conn || conn->qcc_disable)
+    {
+      return;
+    }
+    if (!conn->qcc)
+    {
+      qcc_initialize(conn);
+    }
+    static_cast<Snowflake::Client::ClientQueryContextCache *>(conn->qcc)->setCapacity(capacity);
+  }
+
+  cJSON* qcc_serialize(SF_CONNECT * conn)
+  {
+    if (!conn || conn->qcc_disable || !conn->qcc)
+    {
+      return NULL;
+    }
+
+    return static_cast<Snowflake::Client::ClientQueryContextCache *>(conn->qcc)->serializeQueryContext();
+  }
+
+  void qcc_deserialize(SF_CONNECT * conn, cJSON* query_context)
+  {
+    if (!conn || conn->qcc_disable)
+    {
+      return;
+    }
+    if (!conn->qcc)
+    {
+      qcc_initialize(conn);
+    }
+
+    static_cast<Snowflake::Client::ClientQueryContextCache *>(conn->qcc)->deserializeQueryContext(query_context);
+  }
+
+  void qcc_terminate(SF_CONNECT * conn)
+  {
+    if (!conn || !conn->qcc)
+    {
+      return;
+    }
+
+    delete static_cast<Snowflake::Client::ClientQueryContextCache *>(conn->qcc);
+  }
+
+} // extern "C"
+
+namespace Snowflake
+{
+namespace Client
+{
+
+// Public ======================================================================
+void ClientQueryContextCache::deserializeQueryContext(cJSON * data)
+{
+  if ((!data) || (data->type != cJSON_Object))
+  {
+    // Clear the cache
+    clearCache();
+    return;
+  }
+
+  // Deserialize the entries. The first entry with priority is the main entry.
+  // Save all entries into one list to simplify the logic. An example JSON is:
+  // {
+  //   "entries": [
+  //    {
+  //     "id": 0,
+  //     "read_timestamp": 123456789,
+  //     "priority": 0,
+  //     "context": "base64 encoded context"
+  //    },
+  //     {
+  //       "id": 1,
+  //       "read_timestamp": 123456789,
+  //       "priority": 1,
+  //       "context": "base64 encoded context"
+  //     },
+  //     {
+  //       "id": 2,
+  //       "read_timestamp": 123456789,
+  //       "priority": 2,
+  //       "context": "base64 encoded context"
+  //     }
+  //   ]
+  std::vector<QueryContextElement> elements;
+  cJSON * entries = snowflake_cJSON_GetObjectItem(data, QCC_ENTRIES_KEY);
+  if ((entries) && (entries->type == cJSON_Array))
+  {
+    int arraySize = snowflake_cJSON_GetArraySize(entries);
+    for (int i = 0; i < arraySize; i++)
+    {
+      QueryContextElement entry;
+      if (deserializeQueryContextElement(snowflake_cJSON_GetArrayItem(entries, i), entry))
+      {
+        elements.push_back(entry);
+      }
+      else
+      {
+        CXX_LOG_TRACE("ClientQueryContextCache::deserializeQueryContext: "
+                      "meets mismatch field type. Clear the QueryContextCache.");
+        clearCache();
+        return;
+      }
+    }
+  }
+
+  UpdateQueryContextCache(elements);
+}
+
+void ClientQueryContextCache::deserializeQueryContextReq(cJSON * data)
+{
+  if ((!data) || (data->type != cJSON_Object))
+  {
+    // Clear the cache
+    clearCache();
+    return;
+  }
+
+  std::vector<QueryContextElement> elements;
+  cJSON * entries = snowflake_cJSON_GetObjectItem(data, QCC_ENTRIES_KEY);
+  int arraySize = snowflake_cJSON_GetArraySize(entries);
+  if ((entries) && (entries->type == cJSON_Array))
+  {
+    for (int i = 0; i < arraySize; i++)
+    {
+      QueryContextElement entry;
+      if (deserializeQueryContextElementReq(snowflake_cJSON_GetArrayItem(entries, i), entry))
+      {
+        elements.push_back(entry);
+      }
+      else
+      {
+        CXX_LOG_TRACE("ClientQueryContextCache::deserializeQueryContextReq: "
+          "meets mismatch field type. Clear the QueryContextCache.");
+        clearCache();
+        return;
+      }
+    }
+  }
+
+  UpdateQueryContextCache(elements);
+}
+
+cJSON * ClientQueryContextCache::serializeQueryContext()
+{
+  std::vector<QueryContextElement> elements;
+  GetQueryContextEntries(elements);
+
+  cJSON * queryContext = snowflake_cJSON_CreateObject();
+  cJSON * entries = snowflake_cJSON_CreateArray();
+  for (auto itr = elements.begin(); itr != elements.end(); itr++)
+  {
+    cJSON * entry = snowflake_cJSON_CreateObject();
+    snowflake_cJSON_AddUint64ToObject(entry, QCC_ID_KEY, itr->id);
+    snowflake_cJSON_AddUint64ToObject(entry, QCC_PRIORITY_KEY, itr->priority);
+    snowflake_cJSON_AddUint64ToObject(entry, QCC_TIMESTAMP_KEY, itr->readTimestamp);
+    cJSON * context = snowflake_cJSON_CreateObject();
+    if (!itr->context.empty())
+    {
+      snowflake_cJSON_AddStringToObject(context, QCC_CONTEXT_VALUE_KEY, itr->context.c_str());
+    }
+    snowflake_cJSON_AddItemToObject(entry, QCC_CONTEXT_KEY, context);
+    snowflake_cJSON_AddItemToArray(entries, entry);
+  }
+
+  snowflake_cJSON_AddItemToObject(queryContext, QCC_ENTRIES_KEY, entries);
+
+  return queryContext;
+}
+
+// Private =====================================================================
+bool ClientQueryContextCache::deserializeQueryContextElement(cJSON * entryNode,
+                                                       QueryContextElement & contextElement)
+{
+  cJSON * id = snowflake_cJSON_GetObjectItem(entryNode, QCC_ID_KEY);
+  if (id && (id->type == cJSON_Number))
+  {
+    contextElement.id = snowflake_cJSON_GetUint64Value(id);
+  }
+  else
+  {
+    CXX_LOG_WARN("ClientQueryContextCache::deserializeQueryContextElement: `id` field is not integer type");
+    return false;
+  }
+
+  cJSON * timestamp = snowflake_cJSON_GetObjectItem(entryNode, QCC_TIMESTAMP_KEY);
+  if (timestamp && (timestamp->type == cJSON_Number))
+  {
+    contextElement.readTimestamp = snowflake_cJSON_GetUint64Value(timestamp);
+  }
+  else
+  {
+    CXX_LOG_WARN("ClientQueryContextCache::deserializeQueryContextElement: `timestamp` field is not integer type");
+    return false;
+  }
+
+  cJSON * priority = snowflake_cJSON_GetObjectItem(entryNode, QCC_PRIORITY_KEY);
+  if (priority && (priority->type == cJSON_Number))
+  {
+    contextElement.priority = snowflake_cJSON_GetUint64Value(priority);
+  }
+  else
+  {
+    CXX_LOG_WARN("ClientQueryContextCache::deserializeQueryContextElement: `priority` field is not integer type");
+    return false;
+  }
+
+  cJSON * context = snowflake_cJSON_GetObjectItem(entryNode, QCC_CONTEXT_KEY);
+  if (!context || context->type == cJSON_NULL)
+  {
+    return true;
+  }
+  if (context->type == cJSON_String)
+  {
+    contextElement.context = snowflake_cJSON_GetStringValue(context);
+  }
+  else
+  {
+    CXX_LOG_WARN("ClientQueryContextCache::deserializeQueryContextElement: `context` field is not string type");
+    return false;
+  }
+
+  return true;
+}
+
+bool ClientQueryContextCache::deserializeQueryContextElementReq(cJSON * entryNode,
+                                                          QueryContextElement & contextElement)
+{
+  cJSON * id = snowflake_cJSON_GetObjectItem(entryNode, QCC_ID_KEY);
+  if (id && (id->type == cJSON_Number))
+  {
+    contextElement.id = snowflake_cJSON_GetUint64Value(id);
+  }
+  else
+  {
+    CXX_LOG_WARN("ClientQueryContextCache::deserializeQueryContextElement: `id` field is not integer type");
+    return false;
+  }
+
+  cJSON * timestamp = snowflake_cJSON_GetObjectItem(entryNode, QCC_TIMESTAMP_KEY);
+  if (timestamp && (timestamp->type == cJSON_Number))
+  {
+    contextElement.readTimestamp = snowflake_cJSON_GetUint64Value(timestamp);
+  }
+  else
+  {
+    CXX_LOG_WARN("ClientQueryContextCache::deserializeQueryContextElement: `timestamp` field is not integer type");
+    return false;
+  }
+
+  cJSON * priority = snowflake_cJSON_GetObjectItem(entryNode, QCC_PRIORITY_KEY);
+  if (priority && (priority->type == cJSON_Number))
+  {
+    contextElement.priority = snowflake_cJSON_GetUint64Value(priority);
+  }
+  else
+  {
+    CXX_LOG_WARN("ClientQueryContextCache::deserializeQueryContextElement: `priority` field is not integer type");
+    return false;
+  }
+
+  cJSON * context = snowflake_cJSON_GetObjectItem(entryNode, QCC_CONTEXT_KEY);
+  if (!context || context->type == cJSON_NULL)
+  {
+    return true;
+  }
+  if (context->type != cJSON_Object)
+  {
+    return false;
+  }
+
+  cJSON * contextValue = snowflake_cJSON_GetObjectItem(context, QCC_CONTEXT_VALUE_KEY);
+  if (!contextValue || contextValue->type == cJSON_NULL)
+  {
+    return true;
+  }
+
+  if (contextValue->type == cJSON_String)
+  {
+    contextElement.context = snowflake_cJSON_GetStringValue(contextValue);
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace Client
+} // namespace Snowflake

--- a/cpp/lib/ClientQueryContextCache.hpp
+++ b/cpp/lib/ClientQueryContextCache.hpp
@@ -1,0 +1,60 @@
+/*
+* File:   ClientQueryContextCache.hpp
+* Author: harryx
+*
+* Copyright (c) 2023 Snowflake Computing
+*
+* Created on November 29, 2023, 12:40 PM
+*/
+
+#pragma once
+#ifndef CLIENT_QUERY_CONTEXT_CACHE_HPP
+#define CLIENT_QUERY_CONTEXT_CACHE_HPP
+
+#include <mutex>
+#include <map>
+#include <set>
+#include <vector>
+#include "cJSON.h"
+#include "snowflake/client.h"
+#include "snowflake/QueryContextCache.hpp"
+
+namespace Snowflake
+{
+namespace Client
+{
+
+class ClientQueryContextCache : public QueryContextCache
+{
+public:
+  // constructor
+  ClientQueryContextCache(size_t capacity) : QueryContextCache(capacity) {}
+
+  /**
+  * @param data: the JSON value of QueryContext Object
+  */
+  void deserializeQueryContext(cJSON * data);
+
+  cJSON * serializeQueryContext();
+
+  /**
+  * for test purpose only, deserialize from JSON value serialized from cache
+  * for sending request
+  * @param data: the JSON value of QueryContext Object
+  */
+  void deserializeQueryContextReq(cJSON * data);
+
+private:
+  bool deserializeQueryContextElement(cJSON * entryNode,
+                                      QueryContextElement & contextElement);
+
+  // for test purpose only, deserializeQueryContextElement from serialized
+  // JSON value for request
+  bool deserializeQueryContextElementReq(cJSON * entryNode,
+                                         QueryContextElement & contextElement);
+};
+
+} // namespace Client
+} // namespace Snowflake
+
+#endif  // QUERY_CONTEXT_CACHE_HPP

--- a/cpp/lib/ClientQueryContextCache.hpp
+++ b/cpp/lib/ClientQueryContextCache.hpp
@@ -1,11 +1,6 @@
 /*
-* File:   ClientQueryContextCache.hpp
-* Author: harryx
-*
-* Copyright (c) 2023 Snowflake Computing
-*
-* Created on November 29, 2023, 12:40 PM
-*/
+ * Copyright (c) 2024 Snowflake Computing, Inc. All rights reserved.
+ */
 
 #pragma once
 #ifndef CLIENT_QUERY_CONTEXT_CACHE_HPP

--- a/cpp/lib/QueryContextCache.cpp
+++ b/cpp/lib/QueryContextCache.cpp
@@ -7,70 +7,8 @@
 * Created on August 31, 2023, 4:05 PM
 */
 
-#include "QueryContextCache.hpp"
+#include "snowflake/QueryContextCache.hpp"
 #include "../logger/SFLogger.hpp"
-
-// wrapper functions for C
-extern "C" {
-
-  void qcc_initialize(SF_CONNECT * conn)
-  {
-    if (!conn || conn->qcc_disable || conn->qcc)
-    {
-      return;
-    }
-
-    conn->qcc = (void *) new Snowflake::Client::QueryContextCache(conn->qcc_capacity);
-  }
-
-  void qcc_set_capacity(SF_CONNECT * conn, uint64 capacity)
-  {
-    if (!conn || conn->qcc_disable)
-    {
-      return;
-    }
-    if (!conn->qcc)
-    {
-      qcc_initialize(conn);
-    }
-    static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc)->setCapacity(capacity);
-  }
-
-  cJSON* qcc_serialize(SF_CONNECT * conn)
-  {
-    if (!conn || conn->qcc_disable || !conn->qcc)
-    {
-      return NULL;
-    }
-
-    return static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc)->serializeQueryContext();
-  }
-
-  void qcc_deserialize(SF_CONNECT * conn, cJSON* query_context)
-  {
-    if (!conn || conn->qcc_disable)
-    {
-      return;
-    }
-    if (!conn->qcc)
-    {
-      qcc_initialize(conn);
-    }
-
-    static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc)->deserializeQueryContext(query_context);
-  }
-
-  void qcc_terminate(SF_CONNECT * conn)
-  {
-    if (!conn || !conn->qcc)
-    {
-      return;
-    }
-
-    delete static_cast<Snowflake::Client::QueryContextCache *>(conn->qcc);
-  }
-
-} // extern "C"
 
 namespace Snowflake
 {
@@ -107,65 +45,19 @@ void QueryContextCache::setCapacity(size_t capacity)
   CXX_LOG_TRACE("QueryContextCache::setCapacity: set capacity from %d to %d", m_capacity, capacity);
 }
 
-void QueryContextCache::deserializeQueryContext(cJSON * data)
+void QueryContextCache::UpdateQueryContextCache(const std::vector<QueryContextElement>& entries)
 {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   // Log existing cache entries
   logCacheEntries();
 
-  if ((!data) || (data->type != cJSON_Object))
+  for (auto entry = entries.begin(); entry != entries.end(); entry++)
   {
-    // Clear the cache
-    clearCache();
-    return;
+    merge(entry->id, entry->readTimestamp, entry->priority, entry->context);
   }
-
-  // Deserialize the entries. The first entry with priority is the main entry.
-  // Save all entries into one list to simplify the logic. An example JSON is:
-  // {
-  //   "entries": [
-  //    {
-  //     "id": 0,
-  //     "read_timestamp": 123456789,
-  //     "priority": 0,
-  //     "context": "base64 encoded context"
-  //    },
-  //     {
-  //       "id": 1,
-  //       "read_timestamp": 123456789,
-  //       "priority": 1,
-  //       "context": "base64 encoded context"
-  //     },
-  //     {
-  //       "id": 2,
-  //       "read_timestamp": 123456789,
-  //       "priority": 2,
-  //       "context": "base64 encoded context"
-  //     }
-  //   ]
-  cJSON * entries = snowflake_cJSON_GetObjectItem(data, QCC_ENTRIES_KEY);
-  if ((entries) && (entries->type == cJSON_Array))
-  {
-    int arraySize = snowflake_cJSON_GetArraySize(entries);
-    for (int i = 0; i < arraySize; i++)
-    {
-      QueryContextElement entry;
-      if (deserializeQueryContextElement(snowflake_cJSON_GetArrayItem(entries, i), entry))
-      {
-        merge(entry.id, entry.readTimestamp, entry.priority, entry.context);
-      }
-      else
-      {
-        CXX_LOG_TRACE("QueryContextCache::deserializeQueryContext: "
-                      "meets mismatch field type. Clear the QueryContextCache.");
-        clearCache();
-        return;
-      }
-    }
-    // after merging all entries, sync the internal priority map to priority map. Because of priority swicth from GS side,
-    // there could be priority key conflict if we directly operating on the priorityMap during a round of merge.
-    syncPriorityMap();
-  }
+  // after merging all entries, sync the internal priority map to priority map. Because of priority swicth from GS side,
+  // there could be priority key conflict if we directly operating on the priorityMap during a round of merge.
+  syncPriorityMap();
 
   // After merging all entries, truncate to capacity
   checkCacheCapacity();
@@ -174,78 +66,21 @@ void QueryContextCache::deserializeQueryContext(cJSON * data)
   logCacheEntries();
 }
 
-void QueryContextCache::deserializeQueryContextReq(cJSON * data)
+size_t QueryContextCache::GetQueryContextEntries(std::vector<QueryContextElement>& entries)
 {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
   // Log existing cache entries
   logCacheEntries();
 
-  if ((!data) || (data->type != cJSON_Object))
-  {
-    // Clear the cache
-    clearCache();
-    return;
-  }
+  entries.clear();
 
-  cJSON * entries = snowflake_cJSON_GetObjectItem(data, QCC_ENTRIES_KEY);
-  int arraySize = snowflake_cJSON_GetArraySize(entries);
-  if ((entries) && (entries->type == cJSON_Array))
-  {
-    for (int i = 0; i < arraySize; i++)
-    {
-      QueryContextElement entry;
-      if (deserializeQueryContextElementReq(snowflake_cJSON_GetArrayItem(entries, i), entry))
-      {
-        merge(entry.id, entry.readTimestamp, entry.priority, entry.context);
-      }
-      else
-      {
-        CXX_LOG_TRACE("QueryContextCache::deserializeQueryContextReq: "
-          "meets mismatch field type. Clear the QueryContextCache.");
-        clearCache();
-        return;
-      }
-    }
-    // after merging all entries, sync the internal priority map to priority map. Because of priority swicth from GS side,
-    // there could be priority key conflict if we directly operating on the priorityMap during a round of merge.
-    syncPriorityMap();
-  }
-
-  // After merging all entries, truncate to capacity
-  checkCacheCapacity();
-
-  // Log existing cache entries
-  logCacheEntries();
-}
-
-cJSON *  QueryContextCache::serializeQueryContext()
-{
-  std::lock_guard<std::recursive_mutex> guard(m_mutex);
-
-  // Log existing cache entries
-  logCacheEntries();
-
-  cJSON * queryContext = snowflake_cJSON_CreateObject();
-  cJSON * entries = snowflake_cJSON_CreateArray();
   for (auto itr = m_cacheSet.begin(); itr != m_cacheSet.end(); itr++)
   {
-    cJSON * entry = snowflake_cJSON_CreateObject();
-    snowflake_cJSON_AddUint64ToObject(entry, QCC_ID_KEY, itr->id);
-    snowflake_cJSON_AddUint64ToObject(entry, QCC_PRIORITY_KEY, itr->priority);
-    snowflake_cJSON_AddUint64ToObject(entry, QCC_TIMESTAMP_KEY, itr->readTimestamp);
-    cJSON * context = snowflake_cJSON_CreateObject();
-    if (!itr->context.empty())
-    {
-      snowflake_cJSON_AddStringToObject(context, QCC_CONTEXT_VALUE_KEY, itr->context.c_str());
-    }
-    snowflake_cJSON_AddItemToObject(entry, QCC_CONTEXT_KEY, context);
-    snowflake_cJSON_AddItemToArray(entries, entry);
+    entries.emplace_back(*itr);
   }
 
-  snowflake_cJSON_AddItemToObject(queryContext, QCC_ENTRIES_KEY, entries);
-
-  return queryContext;
+  return entries.size();
 }
 
 void QueryContextCache::merge(uint64 id, uint64 readTimestamp,
@@ -350,124 +185,6 @@ size_t QueryContextCache::getElements(std::vector<uint64>& ids,
 }
 
 // Private =====================================================================
-bool QueryContextCache::deserializeQueryContextElement(cJSON * entryNode,
-                                                       QueryContextElement & contextElement)
-{
-  cJSON * id = snowflake_cJSON_GetObjectItem(entryNode, QCC_ID_KEY);
-  if (id && (id->type == cJSON_Number))
-  {
-    contextElement.id = snowflake_cJSON_GetUint64Value(id);
-  }
-  else
-  {
-    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `id` field is not integer type");
-    return false;
-  }
-
-  cJSON * timestamp = snowflake_cJSON_GetObjectItem(entryNode, QCC_TIMESTAMP_KEY);
-  if (timestamp && (timestamp->type == cJSON_Number))
-  {
-    contextElement.readTimestamp = snowflake_cJSON_GetUint64Value(timestamp);
-  }
-  else
-  {
-    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `timestamp` field is not integer type");
-    return false;
-  }
-
-  cJSON * priority = snowflake_cJSON_GetObjectItem(entryNode, QCC_PRIORITY_KEY);
-  if (priority && (priority->type == cJSON_Number))
-  {
-    contextElement.priority = snowflake_cJSON_GetUint64Value(priority);
-  }
-  else
-  {
-    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `priority` field is not integer type");
-    return false;
-  }
-
-  cJSON * context = snowflake_cJSON_GetObjectItem(entryNode, QCC_CONTEXT_KEY);
-  if (!context || context->type == cJSON_NULL)
-  {
-    return true;
-  }
-  if (context->type == cJSON_String)
-  {
-    contextElement.context = snowflake_cJSON_GetStringValue(context);
-  }
-  else
-  {
-    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `context` field is not string type");
-    return false;
-  }
-
-  return true;
-}
-
-bool QueryContextCache::deserializeQueryContextElementReq(cJSON * entryNode,
-                                                          QueryContextElement & contextElement)
-{
-  cJSON * id = snowflake_cJSON_GetObjectItem(entryNode, QCC_ID_KEY);
-  if (id && (id->type == cJSON_Number))
-  {
-    contextElement.id = snowflake_cJSON_GetUint64Value(id);
-  }
-  else
-  {
-    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `id` field is not integer type");
-    return false;
-  }
-
-  cJSON * timestamp = snowflake_cJSON_GetObjectItem(entryNode, QCC_TIMESTAMP_KEY);
-  if (timestamp && (timestamp->type == cJSON_Number))
-  {
-    contextElement.readTimestamp = snowflake_cJSON_GetUint64Value(timestamp);
-  }
-  else
-  {
-    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `timestamp` field is not integer type");
-    return false;
-  }
-
-  cJSON * priority = snowflake_cJSON_GetObjectItem(entryNode, QCC_PRIORITY_KEY);
-  if (priority && (priority->type == cJSON_Number))
-  {
-    contextElement.priority = snowflake_cJSON_GetUint64Value(priority);
-  }
-  else
-  {
-    CXX_LOG_WARN("QueryContextCache::deserializeQueryContextElement: `priority` field is not integer type");
-    return false;
-  }
-
-  cJSON * context = snowflake_cJSON_GetObjectItem(entryNode, QCC_CONTEXT_KEY);
-  if (!context || context->type == cJSON_NULL)
-  {
-    return true;
-  }
-  if (context->type != cJSON_Object)
-  {
-    return false;
-  }
-
-  cJSON * contextValue = snowflake_cJSON_GetObjectItem(context, QCC_CONTEXT_VALUE_KEY);
-  if (!contextValue || contextValue->type == cJSON_NULL)
-  {
-    return true;
-  }
-
-  if (contextValue->type == cJSON_String)
-  {
-    contextElement.context = snowflake_cJSON_GetStringValue(contextValue);
-  }
-  else
-  {
-    return false;
-  }
-
-  return true;
-}
-
 void QueryContextCache::addQCE(const QueryContextElement& qce)
 {
   m_idMap[qce.id] = qce;

--- a/cpp/lib/QueryContextCache.cpp
+++ b/cpp/lib/QueryContextCache.cpp
@@ -1,11 +1,6 @@
 /*
-* File:   QueryContextCache.cpp
-* Author: harryx
-*
-* Copyright (c) 2023 Snowflake Computing
-*
-* Created on August 31, 2023, 4:05 PM
-*/
+ * Copyright (c) 2024 Snowflake Computing, Inc. All rights reserved.
+ */
 
 #include "snowflake/QueryContextCache.hpp"
 #include "../logger/SFLogger.hpp"

--- a/include/snowflake/QueryContextCache.hpp
+++ b/include/snowflake/QueryContextCache.hpp
@@ -1,11 +1,6 @@
 /*
-* File:   QueryContextCache.hpp
-* Author: harryx
-*
-* Copyright (c) 2023 Snowflake Computing
-*
-* Created on August 31, 2023, 4:05 PM
-*/
+ * Copyright (c) 2024 Snowflake Computing, Inc. All rights reserved.
+ */
 
 #pragma once
 #ifndef QUERY_CONTEXT_CACHE_HPP

--- a/include/snowflake/QueryContextCache.hpp
+++ b/include/snowflake/QueryContextCache.hpp
@@ -11,11 +11,11 @@
 #ifndef QUERY_CONTEXT_CACHE_HPP
 #define QUERY_CONTEXT_CACHE_HPP
 
-#include "query_context_cache.h"
 #include <mutex>
 #include <map>
 #include <set>
 #include <vector>
+#include "snowflake/client.h"
 
 namespace Snowflake
 {
@@ -61,20 +61,6 @@ public:
   void setCapacity(size_t capacity);
 
   /**
-  * @param data: the JSON value of QueryContext Object
-  */
-  void deserializeQueryContext(cJSON * data);
-
-  cJSON * serializeQueryContext();
-
-  /**
-  * for test purpose only, deserialize from JSON value serialized from cache
-  * for sending request
-  * @param data: the JSON value of QueryContext Object
-  */
-  void deserializeQueryContextReq(cJSON * data);
-
-  /**
   * Merge a new element comes from the server with the existing cache. Merge is based on read time
   * stamp for the same id and based on priority for two different ids.
   *
@@ -108,15 +94,24 @@ public:
                      std::vector<uint64>& priorities,
                      std::vector<std::string>& contexts);
 
+protected:
+  /**
+  * Update Query Context Cache
+  *
+  * @param entries Query context entries to be updated to cache.
+  */
+  void UpdateQueryContextCache(const std::vector<QueryContextElement>& entries);
+
+  /**
+  * Get entries from Query Context Cache
+  *
+  * @param entries Output all entries in cache.
+  *
+  * @return the number of the entries.
+  */
+  size_t GetQueryContextEntries(std::vector<QueryContextElement>& entries);
+
 private:
-  bool deserializeQueryContextElement(cJSON * entryNode,
-                                      QueryContextElement & contextElement);
-
-  // for test purpose only, deserializeQueryContextElement from serialized
-  // JSON value for request
-  bool deserializeQueryContextElementReq(cJSON * entryNode,
-                                         QueryContextElement & contextElement);
-
   /**
   * Add an element in the cache.
   *
@@ -152,7 +147,7 @@ private:
 
   /** Debugging purpose, log the all entries in the cache. */
   void logCacheEntries();
-
+  
   // The mutex protecting access to the query context cache
   std::recursive_mutex m_mutex;
 

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -211,15 +211,15 @@ typedef enum SF_STATUS {
 #define SF_SQLSTATE_OPTIONAL_FEATURE_NOT_IMPLEMENTED "HYC00"
 
 // For Query Context Cache
-#define QCC_CAPACITY_DEF        5
-#define QCC_RSP_KEY             "queryContext"
-#define QCC_REQ_KEY             "queryContextDTO"
-#define QCC_ENTRIES_KEY         "entries"
-#define QCC_ID_KEY              "id"
-#define QCC_PRIORITY_KEY        "priority"
-#define QCC_TIMESTAMP_KEY       "timestamp"
-#define QCC_CONTEXT_KEY         "context"
-#define QCC_CONTEXT_VALUE_KEY   "base64Data"
+#define SF_QCC_CAPACITY_DEF        5
+#define SF_QCC_RSP_KEY             "queryContext"
+#define SF_QCC_REQ_KEY             "queryContextDTO"
+#define SF_QCC_ENTRIES_KEY         "entries"
+#define SF_QCC_ID_KEY              "id"
+#define SF_QCC_PRIORITY_KEY        "priority"
+#define SF_QCC_TIMESTAMP_KEY       "timestamp"
+#define SF_QCC_CONTEXT_KEY         "context"
+#define SF_QCC_CONTEXT_VALUE_KEY   "base64Data"
 
 /**
  * Attributes for Snowflake database session context.

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -210,6 +210,17 @@ typedef enum SF_STATUS {
 #define SF_SQLSTATE_INVALID_CURSOR_POSITION "HY108"
 #define SF_SQLSTATE_OPTIONAL_FEATURE_NOT_IMPLEMENTED "HYC00"
 
+// For Query Context Cache
+#define QCC_CAPACITY_DEF        5
+#define QCC_RSP_KEY             "queryContext"
+#define QCC_REQ_KEY             "queryContextDTO"
+#define QCC_ENTRIES_KEY         "entries"
+#define QCC_ID_KEY              "id"
+#define QCC_PRIORITY_KEY        "priority"
+#define QCC_TIMESTAMP_KEY       "timestamp"
+#define QCC_CONTEXT_KEY         "context"
+#define QCC_CONTEXT_VALUE_KEY   "base64Data"
+
 /**
  * Attributes for Snowflake database session context.
  */

--- a/lib/client.c
+++ b/lib/client.c
@@ -708,7 +708,7 @@ SF_CONNECT *STDCALL snowflake_init() {
         sf->retry_on_connect_count = 0;
         sf->retry_count = SF_MAX_RETRY;
 
-        sf->qcc_capacity = QCC_CAPACITY_DEF;
+        sf->qcc_capacity = SF_QCC_CAPACITY_DEF;
         sf->qcc_disable = SF_BOOLEAN_FALSE;
         sf->qcc = NULL;
     }
@@ -925,7 +925,7 @@ SF_STATUS STDCALL snowflake_connect(SF_CONNECT *sf) {
 
             _mutex_lock(&sf->mutex_parameters);
             ret = _set_parameters_session_info(sf, data);
-            qcc_deserialize(sf, snowflake_cJSON_GetObjectItem(data, QCC_RSP_KEY));
+            qcc_deserialize(sf, snowflake_cJSON_GetObjectItem(data, SF_QCC_RSP_KEY));
             _mutex_unlock(&sf->mutex_parameters);
             if (ret > 0) {
                 goto cleanup;
@@ -2031,7 +2031,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
     cJSON * qcc = qcc_serialize(sfstmt->connection);
     if (qcc != NULL)
     {
-      snowflake_cJSON_AddItemToObject(body, QCC_REQ_KEY, qcc);
+      snowflake_cJSON_AddItemToObject(body, SF_QCC_REQ_KEY, qcc);
     }
 
     s_body = snowflake_cJSON_Print(body);
@@ -2159,7 +2159,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
                 /* Set other parameters. Ignore the status */
                 _set_current_objects(sfstmt, data);
                 _set_parameters_session_info(sfstmt->connection, data);
-                qcc_deserialize(sfstmt->connection, snowflake_cJSON_GetObjectItem(data, QCC_RSP_KEY));
+                qcc_deserialize(sfstmt->connection, snowflake_cJSON_GetObjectItem(data, SF_QCC_RSP_KEY));
                 _mutex_unlock(&sfstmt->connection->mutex_parameters);
                 int64 stmt_type_id;
                 if (json_copy_int(&stmt_type_id, data, "statementTypeId")) {

--- a/lib/query_context_cache.h
+++ b/lib/query_context_cache.h
@@ -8,16 +8,6 @@
 #include "snowflake/client.h"
 #include "cJSON.h"
 
-#define QCC_CAPACITY_DEF        5
-#define QCC_RSP_KEY             "queryContext"
-#define QCC_REQ_KEY             "queryContextDTO"
-#define QCC_ENTRIES_KEY         "entries"
-#define QCC_ID_KEY              "id"
-#define QCC_PRIORITY_KEY        "priority"
-#define QCC_TIMESTAMP_KEY       "timestamp"
-#define QCC_CONTEXT_KEY         "context"
-#define QCC_CONTEXT_VALUE_KEY   "base64Data"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tests/test_unit_query_context_cache.cpp
+++ b/tests/test_unit_query_context_cache.cpp
@@ -3,7 +3,7 @@
  */
 
 #include <string>
-#include "./lib/QueryContextCache.hpp"
+#include "./lib/ClientQueryContextCache.hpp"
 #include "utils/test_setup.h"
 #include "utils/TestSetup.hpp"
 
@@ -19,7 +19,7 @@ static const uint64 BASE_PRIORITY = 0;
 class QueryContextCacheTestHelper
 {
 public:
-  Snowflake::Client::QueryContextCache qcc;
+  Snowflake::Client::ClientQueryContextCache qcc;
   std::vector<uint64> expectedIDs;
   std::vector<uint64> expectedReadTimestamp;
   std::vector<uint64> expectedPriority;


### PR DESCRIPTION
sdk issue 643
Make the QCC implementation reusable.
To reuse the implementation in ODBC, similar as what's been done in ClientQueryContextCache, make a subclass of QueryContextCache and use picojson instead of cJSON.