### PR TITLE
SNOW-1825584: Cache deps to speed up the builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,11 +21,25 @@ jobs:
                 cloud_provider: [ 'AWS', 'AZURE', 'GCP' ]
         steps:
             - uses: actions/checkout@v1
+            - name: Restore cached deps
+              id: cache-restore-deps
+              uses: actions/cache/restore@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Linux-dep-cache
+              if: github.event_name == 'pull_request'
             - name: Build
               shell: bash
               env:
                   BUILD_TYPE: ${{ matrix.build_type }}
               run: ci/build_linux.sh
+            - name: Cache deps
+              id: cache-save-deps
+              uses: actions/cache/save@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ github.sha }}-Linux-dep-cache
+              if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
             - uses: actions/setup-python@v1
               with:
                 python-version: '3.7'
@@ -37,6 +51,7 @@ jobs:
                   CLOUD_PROVIDER: ${{ matrix.cloud_provider }}
                   PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
               run: ci/test_linux.sh
+
     build-test-win:
         name: Build-Test-Win
         runs-on: windows-2019
@@ -49,6 +64,13 @@ jobs:
                 cloud_provider: [ 'AWS', 'AZURE', 'GCP' ]
         steps:
             - uses: actions/checkout@v1
+            - name: Restore cached deps
+              id: cache-restore-deps
+              uses: actions/cache/restore@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ matrix.platform }}-${{ matrix.vs_version }}-${{ github.event.pull_request.base.sha }}-Win-dep-cache
+              if: github.event_name == 'pull_request'
             - name: Build
               shell: cmd
               env:
@@ -56,6 +78,13 @@ jobs:
                   BUILD_TYPE: ${{ matrix.build_type }}
                   VS_VERSION: ${{ matrix.vs_version }}
               run: ci\build_win.bat
+            - name: Cache deps
+              id: cache-save-deps
+              uses: actions/cache/save@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ matrix.platform }}-${{ matrix.vs_version }}-${{ github.sha }}-Win-dep-cache
+              if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
             - uses: actions/setup-python@v1
               with:
                 python-version: '3.7'
@@ -81,6 +110,13 @@ jobs:
                 cloud_provider: [ 'AWS', 'AZURE', 'GCP' ]
         steps:
             - uses: actions/checkout@v1
+            - name: Restore cached deps
+              id: cache-restore-deps
+              uses: actions/cache/restore@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ matrix.platform }}-${{ matrix.vs_version }}-${{ github.event.pull_request.base.sha }}-Win-dep-cache
+              if: github.event_name == 'pull_request'
             - name: Build
               shell: cmd
               env:
@@ -88,6 +124,13 @@ jobs:
                   BUILD_TYPE: ${{ matrix.build_type }}
                   VS_VERSION: ${{ matrix.vs_version }}
               run: ci\build_win.bat
+            - name: Cache deps
+              id: cache-save-deps
+              uses: actions/cache/save@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ matrix.platform }}-${{ matrix.vs_version }}-${{ github.sha }}-Win-dep-cache
+              if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
             - uses: actions/setup-python@v1
               with:
                 python-version: '3.7'
@@ -114,11 +157,25 @@ jobs:
             - name: Install Homebrew Bash
               shell: bash
               run: brew install bash
+            - name: Restore cached deps
+              id: cache-restore-deps
+              uses: actions/cache/restore@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Mac-dep-cache
+              if: github.event_name == 'pull_request'
             - name: Build
               shell: bash
               env:
                 BUILD_TYPE: ${{ matrix.build_type }}
               run: ./ci/build_mac.sh
+            - name: Cache deps
+              id: cache-save-deps
+              uses: actions/cache/save@v3
+              with:
+                path: dep-cache
+                key: ${{ matrix.build_type }}-${{ github.sha }}-Mac-dep-cache
+              if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
             - name: Test
               shell: bash
               env:

--- a/scripts/_init.sh
+++ b/scripts/_init.sh
@@ -10,6 +10,7 @@ export TERM=vt100
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DEPS_DIR=$(cd $DIR/../deps && pwd)
 ARTIFACTS_DIR=$DIR/../artifacts
+CACHE_DIR="$DIR/../dep-cache"
 mkdir -p $ARTIFACTS_DIR
 
 PLATFORM=$(echo $(uname) | tr '[:upper:]' '[:lower:]')

--- a/scripts/utils.bat
+++ b/scripts/utils.bat
@@ -75,10 +75,6 @@ goto :EOF
 
 :zip_file
     setlocal
-    if not defined JENKINS_URL (
-        echo === No zip file is created if not Jenkins
-        goto :EOF
-    )
     set component_name=%~1
     set component_version=%~2
     if not exist artifacts md artifacts
@@ -94,10 +90,6 @@ goto :EOF
 
 :zip_files
     setlocal
-    if not defined JENKINS_URL (
-        echo === No zip file is created if not Jenkins
-        goto :EOF
-    )
     set component_name=%~1
     set component_version=%~2
     set files=%~3

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -65,7 +65,7 @@ function zip_file()
 
     local zip_file_name=$(get_zip_file_name "$component_name" "$component_version" "$build_type")
 
-    if [[ -z "$GITHUB_ACTIONS" ]] && [[ -n "$GIT_BRANCH" ]]; then
+    if [[ -n "$GIT_BRANCH" ]]; then
         local f=$UTILS_DIR/../artifacts/$zip_file_name
         rm -f $f
         pushd $DEPENDENCY_DIR/
@@ -85,7 +85,7 @@ function zip_files()
 
     local zip_file_name=$(get_zip_file_name "$component_name" "$component_version" "$build_type")
 
-    if [[ -z "$GITHUB_ACTIONS" ]] && [[ -n "$GIT_BRANCH" ]]; then
+    if [[ -n "$GIT_BRANCH" ]]; then
         local f=$UTILS_DIR/../artifacts/$zip_file_name
         rm -f $f
         pushd $DEPENDENCY_DIR/
@@ -115,6 +115,18 @@ function upload_to_sfc_dev1_data()
 
     local zip_file_name=$(get_zip_file_name $component_name $component_version $build_type)
     aws s3 cp --only-show-errors $UTILS_DIR/../artifacts/$zip_file_name $DEP_URL_PREFIX/$component_name/
+}
+
+function cache_dependency()
+{
+
+    local component_name=$1
+    local component_version=$2
+    local build_type=$3
+
+    local zip_file_name=$(get_zip_file_name $component_name $component_version $build_type)
+    mkdir -p $CACHE_DIR
+    cp $UTILS_DIR/../artifacts/$zip_file_name "$CACHE_DIR/"
 }
 
 function upload_to_sfc_jenkins()
@@ -180,3 +192,4 @@ function set_parameters()
         exit 1
     fi
 }
+


### PR DESCRIPTION
Uses github action caches to speed up the builds:
- Creates a cache associated with a commit on master branch (when built on master)
- Restores the cache on build step in pull requests resulting in faster builds (19m down to 4.5m on Release Linux build)