### PR TITLE
SNOW-1795105 fix permissions for create-issue

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   create-issue:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: ((github.event_name == 'issue_comment' && github.event.comment.body == 'recreate jira' && github.event.comment.user.login == 'sfc-gh-mkeller') || (github.event_name == 'issues' && github.event.pull_request.user.login != 'whitesource-for-github-com[bot]'))
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
There is no code change here, just GH Action is modified.

`create-issue` GH Action fails, after creating the Jira ticket, it is not able to update the autogenerated Jira id back into the GH Issue's title:
```
fatal     HttpError: Resource not accessible by integration
```

Looks to be the same as `SNOW-1334777` so applying the same solution. 