### PR TITLE
SNOW-1526802: sf_getenv_s on Windows with variable not set

### DIFF
--- a/lib/platform.c
+++ b/lib/platform.c
@@ -270,8 +270,10 @@ int STDCALL sf_setenv(const char *name, const char *value) {
 
 char * STDCALL sf_getenv_s(const char *name, char *outbuf, size_t bufsize) {
 #ifdef _WIN32
-    size_t len;
-    return getenv_s(&len, outbuf, bufsize, name) ? NULL : outbuf;
+    size_t len = 0;
+    // SNOW-1526802 on Windows environment variable can't be set to empty
+    // and getenv_s returns 0 with length of 0 for environment variables not being set
+    return getenv_s(&len, outbuf, bufsize, name) || (len == 0) ? NULL : outbuf;
 #else
     char* envval = getenv(name);
     if (!envval)

--- a/tests/test_unit_proxy.cpp
+++ b/tests/test_unit_proxy.cpp
@@ -66,8 +66,6 @@ void test_proxy_empty(void **unused)
 
 void test_allproxy_noproxy_fromenv(void **unused)
 {
-    SKIP_IF_PROXY_ENV_IS_SET;
-
     sf_setenv("all_proxy", "https://someuser:somepwd@somewhere.com:5050");
     sf_setenv("no_proxy", "proxyserver.com");
     test_proxy_parts_equality("", "someuser", "somepwd", "somewhere.com", 5050, Proxy::Protocol::HTTPS, "proxyserver.com", true);
@@ -77,8 +75,6 @@ void test_allproxy_noproxy_fromenv(void **unused)
 
 void test_httpsproxy_fromenv(void **unused)
 {
-    SKIP_IF_PROXY_ENV_IS_SET;
-
     sf_setenv("https_proxy", "https://someuser:somepwd@somewhere.com:5050");
     test_proxy_parts_equality("", "someuser", "somepwd", "somewhere.com", 5050, Proxy::Protocol::HTTPS, "", true);
     sf_unsetenv("https_proxy");
@@ -86,8 +82,6 @@ void test_httpsproxy_fromenv(void **unused)
 
 void test_httpproxy_fromenv(void **unused)
 {
-    SKIP_IF_PROXY_ENV_IS_SET;
-
     sf_setenv("http_proxy", "http://username:password@proxyserver.company.com:80");
     test_proxy_parts_equality("", "username", "password", "proxyserver.company.com", 80, Proxy::Protocol::HTTP, "", true);
     sf_unsetenv("http_proxy");
@@ -95,8 +89,6 @@ void test_httpproxy_fromenv(void **unused)
 
 void test_noproxy_fromenv(void **unused)
 {
-    SKIP_IF_PROXY_ENV_IS_SET;
-
     sf_setenv("NO_PROXY", "proxyserver.company.com");
     test_proxy_parts_equality("", "", "", "", 0, Proxy::Protocol::NONE, "proxyserver.company.com", true);
     sf_unsetenv("NO_PROXY");


### PR DESCRIPTION
getenv_s() returns 0 (success) for variables not set.
remove skip condition in test case to ensure the test case never be skipped unexpectedly.