### PR TITLE
SNOW-983100: libsnowflakeclient - banned functions in ODBC v3.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ set(SOURCE_FILES_CPP_WRAPPER
         include/snowflake/Param.hpp
         include/snowflake/Exceptions.hpp
         include/snowflake/jwtWrapper.h
+        include/snowflake/Util.hpp
         cpp/lib/Exceptions.cpp
         cpp/lib/Connection.cpp
         cpp/lib/Statement.cpp

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -20,6 +20,7 @@
 #include "logger/SFLogger.hpp"
 #include "snowflake/platform.h"
 #include "snowflake/Simba_CRTFunctionSafe.h"
+#include "snowflake/Util.hpp"
 #include <chrono>
 #ifdef _WIN32
 #include <windows.h>
@@ -847,20 +848,18 @@ RemoteStorageRequestOutcome Snowflake::Client::FileTransferAgent::downloadSingle
      }
      catch (...) {
        std::string err = "Could not open file " + fileMetadata->destPath + " to downoad";
-       char* str_error = sf_strerror(errno);
+       cbuf_t str_error(sf_strerror(errno));
        CXX_LOG_DEBUG("Could not open file %s to downoad: %s",
-                     fileMetadata->destPath.c_str(), str_error);
-       sf_free_s(str_error);
+                     fileMetadata->destPath.c_str(), (char*)str_error);
        m_executionResults->SetTransferOutCome(outcome, resultIndex);
        break;
      }
      if (!dstFile.is_open())
      {
        std::string err = "Could not open file " + fileMetadata->destPath + " to downoad";
-       char* str_error = sf_strerror(errno);
+       cbuf_t str_error(sf_strerror(errno));
        CXX_LOG_DEBUG("Could not open file %s to downoad: %s",
-                     fileMetadata->destPath.c_str(), str_error);
-       sf_free_s(str_error);
+                     fileMetadata->destPath.c_str(), (char*)str_error);
        m_executionResults->SetTransferOutCome(outcome, resultIndex);
        break;
      }

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "snowflake/Simba_CRTFunctionSafe.h"
+#include "snowflake/Util.hpp"
 #include "SnowflakeAzureClient.hpp"
 #include "FileMetadataInitializer.hpp"
 #include "snowflake/client.h"
@@ -61,17 +62,15 @@ SnowflakeAzureClient::SnowflakeAzureClient(StageInfo *stageInfo,
       CXX_LOG_TRACE("ca bundle file from SF_GLOBAL_CA_BUNDLE_FILE *%s*", caBundleFile);
   }
   if( caBundleFile[0] == 0 ) {
-      char* capath = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+      cbuf_t capath(sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE"));
       if (capath) {
           if (strlen(capath) > MAX_PATH - 1) {
-              sf_free_s(capath);
               throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,
                   "CA bundle file path too long.");
           }
           if (!sb_strcpy(caBundleFile, (size_t)MAX_PATH, capath)) {
               caBundleFile[0] = 0;
           }
-          sf_free_s(capath);
           CXX_LOG_TRACE("ca bundle file from SNOWFLAKE_TEST_CA_BUNDLE_FILE *%s*", caBundleFile);
       }
   }

--- a/cpp/util/Proxy.cpp
+++ b/cpp/util/Proxy.cpp
@@ -5,18 +5,7 @@
 #include "snowflake/Proxy.hpp"
 #include "snowflake/Simba_CRTFunctionSafe.h"
 #include "snowflake/platform.h"
-
-namespace {
-    char* get_env_or(const char* name) {
-        return sf_getenv(name);
-    }
-    template <typename... Args>
-    char* get_env_or(const char* prime, Args... fallback)
-    {
-        char* value = get_env_or(prime);
-        return value ? value : get_env_or(fallback...);
-    }
-}
+#include "snowflake/Util.hpp"
 
 Snowflake::Client::Util::Proxy::Proxy(const std::string &proxy_str)
 {
@@ -82,18 +71,15 @@ void Snowflake::Client::Util::Proxy::clearPwd() {
 }
 
 void Snowflake::Client::Util::Proxy::setProxyFromEnv() {
-    char* env_value = get_env_or("all_proxy", "https_proxy", "http_proxy");
-    if (env_value != nullptr) {
-        std::string proxy(env_value);
-        sf_free_s(env_value);
-        stringToProxyParts(proxy);
+    cbuf_t proxy_value(sf_getenv_or("all_proxy", "https_proxy", "http_proxy"));
+    if (proxy_value) {
+        stringToProxyParts(std::string(proxy_value));
     }
 
     // Get noproxy string
-    env_value = get_env_or("no_proxy", "NO_PROXY");
-    if (env_value != nullptr) {
-        m_noProxy = env_value;
-        sf_free_s(env_value);
+    cbuf_t noproxy_value = sf_getenv_or("no_proxy", "NO_PROXY");
+    if (noproxy_value) {
+        m_noProxy = (const char*) noproxy_value;
     }
 }
 

--- a/cpp/util/ThreadPool.hpp
+++ b/cpp/util/ThreadPool.hpp
@@ -11,6 +11,8 @@
 #include <pthread.h>
 #endif
 
+#include <cstdlib>
+
 #include <vector>
 #include <deque>
 #include <functional>
@@ -155,7 +157,9 @@ public:
     int err = pthread_key_create(&key, NULL);
     if (err)
     {
-      CXX_LOG_ERROR("Thread pool creating key failed with error: %s", strerror(err));
+      char* str_err = sf_strerror(err);
+      CXX_LOG_ERROR("Thread pool creating key failed with error: %s", str_err);
+      free(str_err);
       throw SnowflakeTransferException(TransferError::INTERNAL_ERROR,
                                        "Thread context fail to initialize");
     }

--- a/include/snowflake/Simba_CRTFunctionSafe.h
+++ b/include/snowflake/Simba_CRTFunctionSafe.h
@@ -30,13 +30,6 @@ extern "C" {
     #endif
 #endif
 
-extern char* STDCALL sf_getenv(const char *name);
-extern char* STDCALL sf_strerror(int);
-
-#if defined(WIN32) || defined(_WIN64)   // For Windows
-
-    #define sf_free_s(x)        free(x)
-
     /// @brief Copy a string.
     /// 
     /// @param out_dest         Destination string buffer. (NOT OWN)
@@ -49,11 +42,23 @@ extern char* STDCALL sf_strerror(int);
         size_t in_destSize,
         const char* in_src)
     {
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         if (0 == strcpy_s(out_dest, in_destSize, in_src))
         {
             return out_dest;
         }
         return NULL;
+    #else
+        if (out_dest == NULL || in_src == NULL || out_dest == in_src || in_destSize == 0)
+            return NULL;                    // quick checks
+        size_t ncopy = 0;
+        for (; ncopy < in_destSize && in_src[ncopy]; ++ncopy) ;
+        if (ncopy == in_destSize)
+            return NULL;                    // truncation would occur
+        if (out_dest < in_src && out_dest + ncopy + 1 >= in_src || out_dest > in_src && in_src + ncopy + 1 >= out_dest)
+            return NULL;                    // overlap would occur
+        return strcpy(out_dest, in_src);
+    #endif
     }
 
     /// @brief Copy characters of one string to another.
@@ -70,11 +75,23 @@ extern char* STDCALL sf_strerror(int);
         const char* in_src,
         size_t in_sizeToCopy)
     {
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         if (0 == strncpy_s(out_dest, in_destSize, in_src, in_sizeToCopy))
         {
             return out_dest;
         }
         return NULL;
+    #else
+        if (out_dest == NULL || in_src == NULL || out_dest == in_src || in_destSize == 0)
+            return NULL;                    // quick checks
+        size_t ncopy = 0;
+        for (; ncopy < in_destSize && ncopy < in_sizeToCopy && in_src[ncopy]; ++ncopy) ;
+        if (ncopy == in_destSize)
+            return NULL;                    // truncation would occur
+        if (out_dest < in_src && out_dest + ncopy + 1 >= in_src || out_dest > in_src && in_src + ncopy + 1 >= out_dest)
+            return NULL;                    // overlap would occur
+        return strncpy(out_dest, in_src, ncopy);
+    #endif
     }
 
     /// @brief Append to a string.
@@ -89,11 +106,29 @@ extern char* STDCALL sf_strerror(int);
         size_t in_destSize,
         const char* in_src)
     {
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         if (0 == strcat_s(out_dest, in_destSize, in_src))
         {
             return out_dest;
         }
         return NULL;
+    #else
+        if (out_dest == NULL || in_src == NULL || out_dest == in_src || in_destSize == 0)
+            return NULL;                // quick checks
+        size_t ndst = 0;
+        char* pdst = out_dest;
+        for (; ndst < in_destSize && *pdst; ++ndst, ++pdst) ;
+        if (ndst == in_destSize) return NULL;       // there's no null in the first destSize of dest
+        // now pdst points to the next of dest tail
+        size_t max_cat = in_destSize - ndst;
+        size_t ncat = 0;
+        for (; ncat < max_cat && in_src[ncat]; ++ncat) ;
+        if (ncat == max_cat) return NULL;           // truncation would occur
+        if (pdst < in_src && pdst + ncat + 1 >= in_src || pdst > in_src && in_src + ncat >= pdst)
+            return NULL;                            // overlap would occur
+        strcpy(pdst, in_src);
+        return out_dest;
+    #endif
     }
 
     /// @brief Append characters of one string to another.
@@ -110,11 +145,30 @@ extern char* STDCALL sf_strerror(int);
         const char* in_src,
         size_t in_sizeToCopy)
     {
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         if (0 == strncat_s(out_dest, in_destSize, in_src, in_sizeToCopy))
         {
             return out_dest;
         }
         return NULL;
+    #else
+        if (out_dest == NULL || in_src == NULL || out_dest == in_src || in_destSize == 0)
+            return NULL;                            // quick checks
+        size_t ndst = 0;
+        char* pdst = out_dest;
+        for (; ndst < in_destSize && *pdst; ++ndst, ++pdst) ;
+        if (ndst == in_destSize) return NULL;       // there's no null in the first destSize of dest
+        // now pdst points to the next of dest tail
+        size_t max_cat = in_destSize - ndst;
+        size_t ncat = 0;
+        // find out how much actually concated, truncation is allowed
+        for (; ncat < max_cat && ncat < in_sizeToCopy && in_src[ncat]; ++ncat) ;
+        if (ncat == max_cat) return NULL;           // truncation would occur
+        if (pdst < in_src && pdst + ncat + 1 >= in_src || pdst > in_src && in_src + ncat >= pdst)
+            return NULL;                            // overlap would occur
+        strcpy(pdst, in_src);
+        return out_dest;
+    #endif
     }
 
     /// @brief Copy bytes between buffers. 
@@ -131,11 +185,19 @@ extern char* STDCALL sf_strerror(int);
         const void* in_src,
         size_t in_sizeToCopy)
     {
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         if (0 == memcpy_s(out_dest, in_destSize, in_src, in_sizeToCopy))
         {
             return out_dest;
         }
         return NULL;
+    #else
+        if (out_dest == NULL || in_src == NULL || out_dest == in_src || in_destSize < in_sizeToCopy)
+            return NULL;            // quick checks
+        if (out_dest < in_src && (char*)out_dest + in_sizeToCopy > (char*) in_src || out_dest > in_src && (char*)in_src + in_sizeToCopy >= (char*) out_dest)
+            return NULL;                            // overlap would occur
+        return memcpy(out_dest, in_src, in_sizeToCopy);
+    #endif
     }
 
     /// @brief Write formatted output using a pointer to a list of arguments.
@@ -159,9 +221,24 @@ extern char* STDCALL sf_strerror(int);
         const char* in_format,
         va_list in_argPtr)
     {
+        // vsnprintf takes the size including terminating null while in_sizeToWrite does not
+        // include terminating null.
         if (in_sizeToWrite >= in_sizeOfBuffer) return -1;
 
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         return _vsnprintf_s(out_buffer, in_sizeOfBuffer, _TRUNCATE, in_format, in_argPtr);
+    #else
+        if (out_buffer == NULL || in_format == NULL || in_sizeOfBuffer == 0)
+            return -1;      // quick checks
+        // for now skip checks such as
+        //   %n, %s
+        //   encoding checks
+        //   buffer exceed
+        int ret = vsnprintf(out_buffer, in_sizeToWrite + 1, in_format, in_argPtr);
+        if ((ret < 0) || ((size_t)ret > in_sizeToWrite)) return -1;
+
+        return ret;
+    #endif
     }
 
     /// @brief Write formatted data to a string. 
@@ -185,7 +262,6 @@ extern char* STDCALL sf_strerror(int);
         va_start(formatParams, in_format);
         int bytesWritten = sb_vsnprintf(out_buffer, in_sizeOfBuffer, in_sizeOfBuffer - 1, in_format, formatParams);
         va_end(formatParams);
-
         return bytesWritten;
     }
 
@@ -207,7 +283,12 @@ extern char* STDCALL sf_strerror(int);
     {
         va_list formatParams;
         va_start(formatParams, in_format);
+
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         int ret = vsscanf_s(in_buffer, in_format, formatParams);
+    #else
+        int ret = vsscanf(in_buffer, in_format, formatParams);
+    #endif
         va_end(formatParams);
 
         return ret;
@@ -223,9 +304,14 @@ extern char* STDCALL sf_strerror(int);
     {
         va_list vlist;
         va_start(vlist, in_format);
-        int bytesWritten = vfprintf_s(in_stream, in_format, vlist);
-        va_end(vlist);
 
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
+        int bytesWritten = vfprintf_s(in_stream, in_format, vlist);
+    #else
+        int bytesWritten = vfprintf(in_stream, in_format, vlist);
+    #endif
+
+        va_end(vlist);
         return bytesWritten;
     }
 
@@ -239,164 +325,15 @@ extern char* STDCALL sf_strerror(int);
     {
         va_list vlist;
         va_start(vlist, in_format);
+
+    #if defined(_WIN32) || defined(WIN32) || defined(_WIN64)   // For Windows
         int bytesWritten = vfprintf_s(stdout, in_format, vlist);
-        va_end(vlist);
+    #else
+        int bytesWritten = vfprintf(stdout, in_format, vlist);
+    #endif
 
-        return bytesWritten;
     }
 
-
-    #define sb_getenv sf_getenv
-    #define sb_strerror sf_strerror
-
-
-#else   // For all other platforms except Windows
-
-    #define sf_free_s(x)
-
-    /// @brief Copy a string.
-    /// 
-    /// @param out_dest         Destination string buffer. (NOT OWN)
-    /// @param in_destSize      Size of the destination string buffer.
-    /// @param in_src           Null-terminated source string buffer. (NOT OWN)
-    /// 
-    /// @return The destination string; NULL if an error occurred. (NOT OWN)
-    static inline char* sb_strcpy(
-        char* out_dest,
-        size_t in_destSize,
-        const char* in_src)
-    {
-        return strcpy(out_dest, in_src);
-    }
-
-    /// @brief Copy characters of one string to another.
-    ///
-    /// @param out_dest         Destination string. (NOT OWN)
-    /// @param in_destSize      The size of the destination string, in characters. 
-    /// @param in_src           Source string. (NOT OWN)
-    /// @param in_sizeToCopy    Number of characters to be copied.
-    /// 
-    /// @return The destination string; NULL if a truncation or error occurred. (NOT OWN)
-    static inline char* sb_strncpy(
-        char* out_dest,
-        size_t in_destSize,
-        const char* in_src,
-        size_t in_sizeToCopy)
-    {
-        return strncpy(out_dest, in_src, in_sizeToCopy);
-    }
-
-    /// @brief Append to a string.
-    /// 
-    /// @param out_dest         Destination string to append to. (NOT OWN)
-    /// @param in_destSize      Size of the destination string buffer.
-    /// @param in_src           Null-terminated source string buffer. (NOT OWN)
-    /// 
-    /// @return The destination string; NULL if an error occurred. (NOT OWN)
-    static inline char* sb_strcat(
-        char* out_dest,
-        size_t in_destSize,
-        const char* in_src)
-    {
-        return strcat(out_dest, in_src);
-    }
-
-    /// @brief Append characters of one string to another.
-    ///
-    /// @param out_dest         Destination string to append to. (NOT OWN)
-    /// @param in_destSize      The size of the destination string buffer, in characters. 
-    /// @param in_src           Source string. (NOT OWN)
-    /// @param in_sizeToCopy    Number of characters to be copied.
-    /// 
-    /// @return The destination string; NULL if a truncation or error occurred. (NOT OWN)
-    static inline char* sb_strncat(
-        char* out_dest,
-        size_t in_destSize,
-        const char* in_src,
-        size_t in_sizeToCopy)
-    {
-        return strncat(out_dest, in_src, in_sizeToCopy);
-    }
-
-    /// @brief Copy bytes between buffers. 
-    /// 
-    /// @param out_dest         Destination buffer. (NOT OWN)
-    /// @param in_destSize      Size of the destination buffer. 
-    /// @param in_src           Buffer to copy from. (NOT OWN)
-    /// @param in_sizeToCopy    Number of bytes to copy.
-    /// 
-    /// @return A pointer to destination; NULL if an error occurred. (NOT OWN)
-    static inline void* sb_memcpy(
-        void* out_dest,
-        size_t in_destSize,
-        const void* in_src,
-        size_t in_sizeToCopy)
-    {
-        return memcpy(out_dest, in_src, in_sizeToCopy);
-    }
-
-    /// @brief Write formatted output using a pointer to a list of arguments.
-    /// 
-    /// Note: To ensure that there is room for the terminating null, be sure that in_sizeToWrite is 
-    /// strictly less than in_sizeOfBuffer.
-    /// 
-    /// @param out_buffer       Storage location for output. (NOT OWN)
-    /// @param in_sizeOfBuffer  Size of buffer in characters. 
-    /// @param in_sizeToWrite   Maximum number of characters to write (not including the 
-    ///                         terminating null).
-    /// @param in_format        Format control string. (NOT OWN)
-    /// @param in_argPtr        Pointer to list of arguments.
-    /// 
-    /// @return The number of bytes written to the buffer, not counting the terminating null 
-    /// character; -1 if the truncation or error occurred.
-    static inline int sb_vsnprintf(
-        char* out_buffer,
-        size_t in_sizeOfBuffer,
-        size_t in_sizeToWrite,
-        const char* in_format,
-        va_list in_argPtr)
-    {
-        // vsnprintf takes the size including terminating null while in_sizeToWrite does not
-        // include terminating null.
-        if (in_sizeToWrite >= in_sizeOfBuffer) return -1;
-
-        int ret = vsnprintf(out_buffer, in_sizeToWrite + 1, in_format, in_argPtr);
-        if ((ret < 0) || ((size_t)ret > in_sizeToWrite)) return -1;
-
-        return ret;
-    }
-
-    /// @brief Write formatted data to a string. 
-    /// 
-    /// @param out_buffer       Storage location for output. (NOT OWN)
-    /// @param in_sizeOfBuffer  Size of buffer in characters. 
-    /// @param in_format        Format control string. (NOT OWN)
-    /// @param ...	            Optional arguments for printf style conversions.
-    /// 
-    /// @return The number of bytes written to the buffer, not counting the terminating null 
-    /// character; -1 if an error occurred.
-    static inline int sb_sprintf(
-        char* out_buffer,
-        size_t in_sizeOfBuffer,
-        const char* in_format,
-        ...)
-    {
-        va_list formatParams;
-        va_start(formatParams, in_format);
-        int bytesWritten = sb_vsnprintf(out_buffer, in_sizeOfBuffer, in_sizeOfBuffer - 1, in_format, formatParams);
-        va_end(formatParams);
-
-        return bytesWritten;
-    }
-
-#define sb_sscanf sscanf
-#define sb_fprintf fprintf
-#define sb_printf printf
-#define sb_strerror strerror
-
-#define sb_getenv getenv
-
-#endif
 
     /// @brief Open a file.
     /// 
@@ -412,11 +349,10 @@ extern char* STDCALL sf_strerror(int);
         // to simulate fopen, *out_file is guaranteed to be set, fopen_s don't change out_file on error
         return fopen_s(out_file, in_filename, in_mode) ? (*out_file = NULL) : *out_file;
 #else
+        // posix systems don't have issues of fopen on Windows
         return *out_file = fopen(in_filename, in_mode);
 #endif
     }
-
-#define sb_free_s       sf_free_s
 
 
 #ifdef __cplusplus

--- a/include/snowflake/Util.hpp
+++ b/include/snowflake/Util.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018-2024 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#ifndef SNOWFLAKE_UTIL_H
+#define SNOWFLAKE_UTIL_H
+
+#include "snowflake/platform.h"
+
+// a smart pointer that free memory allocated by stdlib (malloc/calloc/realloc)
+template <typename T=char>
+class basic_cbuf_t {
+public:
+    basic_cbuf_t(T* p) : p_(p) {}
+    ~basic_cbuf_t() { if (p_) free(p_); }
+    T* value() { return p_; }
+    operator T* () { return p_; }
+    operator const T* () { return p_; }
+    operator bool () { return p_ != NULL; }
+private:
+    T* p_;
+};
+typedef basic_cbuf_t<char> cbuf_t;
+
+// try to get alternative environment variables
+template <typename T=char>
+T* sf_getenv_or(const char* name) {
+    return sf_getenv(name);
+}
+template <typename T=char, typename... Args>
+T* sf_getenv_or(const char* prime, Args... fallback)
+{
+    T* value = sf_getenv_or<T>(prime);
+    return value ? value : sf_getenv_or<T>(fallback...);
+}
+
+#endif

--- a/include/snowflake/platform.h
+++ b/include/snowflake/platform.h
@@ -63,14 +63,8 @@ int STDCALL sf_unsetenv(const char *name);
 
 int STDCALL sf_mkdir(const char *path);
 
-/* on Windows, this function allocate new memory, caller should free it */
+/* this function allocate new memory, caller should free it */
 char* STDCALL sf_strerror(int errnum);
-
-#ifdef _WIN32
-#define sf_free_s(x)       free(x)
-#else
-#define sf_free_s(x)
-#endif
 
 int STDCALL
 _thread_init(SF_THREAD_HANDLE *thread, void *(*proc)(void *), void *arg);
@@ -143,6 +137,10 @@ void STDCALL sf_get_uniq_tmp_dir(char * tmpDir);
 void STDCALL sf_get_username(char * username, int bufLen);
 
 void STDCALL sf_delete_uniq_dir_if_exists(const char *tmpfile);
+
+void STDCALL sf_platform_init();
+void STDCALL sf_platform_term();
+
 
 #ifdef __cplusplus
 }

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -151,7 +151,7 @@ log_log_va_list(int level, const char *file, int line, const char *ns,
             sb_fprintf(stderr,
                 "Error opening file from file path: %s\nError code: %s\n",
                 L.path, str_error);
-            sf_free_s(str_error);
+            free(str_error);
             L.path = NULL;
         }
     }

--- a/tests/test_connect.c
+++ b/tests/test_connect.c
@@ -3,6 +3,7 @@
 //
 
 #include "utils/test_setup.h"
+#include "snowflake/Util.hpp"
 
 /**
  * Test connection with null context
@@ -194,12 +195,9 @@ void test_connect_with_ocsp_cache_server_on(void **unused) {
 * in parameter are being used.
 */
 void test_connect_with_proxy(void **unused) {
-  if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-    sf_getenv("http_proxy"))
-  {
-    // skip the test if the test evironment uses proxy already
-    return;
-  }
+  cbuf_t proxy_value(sf_getenv_or("all_proxy", "https_proxy", "http_proxy"));
+  if (proxy_value)
+    return;    // skip the test if the test evironment uses proxy already
 
   // set invalid proxy in environment variables
   sf_setenv("https_proxy", "a.b.c");

--- a/tests/test_simple_put.cpp
+++ b/tests/test_simple_put.cpp
@@ -14,6 +14,8 @@
 #include "StatementPutGet.hpp"
 #include "FileTransferAgent.hpp"
 #include "boost/filesystem.hpp"
+#include "snowflake/Util.hpp"
+
 
 #define COLUMN_STATUS "STATUS"
 #define COLUMN_SOURCE "SOURCE"
@@ -32,7 +34,7 @@ using namespace boost::filesystem;
 
 // use encoding directly instead of actual character to avoid
 // build issue with encoding on different platforms
-// it's character é which is 0xe9 in Windows-1252 and 0xc3 0xa9 in UTF-8
+// it's character ï¿½ which is 0xe9 in Windows-1252 and 0xc3 0xa9 in UTF-8
 // On windows the default encoding is Windows-1252 on Linux/Mac it's UTF-8
 #ifdef _WIN32
 static std::string PLATFORM_STR = "\xe9";
@@ -1260,13 +1262,17 @@ void test_2GBlarge_get(void **unused)
   test_simple_get_data(getcmd.c_str(), std::to_string(FILE_SIZE_2GB).c_str());
 }
 
+// check if the test environment uses proxy already
+// many tests skip in this case
+static bool is_use_proxy()
+{
+    cbuf_t proxy_value(sf_getenv_or("all_proxy", "https_proxy", "http_proxy"));
+    return (proxy_value) ? true : false;
+}
+
 void test_simple_put_with_proxy(void **unused)
 {
-  if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-    sf_getenv("http_proxy")) {
-    // skip the test if the test environment uses proxy already
-    return;
-  }
+  if (is_use_proxy()) return;
 
   // set invalid proxy in environment variables
   sf_setenv("https_proxy", "a.b.c");
@@ -1306,11 +1312,7 @@ void test_simple_put_with_proxy(void **unused)
 
 void test_simple_put_with_noproxy(void **unused)
 {
-  if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-    sf_getenv("http_proxy")) {
-    // skip the test if the test evironment uses proxy already
-    return;
-  }
+  if (is_use_proxy()) return;
 
   // set invalid proxy in environment variables
   sf_setenv("https_proxy", "a.b.c");
@@ -1351,11 +1353,7 @@ void test_simple_put_with_noproxy(void **unused)
 
 void test_simple_put_with_proxy_fromenv(void **unused)
 {
-    if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-        sf_getenv("http_proxy")) {
-        // skip the test if the test environment uses proxy already
-        return;
-    }
+  if (is_use_proxy()) return;
 
     // set invalid proxy settings
     sf_setenv("https_proxy", "a.b.c");
@@ -1402,11 +1400,7 @@ void test_simple_put_with_proxy_fromenv(void **unused)
 
 void test_simple_put_with_noproxy_fromenv(void **unused)
 {
-    if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-        sf_getenv("http_proxy")) {
-        // skip the test if the test environment uses proxy already
-        return;
-    }
+  if (is_use_proxy()) return;
 
     // set invalid proxy settings
     sf_setenv("https_proxy", "a.b.c");

--- a/tests/test_unit_azure_client.cpp
+++ b/tests/test_unit_azure_client.cpp
@@ -16,6 +16,8 @@
 #include "StorageClientFactory.hpp"
 #include "utils/test_setup.h"
 #include "utils/TestSetup.hpp"
+#include "snowflake/Util.hpp"
+
 
 using namespace ::Snowflake::Client;
 
@@ -179,7 +181,7 @@ void test_azure_empty_cafile_noenv(void ** unused)
     transferConfig.caBundleFile = cafile;
 
     // Modify the environment variable temporarily and restore at the end of test
-    const char* currentCABundleFile = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+    cbuf_t currentCABundleFile(sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE"));
     if (currentCABundleFile)
     {
         hasCAfileEnvChanged = true;
@@ -215,7 +217,7 @@ void test_azure_empty_cafile_from_env(void ** unused)
     transferConfig.caBundleFile = cafile;
 
     // Modify the environment variable temporarily and restore at the end of test
-    const char* currentCABundleFile = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+    cbuf_t currentCABundleFile(sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE"));
     sf_setenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE", "/tmp/cafile/p1.pem");
     hasCAfileEnvChanged = true;
 
@@ -248,7 +250,7 @@ void test_azure_empty_cafile_from_global_env(void ** unused)
     transferConfig.caBundleFile = cafile;
 
     // Modify the environment variable temporarily and restore at the end of test
-    const char* currentCABundleFile = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+    cbuf_t currentCABundleFile(sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE"));
     if (currentCABundleFile)
     {
         hasCAfileEnvChanged = true;
@@ -281,7 +283,7 @@ void test_azure_cafile_path_too_long_from_env_transferconfig_null(void ** unused
     std::string cafile(MAX_PATH, 'a');
 
     // Modify the environment variable temporarily and restore at the end of test
-    const char* currentCABundleFile = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+    cbuf_t currentCABundleFile(sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE"));
     sf_setenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE", cafile.c_str());
     hasCAfileEnvChanged = true;
 
@@ -314,7 +316,7 @@ void test_azure_cafile_path_too_long_from_global_env_transferconfig_null(void **
     std::string cafile(MAX_PATH, 'a');
 
     // Modify the environment variable temporarily and restore at the end of test
-    const char* currentCABundleFile = sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+    cbuf_t currentCABundleFile(sf_getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE"));
     if (currentCABundleFile)
     {
         hasCAfileEnvChanged = true;

--- a/tests/test_unit_proxy.cpp
+++ b/tests/test_unit_proxy.cpp
@@ -6,6 +6,8 @@
 #include "snowflake/Proxy.hpp"
 #include "utils/test_setup.h"
 #include "utils/TestSetup.hpp"
+#include "snowflake/Util.hpp"
+
 
 typedef ::Snowflake::Client::Util::Proxy Proxy;
 
@@ -64,13 +66,17 @@ void test_proxy_empty(void **unused)
     test_proxy_parts_equality("", "", "", "", 0, Proxy::Protocol::NONE, "", false);
 }
 
+// check if the test environment uses proxy already
+// many tests skip in this case
+static bool is_use_proxy()
+{
+    cbuf_t proxy_value(sf_getenv_or("all_proxy", "https_proxy", "http_proxy"));
+    return (proxy_value) ? true : false;
+}
+
 void test_allproxy_noproxy_fromenv(void **unused)
 {
-    if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-        sf_getenv("http_proxy")) {
-        // skip the test if the test environment uses proxy already
-        return;
-    }
+    if (is_use_proxy()) return;
 
     sf_setenv("all_proxy", "https://someuser:somepwd@somewhere.com:5050");
     sf_setenv("no_proxy", "proxyserver.com");
@@ -81,11 +87,7 @@ void test_allproxy_noproxy_fromenv(void **unused)
 
 void test_httpsproxy_fromenv(void **unused)
 {
-    if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-        sf_getenv("http_proxy")) {
-        // skip the test if the test environment uses proxy already
-        return;
-    }
+    if (is_use_proxy()) return;
 
     sf_setenv("https_proxy", "https://someuser:somepwd@somewhere.com:5050");
     test_proxy_parts_equality("", "someuser", "somepwd", "somewhere.com", 5050, Proxy::Protocol::HTTPS, "", true);
@@ -94,11 +96,7 @@ void test_httpsproxy_fromenv(void **unused)
 
 void test_httpproxy_fromenv(void **unused)
 {
-    if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-        sf_getenv("http_proxy")) {
-        // skip the test if the test environment uses proxy already
-        return;
-    }
+    if (is_use_proxy()) return;
 
     sf_setenv("http_proxy", "http://username:password@proxyserver.company.com:80");
     test_proxy_parts_equality("", "username", "password", "proxyserver.company.com", 80, Proxy::Protocol::HTTP, "", true);
@@ -107,11 +105,7 @@ void test_httpproxy_fromenv(void **unused)
 
 void test_noproxy_fromenv(void **unused)
 {
-    if (sf_getenv("all_proxy") || sf_getenv("https_proxy") ||
-        sf_getenv("http_proxy")) {
-        // skip the test if the test environment uses proxy already
-        return;
-    }
+    if (is_use_proxy()) return;
 
     sf_setenv("NO_PROXY", "proxyserver.company.com");
     test_proxy_parts_equality("", "", "", "", 0, Proxy::Protocol::NONE, "proxyserver.company.com", true);


### PR DESCRIPTION
1. replace strerror with strerror_r on Posix (with strerror_s on Windows already)
2. enhance getenv
    2.1. thread safe in driver
    2.2. allow reentrance with cloned value returned
3. strcpy/strncpy/strcat/strncat, implement bounds check according to spec of "secured" version
4. related updates
    4.1. consistent API of sf_getenv and sf_strerror on all platforms
    4.2. fix some memory leaks
    4.3. relevant unit tests updates