### PR TITLE
SNOW-937196: make correction on arrow version for uploading

### DIFF
--- a/scripts/build_arrow.bat
+++ b/scripts/build_arrow.bat
@@ -5,14 +5,14 @@
 set arrow_src_version=0.17.1
 set arrow_build_version=2
 :: The full version number for dependency packaging/uploading/downloading
-set arrow_version=%arrow_src_version%.%arrow_build_version%
+:: SNOW-937196: temporarily disable building arrow from source to revert to pre-build arrow on Windows and Linux x86
+:: set arrow_version=%arrow_src_version%.%arrow_build_version%
+set arrow_version=%arrow_src_version%
 call %*
 goto :EOF
 
 :get_version
-:: SNOW-937196: temporarily disable building arrow from source to revert to pre-build arrow on Windows and Linux x86
-::    set version=%arrow_version%
-    set version=0.17.1
+    set version=%arrow_version%
     goto :EOF
 
 :build


### PR DESCRIPTION
Fix the arrow version for artifacts uploading since the package on S3 for debug version seems broken and we need to re-upload.
