### PR TITLE
SNOW-864140 update build scripts instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ Set the Snowflake connection info in ``parameters.json`` and place it in the roo
     }
 
 where:
+
 - :code:`<your_snowflake_url>` is optional. Set it when your Snowflake URL is not in the format of :code:`account.snowflakecomputing.com`.
 - :code:`<CLOUD_PROVIDER>` is the cloud platform of your Snowflake account. (:code:`AWS`, :code:`AZURE` or :code:`GCP`).
 
@@ -115,7 +116,7 @@ Linux and OSX
 
 .. code-block:: bash
 
-    ./ci/test/test.sh
+    ./scripts/run_tests.sh
 
 Windows
 ^^^^^^^^^^
@@ -125,8 +126,8 @@ Set environment variables: PLATFORM: [x64, x86], BUILD_TYPE: [Debug, Release], V
 .. code-block:: bash
 
     set platform=x64
-    set build_type=Debug
-    set vs_version=VS14
+    set build_type=Release
+    set vs_version=VS17
 
    .\scripts\run_tests.bat
 

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ Set environment variables: PLATFORM: [x64, x86], BUILD_TYPE: [Debug, Release], V
 .. code-block:: bash
 
     set platform=x64
-    set build_type=Debug
-    set vs_version=VS14
+    set build_type=Release
+    set vs_version=VS17
 
     .\scripts\build_dependencies.bat
     .\scripts\build_libsnowflakeclient.bat

--- a/README.rst
+++ b/README.rst
@@ -12,24 +12,45 @@ Snowflake Connector for C/C++
     :target: http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
+Prerequisites
+================================================================================
+
+Operating system
+For a list of the operating systems supported by Snowflake clients, see `Operating system support <https://docs.snowflake.com/en/release-notes/requirements#label-client-operating-system-support>`_.
+
+To build libsnowflakeclient, the following software must be installed:
+
+- On Windows: Visual Studio 2015, 2017, 2019 or 2022
+- On Linux:
+
+  - gcc/g++ 8.3 or higher. **Note**: on certain OS (e.g. Centos 7) the preinstalled gcc/libstdc++ version is below the required minimum. For Centos 7, this is 4.8.5, which is below the requirement. Building libsnowflakeclient might be unsuccessful on such OS's until the prerequisite is fulfilled, i.e. libraries upgraded to at least the minimum version.
+  - cmake 3.17 or higher
+
+- On macOS:
+
+  - clang
+  - cmake 3.17 or higher
+
+To run test cases, the following software must be installed:
+- jq: https://jqlang.github.io/jq/download/
+- python 3.7 or higher
+
 Build and Tests
 ======================================================================
 
 Build
 ----------------------------------------------------------------------
 
-Ensure you have cmake 3.17 or later version.
-
 Linux and OSX
 ^^^^^^^^^^^^^
 
 .. code-block:: bash
 
+    ./scripts/build_dependencies.sh
     ./scripts/build_libsnowflakeclient.sh
 
 Windows
 ^^^^^^^^^^
-
 Set environment variables: PLATFORM: [x64, x86], BUILD_TYPE: [Debug, Release], VS_VERSION: [VS14, VS15, VS16, VS17] and run the script.
 
 .. code-block:: bash
@@ -37,12 +58,14 @@ Set environment variables: PLATFORM: [x64, x86], BUILD_TYPE: [Debug, Release], V
     set platform=x64
     set build_type=Debug
     set vs_version=VS14
-    ci\build.bat
+
+    .\scripts\build_dependencies.bat
+    .\scripts\build_libsnowflakeclient.bat
 
 Prepare for Test
 ----------------------------------------------------------------------
 
-Set the Snowflake connection info in ``parameters.json`` and place it in $HOME:
+Set the Snowflake connection info in ``parameters.json`` and place it in the root path of libsnowflakeclient repository:
 
 .. code-block:: json
 
@@ -55,8 +78,14 @@ Set the Snowflake connection info in ``parameters.json`` and place it in $HOME:
             "SNOWFLAKE_TEST_DATABASE":  "<your_database>",
             "SNOWFLAKE_TEST_SCHEMA":    "<your_schema>",
             "SNOWFLAKE_TEST_ROLE":      "<your_role>"
+            "SNOWFLAKE_TEST_HOST":      "<your_snowflake_url>"
+            "CLOUD_PROVIDER":           "<your_cloud_provider>"
         }
     }
+
+where:
+- :code:`<your_snowflake_url>` is optional. Set it when your Snowflake URL is not in the format of :code:`account.snowflakecomputing.com`.
+- :code:`<CLOUD_PROVIDER>` is the cloud platform of your Snowflake account. (:code:`AWS`, :code:`AZURE` or :code:`GCP`).
 
 Proxy
 ^^^^^^^^^^
@@ -86,7 +115,7 @@ Linux and OSX
 
 .. code-block:: bash
 
-    ./scripts/run_tests.sh
+    ./ci/test/test.sh
 
 Windows
 ^^^^^^^^^^
@@ -98,7 +127,8 @@ Set environment variables: PLATFORM: [x64, x86], BUILD_TYPE: [Debug, Release], V
     set platform=x64
     set build_type=Debug
     set vs_version=VS14
-    ci\test.bat
+
+   .\scripts\run_tests.bat
 
 	
 Code Coverage (Linux)

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ To build libsnowflakeclient, the following software must be installed:
   - cmake 3.17 or higher
 
 To run test cases, the following software must be installed:
+
 - jq: https://jqlang.github.io/jq/download/
 - python 3.7 or higher
 

--- a/cpp/FileTransferAgent.cpp
+++ b/cpp/FileTransferAgent.cpp
@@ -265,7 +265,7 @@ void Snowflake::Client::FileTransferAgent::upload(string *command)
       }
       else if( outcome == RemoteStorageRequestOutcome::FAILED)
       {
-        m_failedTransfers.append(m_largeFilesMeta[i].srcFileName) + ", ";
+        m_failedTransfers += m_largeFilesMeta[i].srcFileName + ", ";
         //Fast fail, return when the first file fails to upload.
         if (isPutFastFailEnabled())
         {
@@ -351,7 +351,7 @@ void Snowflake::Client::FileTransferAgent::uploadFilesInParallel(std::string *co
         {
           if (outcome == RemoteStorageRequestOutcome::FAILED) {
             CXX_LOG_DEBUG("Sequential upload %s FAILED.", metadata->srcFileName.c_str());
-            m_failedTransfers.append(metadata->srcFileName) + ", ";
+            m_failedTransfers += metadata->srcFileName + ", ";
             //Fast fail, return when the first file fails to upload.
             if(isPutFastFailEnabled())
             {
@@ -405,7 +405,7 @@ void Snowflake::Client::FileTransferAgent::uploadFilesInParallel(std::string *co
             //Cannot throw and catch error from a thread.
             CXX_LOG_DEBUG("Parallel upload %s FAILED", metadata->srcFileName.c_str());
             _mutex_lock(&m_parallelFailedMsgMutex);
-            m_failedTransfers.append(metadata->srcFileName) + ", ";
+            m_failedTransfers += metadata->srcFileName + ", ";
             _mutex_unlock(&m_parallelFailedMsgMutex);
           }
           else if (outcome == RemoteStorageRequestOutcome::SUCCESS)
@@ -682,7 +682,7 @@ void Snowflake::Client::FileTransferAgent::download(string *command)
       {
         CXX_LOG_DEBUG("Putget serial large file download, %s file download FAILED.",
                       m_largeFilesMeta[i].srcFileName.c_str());
-        m_failedTransfers.append(m_largeFilesMeta[i].srcFileName) + ", ";
+        m_failedTransfers += m_largeFilesMeta[i].srcFileName + ", ";
         //Fast fail, return when the first file fails to download.
         if (isGetFastFailEnabled())
         {
@@ -748,7 +748,7 @@ void Snowflake::Client::FileTransferAgent::downloadFilesInParallel(std::string *
         else if (outcome == RemoteStorageRequestOutcome::FAILED)
         {
           CXX_LOG_DEBUG("Sequential download %s FAILED.", metadata->srcFileName.c_str());
-          m_failedTransfers.append(metadata->srcFileName) + ", ";
+          m_failedTransfers += metadata->srcFileName + ", ";
           //Fast fail, return when the first file fails to download.
           if (isGetFastFailEnabled())
           {
@@ -796,7 +796,7 @@ void Snowflake::Client::FileTransferAgent::downloadFilesInParallel(std::string *
             {
               CXX_LOG_DEBUG("Parallel download %s FAILED.", metadata->srcFileName.c_str());
               _mutex_lock(&m_parallelFailedMsgMutex);
-              m_failedTransfers.append(metadata->srcFileName) + ", ";
+              m_failedTransfers += metadata->srcFileName + ", ";
               _mutex_unlock(&m_parallelFailedMsgMutex);
             }
             else if (outcome == RemoteStorageRequestOutcome::SUCCESS)
@@ -810,7 +810,7 @@ void Snowflake::Client::FileTransferAgent::downloadFilesInParallel(std::string *
               RemoteStorageRequestOutcome::FAILED, resultIndex);
             CXX_LOG_DEBUG("Parallel download %s FAILED.", metadata->srcFileName.c_str());
             _mutex_lock(&m_parallelFailedMsgMutex);
-            m_failedTransfers.append(metadata->srcFileName) + ", ";
+            m_failedTransfers += metadata->srcFileName + ", ";
             _mutex_unlock(&m_parallelFailedMsgMutex);
           }
 

--- a/deps/curl/lib/vtls/sf_ocsp.c
+++ b/deps/curl/lib/vtls/sf_ocsp.c
@@ -549,7 +549,7 @@ SF_CERT_STATUS checkResponse(OCSP_RESPONSE *resp,
       long validity = (pday*24*60*60 + psec)/100;
       skewInSec = validity > skewInSec ? validity : skewInSec;
       infof(data, "Diff between thisupd and nextupd "
-              "day: %d, sec: %d, Tolerant skew: %d", pday, psec,
+              "day: %d, sec: %d, Tolerant skew: %ld", pday, psec,
               skewInSec);
     }
     else
@@ -779,7 +779,7 @@ static OCSP_RESPONSE * queryResponderUsingCurl(char *url, OCSP_CERTID *certid, c
     }
     else
     {
-      snprintf(urlbuf, sizeof(urlbuf),
+      snprintf(urlbuf, sizeof(urlbuf), "%s",
                ocsp_cache_server_retry_url_pattern);
     }
   }
@@ -882,7 +882,7 @@ static OCSP_RESPONSE * queryResponderUsingCurl(char *url, OCSP_CERTID *certid, c
         }
         else if (response_code < 200 || response_code >= 300)
         {
-          failf(data, "OCSP request failed with non-200 level code: %d",
+          failf(data, "OCSP request failed with non-200 level code: %ld",
                 response_code);
 
           if (ocsp_retry_cnt == max_retry-1)
@@ -1247,7 +1247,7 @@ static SF_OCSP_STATUS checkResponseTimeValidity(OCSP_RESPONSE *resp, struct Curl
             long validity = (pday*24*60*60 + psec)/100;
             skewInSec = validity > skewInSec ? validity : skewInSec;
             infof(data, "Diff between thisupd and nextupd "
-            "day: %d, sec: %d, Tolerant skew: %d", pday, psec,
+            "day: %d, sec: %d, Tolerant skew: %ld", pday, psec,
             skewInSec);
         }
         else
@@ -1550,7 +1550,7 @@ void downloadOCSPCache(struct Curl_easy *data, SF_OTD *ocsp_log_data, char *last
     }
     else if (response_code < 200 || response_code >= 300 )
     {
-      failf(data, "OCSP cache download request failed with non-200 level code: %d, OCSP Cache Could not be downloaded",
+      failf(data, "OCSP cache download request failed with non-200 level code: %ld, OCSP Cache Could not be downloaded",
             response_code);
       sf_otd_set_event_sub_type(OCSP_RESPONSE_CACHE_DOWNLOAD_FAILED, ocsp_log_data);
       goto end;
@@ -2450,7 +2450,7 @@ SF_PUBLIC(CURLcode) checkCertOCSP(struct connectdata *conn,
 
   sf_otd_set_insecure_mode(0, &ocsp_log_data);
 
-  infof(data, "Cert Data Store: %s, Certifcate Chain: %s", st, ch);
+  infof(data, "Cert Data Store: %s, Certifcate Chain: %s", (char*)st, (char*)ch);
   initOCSPCacheServer(data);
 
   infof(data, "Start SF OCSP Validation...");

--- a/include/snowflake/QueryContextCache.hpp
+++ b/include/snowflake/QueryContextCache.hpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <string>
 #include "snowflake/client.h"
 
 namespace Snowflake

--- a/lib/client.c
+++ b/lib/client.c
@@ -3258,15 +3258,17 @@ SF_STATUS STDCALL snowflake_timestamp_get_epoch_seconds(SF_TIMESTAMP *ts,
         return SF_STATUS_ERROR_NULL_POINTER;
     }
 
-    time_t epoch_time_local;
+    time_t epoch_time;
 
     ts->tm_obj.tm_isdst = -1;
-    epoch_time_local = (time_t) mktime(&ts->tm_obj);
     // mktime takes into account tm_gmtoff which is a Linux and OS X ONLY field
 #if defined(__linux__) || defined(__APPLE__)
-    epoch_time_local += ts->tm_obj.tm_gmtoff;
+    epoch_time = (time_t)mktime(&ts->tm_obj);
+    epoch_time += ts->tm_obj.tm_gmtoff;
+#else
+    epoch_time = _mkgmtime64(&ts->tm_obj);
 #endif
-    *epoch_time_ptr = epoch_time_local - (ts->tzoffset * 60);
+    *epoch_time_ptr = epoch_time - (ts->tzoffset * 60);
 
     return SF_STATUS_SUCCESS;
 }

--- a/lib/results.c
+++ b/lib/results.c
@@ -221,7 +221,7 @@ char *value_to_string(void *value, size_t len, SF_C_TYPE c_type) {
             return ret;
         case SF_C_TYPE_BOOLEAN:
             ret = (char*) SF_CALLOC(1, size + 1);
-            sf_strncpy(ret, size + 1, *(sf_bool*)value != (sf_bool)0 ? SF_BOOLEAN_INTERNAL_TRUE_STR : SF_BOOLEAN_INTERNAL_FALSE_STR, size + 1);
+            sf_strcpy(ret, size + 1, *(sf_bool*)value != (sf_bool)0 ? SF_BOOLEAN_INTERNAL_TRUE_STR : SF_BOOLEAN_INTERNAL_FALSE_STR);
             return ret;
         case SF_C_TYPE_BINARY:
             size = (size_t)len * 2 + 1;

--- a/scripts/_init.sh
+++ b/scripts/_init.sh
@@ -3,7 +3,6 @@
 # Initialize varizbles
 
 set -o pipefail
-
 export PATH=/usr/local/bin:$PATH
 export TERM=vt100
 
@@ -35,64 +34,67 @@ if [[ -z "$GCC" || -z "$GXX" ]]; then
     elif (test -f "/usr/lib64/ccache/gcc52") && (test -f "/usr/lib64/ccache/g++52"); then
         GCC="/usr/lib64/ccache/gcc52"
         GXX="/usr/lib64/ccache/g++52"
-    elif which gcc-5 >& /dev/null; then
+    elif which g++-5 >& /dev/null; then
         GCC="$(which gcc-5)"
         GXX="$(which g++-5)"
-    elif which gcc5 >& /dev/null; then
+    elif which g++5 >& /dev/null; then
         GCC="$(which gcc5)"
         GXX="$(which g++5)"
-    elif which gcc-62 >& /dev/null; then
+    elif which g++-62 >& /dev/null; then
         GCC="$(which gcc-62)"
         GXX="$(which g++-62)"
-    elif which gcc62 >& /dev/null; then
+    elif which g++62 >& /dev/null; then
         GCC="$(which gcc62)"
         GXX="$(which g++62)"
-    elif which gcc-6 >& /dev/null; then
+    elif which g++-6 >& /dev/null; then
         GCC="$(which gcc-6)"
         GXX="$(which g++-6)"
-    elif which gcc6 >& /dev/null; then
+    elif which g++6 >& /dev/null; then
         GCC="$(which gcc6)"
         GXX="$(which g++6)"
-    elif which gcc-72 >& /dev/null; then
+    elif which g++-72 >& /dev/null; then
         GCC="$(which gcc-72)"
         GXX="$(which g++-72)"
-    elif which gcc72 >& /dev/null; then
+    elif which g++72 >& /dev/null; then
         GCC="$(which gcc72)"
         GXX="$(which g++72)"
-    elif which gcc-7 >& /dev/null; then
+    elif which g++-7 >& /dev/null; then
         GCC="$(which gcc-7)"
         GXX="$(which g++-7)"
-    elif which gcc7 >& /dev/null; then
+    elif which g++7 >& /dev/null; then
         GCC="$(which gcc7)"
         GXX="$(which g++7)"
-    elif which gcc-82 >& /dev/null; then
+    elif which g++-82 >& /dev/null; then
         GCC="$(which gcc-82)"
         GXX="$(which g++-82)"
-    elif which gcc82 >& /dev/null; then
+    elif which g++82 >& /dev/null; then
         GCC="$(which gcc82)"
         GXX="$(which g++82)"
-    elif which gcc-8 >& /dev/null; then
+    elif which g++-8 >& /dev/null; then
         GCC="$(which gcc-8)"
         GXX="$(which g++-8)"
-    elif which gcc8 >& /dev/null; then
+    elif which g++8 >& /dev/null; then
         GCC="$(which gcc8)"
         GXX="$(which g++8)"
-    elif which gcc-92 >& /dev/null; then
+    elif which g++-92 >& /dev/null; then
         GCC="$(which gcc-92)"
         GXX="$(which g++-92)"
-    elif which gcc92 >& /dev/null; then
+    elif which g++92 >& /dev/null; then
         GCC="$(which gcc92)"
         GXX="$(which g++92)"
-    elif which gcc-9 >& /dev/null; then
+    elif which g++-9 >& /dev/null; then
         GCC="$(which gcc-9)"
         GXX="$(which g++-9)"
-    elif which gcc9 >& /dev/null; then
+    elif which g++9 >& /dev/null; then
         GCC="$(which gcc9)"
         GXX="$(which g++9)"
-    else
+    elif which g++ >& /dev/null; then
         # Default to system
         GCC="$(which gcc)"
         GXX="$(which g++)"
+    else
+        echo "Error: gcc/g++ not found. Please install gcc/g++."
+        exit 1
     fi
 fi
 
@@ -164,3 +166,4 @@ fi
 
 export DEPENDENCY_DIR=$DIR/../deps-build/$PLATFORM/$target
 mkdir -p $DEPENDENCY_DIR
+

--- a/scripts/build_arrow.bat
+++ b/scripts/build_arrow.bat
@@ -31,7 +31,7 @@ set scriptdir=%~dp0
 call "%scriptdir%_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-set curdir=%cd%
+set currdir=%cd%
 set dependencydir=%scriptdir%..\deps-build\
 cd %dependencydir%
 
@@ -55,7 +55,7 @@ if defined GITHUB_ACTIONS (
     del %dependencydir%\*.gz
 )
 
-cd "%curdir%"
+cd "%currdir%"
 
 echo === archiving the library
 call "%scriptdir%utils.bat" :zip_files arrow %arrow_version% "arrow arrow_deps boost"
@@ -64,9 +64,9 @@ if %ERRORLEVEL% NEQ 0 goto :error
 goto :success
 
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_arrow_source.bat
+++ b/scripts/build_arrow_source.bat
@@ -23,7 +23,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-set curdir=%cd%
+set currdir=%cd%
 
 if /I "%platform%"=="x64" (
     set engine_dir=Program Files
@@ -96,7 +96,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 msbuild INSTALL.vcxproj /p:Configuration=%build_type%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-cd "%curdir%"
+cd "%currdir%"
 
 goto :success
 
@@ -104,5 +104,5 @@ goto :success
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_awssdk.bat
+++ b/scripts/build_awssdk.bat
@@ -28,7 +28,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-set curdir=%cd%
+set currdir=%cd%
 
 if /I "%platform%"=="x64" (
     set engine_dir=Program Files
@@ -76,7 +76,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 msbuild INSTALL.vcxproj /p:Configuration=%build_type%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-cd "%curdir%"
+cd "%currdir%"
 
 echo === archiving the library
 call "%scriptdir%utils.bat" :zip_file aws %aws_version%
@@ -85,9 +85,9 @@ if %ERRORLEVEL% NEQ 0 goto :error
 goto :success
 
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_azuresdk.bat
+++ b/scripts/build_azuresdk.bat
@@ -27,7 +27,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-set curdir=%cd%
+set currdir=%cd%
 
 if /I "%platform%"=="x64" (
     set engine_dir=Program Files
@@ -71,7 +71,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 msbuild INSTALL.vcxproj /p:Configuration=%build_type%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-cd "%curdir%"
+cd "%currdir%"
 xcopy /S /E /I /Y /Q  %AZURE_CMAKE_BUILD_DIR%\%build_type%\azure-storage-lite.lib %AZURE_INSTALL_DIR%\lib\
 xcopy /S /E /I /Y /Q  %AZURE_SOURCE_DIR%\include %AZURE_INSTALL_DIR%\include
 
@@ -85,5 +85,5 @@ goto :success
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_boost_source.bat
+++ b/scripts/build_boost_source.bat
@@ -26,7 +26,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-set curdir=%cd%
+set currdir=%cd%
 
 if /I "%platform%"=="x64" (
     set engine_dir=Program Files
@@ -68,7 +68,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 ::remove cmake files including local build path information
 rd /S /Q %BOOST_INSTALL_DIR%\lib\cmake
 
-cd "%curdir%"
+cd "%currdir%"
 
 echo === archiving the library
 call "%scriptdir%utils.bat" :zip_file boost %boost_version%
@@ -80,5 +80,5 @@ goto :success
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_cmocka.bat
+++ b/scripts/build_cmocka.bat
@@ -29,7 +29,7 @@ if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-set curdir=%cd%
+set currdir=%cd%
 
 set target_name=cmocka_a.lib
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
@@ -40,7 +40,7 @@ set INSTALL_DIR=%TMP%\cmocka
 rd /S /Q "%INSTALL_DIR%"
 md "%INSTALL_DIR%"
 
-cd "%curdir%\deps\%CMOCKA_DIR%"
+cd "%currdir%\deps\%CMOCKA_DIR%"
 set cmake_dir=cmake-build-%arcdir%-%vs_version%-%build_type%
 rd /S /Q %cmake_dir%
 md %cmake_dir%
@@ -56,7 +56,7 @@ cmake --build . --config %build_type%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 echo === staging cmocka
-cd "%curdir%"
+cd "%currdir%"
 rmdir /q /s .\deps-build\%build_dir%\cmocka
 md .\deps-build\%build_dir%\cmocka\include
 md .\deps-build\%build_dir%\cmocka\lib
@@ -77,9 +77,9 @@ if %ERRORLEVEL% NEQ 0 goto :error
 goto :success
 
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_curl.bat
+++ b/scripts/build_curl.bat
@@ -1,13 +1,6 @@
 ::
 :: Build Curl
 :: GitHub repo: https://github.com/curl/curl.git
-::
-:: Prerequisite:
-:: - VC 2015 or 2017
-:: Arguments:
-:: - x86 / x64
-:: - Debug / Release
-:: - vs14 / vs15
 
 @echo off
 set CURL_SRC_VERSION=8.10.1
@@ -34,7 +27,7 @@ set dynamic_runtime=%4
 set scriptdir=%~dp0
 call "%scriptdir%_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
-set curdir=%cd%
+set currdir=%cd%
 
 if /I "%platform%"=="x64" (    
     set openssl_target=VC-WIN64A
@@ -96,7 +89,7 @@ copy /v /y .\deps-build\%build_dir%\oob\include\*.h %curl_dep%\include
 if %ERRORLEVEL% NEQ 0 goto :error
 
 echo === building curl
-cd "%curdir%"
+cd "%currdir%"
 set install_dir=.\deps\%CURL_DIR%\builds\libcurl-vc%vc_version%-%arch%-%buildtype%-static-ssl-static-zlib-static-ipv6-sspi
 rmdir /S /Q %install_dir%-obj
 rmdir /S /Q %install_dir%-obj-curl
@@ -116,7 +109,7 @@ nmake ^
     MACHINE=%arch%
 if %ERRORLEVEL% NEQ 0 goto :error
 
-cd "%curdir%"
+cd "%currdir%"
 rd /s /q .\deps-build\%build_dir%\curl
 md .\deps-build\%build_dir%\curl\bin
 md .\deps-build\%build_dir%\curl\lib
@@ -142,9 +135,9 @@ call "%scriptdir%utils.bat" :zip_file curl %curl_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_dependencies.bat
+++ b/scripts/build_dependencies.bat
@@ -21,6 +21,8 @@ set vs_version=%3
 set dynamic_runtime=%4
 
 set scriptdir=%~dp0
+call "%scriptdir%build_arrow.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%build_zlib.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
 if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%build_openssl.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
@@ -36,8 +38,6 @@ if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%build_picojson.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
 if %ERRORLEVEL% NEQ 0 goto :error
 call "%scriptdir%build_cmocka.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
-if %ERRORLEVEL% NEQ 0 goto :error
-call "%scriptdir%build_arrow.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 :success

--- a/scripts/build_dependencies.bat
+++ b/scripts/build_dependencies.bat
@@ -1,0 +1,49 @@
+::
+:: Build Dependencies
+::
+:: Prerequisite:
+:: - VC 2015, 2017, 2019 or 2022
+:: Arguments:
+:: - x86 / x64
+:: - Debug / Release
+:: - vs14 / vs15 / vs16 / vs17
+:: - ON / OFF
+@echo off
+
+call :build %platform% %build_type% %vs_version% OFF
+if %ERRORLEVEL% NEQ 0 exit /b 1
+exit /b 0
+
+:build
+set platform=%1
+set build_type=%2
+set vs_version=%3
+set dynamic_runtime=%4
+
+set scriptdir=%~dp0
+call "%scriptdir%build_zlib.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_openssl.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_oob.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_curl.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_awssdk.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_azuresdk.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_picojson.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_cmocka.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+call "%scriptdir%build_arrow.bat" :build %platform% %build_type% %vs_version% %dynamic_runtime%
+if %ERRORLEVEL% NEQ 0 goto :error
+
+:success
+cd "%curdir%"
+exit /b 0
+
+:error
+cd "%curdir%"
+exit /b 1

--- a/scripts/build_dependencies.sh
+++ b/scripts/build_dependencies.sh
@@ -20,6 +20,6 @@ source $DIR/build_openssl.sh -t $target
 source $DIR/build_oob.sh -t $target
 source $DIR/build_curl.sh    -t $target
 source $DIR/build_awssdk.sh  -t $target
-source $DIR/build_arrow.sh  -t $target
-source $DIR/build_cmocka.sh  -t Debug
 source $DIR/build_azuresdk.sh -t $target
+source $DIR/build_cmocka.sh -t $target
+source $DIR/build_arrow.sh -t $target

--- a/scripts/build_dependencies.sh
+++ b/scripts/build_dependencies.sh
@@ -15,8 +15,8 @@ source $DIR/_init.sh $@
 if [[ "$PLATFORM" == "linux" ]]; then
     source $DIR/build_uuid.sh -t $target
 fi
-source $DIR/build_zlib.sh -t $target
 source $DIR/build_openssl.sh -t $target
+source $DIR/build_zlib.sh -t $target
 source $DIR/build_oob.sh -t $target
 source $DIR/build_curl.sh    -t $target
 source $DIR/build_awssdk.sh  -t $target

--- a/scripts/build_dependencies.sh
+++ b/scripts/build_dependencies.sh
@@ -21,5 +21,6 @@ source $DIR/build_oob.sh -t $target
 source $DIR/build_curl.sh    -t $target
 source $DIR/build_awssdk.sh  -t $target
 source $DIR/build_azuresdk.sh -t $target
+source $DIR/build_picojson.sh -t $target
 source $DIR/build_cmocka.sh -t $target
 source $DIR/build_arrow.sh -t $target

--- a/scripts/build_libsnowflakeclient.bat
+++ b/scripts/build_libsnowflakeclient.bat
@@ -5,8 +5,9 @@
 set scriptdir=%~dp0
 for /f "tokens=3" %%A in ('findstr SF_API_VERSION %scriptdir%..\include\snowflake\version.h') do @set V=%%A
 set libsnowflakeclient_version=%v:"=%
-call %*
-goto :EOF
+call :build %platform% %build_type% %vs_version% OFF ON
+if %ERRORLEVEL% NEQ 0 exit /b 1
+exit /b 0
 
 :get_version
 	set version=%libsnowflakeclient_version%
@@ -41,7 +42,7 @@ echo === build_tests: %build_tests%
 
 call "%scriptdir%_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
-set curdir=%cd%
+set currdir=%cd%
 
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 
@@ -69,7 +70,7 @@ msbuild ALL_BUILD.vcxproj /property:Configuration=%build_type%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 
-cd "%curdir%"
+cd "%currdir%"
 rd /s /q .\deps-build\%build_dir%\libsnowflakeclient
 if %ERRORLEVEL% NEQ 0 goto :error
 
@@ -107,9 +108,9 @@ if defined JENKINS_URL (
     echo === No zip file is created.
 )
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_libsnowflakeclient.bat
+++ b/scripts/build_libsnowflakeclient.bat
@@ -5,9 +5,12 @@
 set scriptdir=%~dp0
 for /f "tokens=3" %%A in ('findstr SF_API_VERSION %scriptdir%..\include\snowflake\version.h') do @set V=%%A
 set libsnowflakeclient_version=%v:"=%
-call :build %platform% %build_type% %vs_version% OFF ON
-if %ERRORLEVEL% NEQ 0 exit /b 1
-exit /b 0
+if "%*"=="" (
+    call :build %platform% %build_type% %vs_version% OFF ON
+) else (
+    call %*
+)
+goto :EOF
 
 :get_version
 	set version=%libsnowflakeclient_version%

--- a/scripts/build_oob.bat
+++ b/scripts/build_oob.bat
@@ -25,7 +25,7 @@ set scriptdir=%~dp0
 
 call "%scriptdir%\_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
-set curdir=%cd%
+set currdir=%cd%
 
 if /I "%platform%"=="x64" (
         set engine_dir=Program Files
@@ -51,7 +51,7 @@ call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 @echo ====== Building oob
-set OOB_SOURCE_DIR=%curdir%\deps\%OOB_DIR%
+set OOB_SOURCE_DIR=%currdir%\deps\%OOB_DIR%
 
 cd %OOB_SOURCE_DIR%
 set CURL_DIR=curl
@@ -59,7 +59,7 @@ nmake -f Makefile.msc clean
 nmake -f Makefile.msc
 
 echo === Staging oob
-cd "%curdir%"
+cd "%currdir%"
 rd /q /s .\deps-build\%build_dir%\oob
 md .\deps-build\%build_dir%\oob\include
 md .\deps-build\%build_dir%\oob\lib
@@ -76,9 +76,9 @@ goto :success
 
 
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_oob.sh
+++ b/scripts/build_oob.sh
@@ -60,6 +60,7 @@ elif [[ "$PLATFORM" == "darwin" ]]; then
         export CFLAGS="-mmacosx-version-min=10.14 -arch $ARCH  -Xarch_$ARCH"
         make LIB=libtelemetry.a
     fi
+    export AR=
 else
     echo "[ERROR] Unknown platform: $PLATFORM"
     exit 1

--- a/scripts/build_openssl.bat
+++ b/scripts/build_openssl.bat
@@ -1,13 +1,6 @@
 ::
 :: Build OpenSSL
 :: GitHub repo: https://github.com/openssl/openssl.git
-::
-:: Prerequisite:
-:: - VC 2015 or 2017
-:: Arguments:
-:: - x86 / x64
-:: - Debug / Release
-:: - vs14 / vs15
 
 @echo off
 set OPENSSL_SRC_VERSION=3.0.15
@@ -41,7 +34,7 @@ set "path=%scriptdir%..\ci\tools;%path%"
 
 call "%scriptdir%_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
-set curdir=%cd%
+set currdir=%cd%
 
 if /I "%platform%"=="x64" (
     set openssl_target=VC-WIN64A
@@ -65,7 +58,7 @@ set ssl_target_name=libssl_a.lib
 
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 
-echo === building openssl: %curdir%\..\deps\%OPENSSL_DIR%
+echo === building openssl: %currdir%\..\deps\%OPENSSL_DIR%
 cd "%scriptdir%..\deps\%OPENSSL_DIR%"
 echo === %PERL_EXE% Configure %openssl_debug_option% %openssl_target% no-shared enable-fips /ZH:SHA_256 /Qspectre /sdl
 %PERL_EXE% Configure %openssl_debug_option% %openssl_target% no-shared enable-fips /ZH:SHA_256 /Qspectre /sdl
@@ -81,13 +74,13 @@ if %ERRORLEVEL% NEQ 0 goto :error
 REM no doc build
 nmake install_sw install_ssldirs DESTDIR=.\_install
 if %ERRORLEVEL% NEQ 0 goto :error
-cd "%curdir%"
+cd "%currdir%"
 
 echo === staging openssl artifacts
-rd /S /Q %curdir%\deps-build\%build_dir%\openssl
-md "%curdir%\deps-build\%build_dir%\openssl\bin"
-md "%curdir%\deps-build\%build_dir%\openssl\include\openssl"
-md "%curdir%\deps-build\%build_dir%\openssl\lib"
+rd /S /Q %currdir%\deps-build\%build_dir%\openssl
+md "%currdir%\deps-build\%build_dir%\openssl\bin"
+md "%currdir%\deps-build\%build_dir%\openssl\include\openssl"
+md "%currdir%\deps-build\%build_dir%\openssl\lib"
 if %ERRORLEVEL% NEQ 0 goto :error
 
 copy /v /y ^
@@ -129,9 +122,9 @@ call "%scriptdir%utils.bat" :zip_file openssl %openssl_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -62,17 +62,17 @@ elif [[ "$PLATFORM" == "darwin" ]]; then
         make install_sw install_ssldirs install_fips > /dev/null
         mv $OPENSSL_BUILD_DIR/lib $OPENSSL_BUILD_DIR/libarm64
         make distclean clean &> /dev/null || true
+        openssl_config_opts+=("no-asm")
         perl ./Configure darwin64-x86_64-cc "${openssl_config_opts[@]}"
         make install_sw install_ssldirs install_fips > /dev/null
-        lipo -create $OPENSSL_BUILD_DIR/lib/libssl.a    $OPENSSL_BUILD_DIR/libarm64/libssl.a    -output $OPENSSL_BUILD_DIR/lib/../libssl.a
-        lipo -create $OPENSSL_BUILD_DIR/lib/libcrypto.a $OPENSSL_BUILD_DIR/libarm64/libcrypto.a -output $OPENSSL_BUILD_DIR/lib/../libcrypto.a
-        lipo -create $OPENSSL_BUILD_DIR/lib/ossl-modules/fips.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/fips.dylib -output $OPENSSL_BUILD_DIR/lib/../fips.dylib
-        lipo -create $OPENSSL_BUILD_DIR/lib/ossl-modules/legacy.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/legacy.dylib -output $OPENSSL_BUILD_DIR/lib/../legacy.dylib
-        mv $OPENSSL_BUILD_DIR/lib/../libssl.a    $OPENSSL_BUILD_DIR/lib/libssl.a
-        mv $OPENSSL_BUILD_DIR/lib/../libcrypto.a $OPENSSL_BUILD_DIR/lib/libcrypto.a
-        mv $OPENSSL_BUILD_DIR/lib/../fips.dylib $OPENSSL_BUILD_DIR/lib/ossl-modules/fips.dylib
-        mv $OPENSSL_BUILD_DIR/lib/../legacy.dylib $OPENSSL_BUILD_DIR/lib/ossl-modules/legacy.dylib
+        mv $OPENSSL_BUILD_DIR/lib $OPENSSL_BUILD_DIR/libx64
+        mkdir -p $OPENSSL_BUILD_DIR/lib
+        lipo -create $OPENSSL_BUILD_DIR/libx64/libssl.a    $OPENSSL_BUILD_DIR/libarm64/libssl.a    -output $OPENSSL_BUILD_DIR/lib/libssl.a
+        lipo -create $OPENSSL_BUILD_DIR/libx64/libcrypto.a $OPENSSL_BUILD_DIR/libarm64/libcrypto.a -output $OPENSSL_BUILD_DIR/lib/libcrypto.a
+        lipo -create $OPENSSL_BUILD_DIR/libx64/ossl-modules/fips.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/fips.dylib -output $OPENSSL_BUILD_DIR/lib/fips.dylib
+        lipo -create $OPENSSL_BUILD_DIR/libx64/ossl-modules/legacy.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/legacy.dylib -output $OPENSSL_BUILD_DIR/lib/legacy.dylib
         rm -rf $OPENSSL_BUILD_DIR/libarm64
+        rm -rf $OPENSSL_BUILD_DIR/libx64
         lipo -info $OPENSSL_BUILD_DIR/lib/libssl.a
         lipo -info $OPENSSL_BUILD_DIR/lib/libcrypto.a
         lipo -info $OPENSSL_BUILD_DIR/lib/ossl-modules/fips.dylib

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -62,17 +62,17 @@ elif [[ "$PLATFORM" == "darwin" ]]; then
         make install_sw install_ssldirs install_fips > /dev/null
         mv $OPENSSL_BUILD_DIR/lib $OPENSSL_BUILD_DIR/libarm64
         make distclean clean &> /dev/null || true
-        openssl_config_opts+=("no-asm")
         perl ./Configure darwin64-x86_64-cc "${openssl_config_opts[@]}"
         make install_sw install_ssldirs install_fips > /dev/null
-        mv $OPENSSL_BUILD_DIR/lib $OPENSSL_BUILD_DIR/libx64
-        mkdir -p $OPENSSL_BUILD_DIR/lib
-        lipo -create $OPENSSL_BUILD_DIR/libx64/libssl.a    $OPENSSL_BUILD_DIR/libarm64/libssl.a    -output $OPENSSL_BUILD_DIR/lib/libssl.a
-        lipo -create $OPENSSL_BUILD_DIR/libx64/libcrypto.a $OPENSSL_BUILD_DIR/libarm64/libcrypto.a -output $OPENSSL_BUILD_DIR/lib/libcrypto.a
-        lipo -create $OPENSSL_BUILD_DIR/libx64/ossl-modules/fips.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/fips.dylib -output $OPENSSL_BUILD_DIR/lib/fips.dylib
-        lipo -create $OPENSSL_BUILD_DIR/libx64/ossl-modules/legacy.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/legacy.dylib -output $OPENSSL_BUILD_DIR/lib/legacy.dylib
+        lipo -create $OPENSSL_BUILD_DIR/lib/libssl.a    $OPENSSL_BUILD_DIR/libarm64/libssl.a    -output $OPENSSL_BUILD_DIR/lib/../libssl.a
+        lipo -create $OPENSSL_BUILD_DIR/lib/libcrypto.a $OPENSSL_BUILD_DIR/libarm64/libcrypto.a -output $OPENSSL_BUILD_DIR/lib/../libcrypto.a
+        lipo -create $OPENSSL_BUILD_DIR/lib/ossl-modules/fips.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/fips.dylib -output $OPENSSL_BUILD_DIR/lib/../fips.dylib
+        lipo -create $OPENSSL_BUILD_DIR/lib/ossl-modules/legacy.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/legacy.dylib -output $OPENSSL_BUILD_DIR/lib/../legacy.dylib
+        mv $OPENSSL_BUILD_DIR/lib/../libssl.a    $OPENSSL_BUILD_DIR/lib/libssl.a
+        mv $OPENSSL_BUILD_DIR/lib/../libcrypto.a $OPENSSL_BUILD_DIR/lib/libcrypto.a
+        mv $OPENSSL_BUILD_DIR/lib/../fips.dylib $OPENSSL_BUILD_DIR/lib/ossl-modules/fips.dylib
+        mv $OPENSSL_BUILD_DIR/lib/../legacy.dylib $OPENSSL_BUILD_DIR/lib/ossl-modules/legacy.dylib
         rm -rf $OPENSSL_BUILD_DIR/libarm64
-        rm -rf $OPENSSL_BUILD_DIR/libx64
         lipo -info $OPENSSL_BUILD_DIR/lib/libssl.a
         lipo -info $OPENSSL_BUILD_DIR/lib/libcrypto.a
         lipo -info $OPENSSL_BUILD_DIR/lib/ossl-modules/fips.dylib

--- a/scripts/build_picojson.bat
+++ b/scripts/build_picojson.bat
@@ -30,7 +30,7 @@ md %PICOJSON_INSTALL_DIR%
 md %PICOJSON_INSTALL_DIR%\include
 copy %PICOJSON_SOURCE_DIR%\picojson.h %PICOJSON_INSTALL_DIR%\include
 
-cd "%curdir%"
+cd "%currdir%"
 
 echo === archiving the library
 call "%scriptdir%utils.bat" :zip_file picojson %picojson_version%
@@ -42,5 +42,5 @@ goto :success
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/build_zlib.bat
+++ b/scripts/build_zlib.bat
@@ -2,13 +2,6 @@
 :: Build zlib for Windows
 :: GitHub repo: https://github.com/madler/zlib.git
 ::
-:: Prerequisite:
-:: - VC 2015 or 2017
-:: Arguments:
-:: - x86 / x64
-:: - Debug / Release
-:: - vs14 / vs15
-::
 @echo off
 set ZLIB_SRC_VERSION=1.3.1
 set ZLIB_BUILD_VERSION=6
@@ -37,7 +30,7 @@ set source_name="zlibstatic.lib"
 set scriptdir=%~dp0
 call "%scriptdir%_init.bat" %platform% %build_type% %vs_version%
 if %ERRORLEVEL% NEQ 0 goto :error
-set curdir=%cd%
+set currdir=%cd%
 
 set target_name=zlib_a.lib
 if "%build_type%"=="Debug" (
@@ -50,8 +43,8 @@ if "%build_type%"=="Release" (
 call "%scriptdir%utils.bat" :setup_visual_studio %vs_version%
 
 echo === building zlib
-echo %curdir%\deps\%ZLIB_DIR%
-cd %curdir%\deps\%ZLIB_DIR%
+echo %currdir%\deps\%ZLIB_DIR%
+cd %currdir%\deps\%ZLIB_DIR%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 set cmake_dir=cmake-build-%arcdir%-%vs_version%-%build_type%
@@ -69,7 +62,7 @@ cmake --build . --config %build_type%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 echo === staging zlib
-cd "%curdir%"
+cd "%currdir%"
 rd /q /s .\deps-build\%build_dir%\zlib
 md .\deps-build\%build_dir%\zlib\include
 md .\deps-build\%build_dir%\zlib\lib
@@ -85,9 +78,9 @@ call "%scriptdir%utils.bat" :zip_file zlib %zlib_version%
 if %ERRORLEVEL% NEQ 0 goto :error
 
 :success
-cd "%curdir%"
+cd "%currdir%"
 exit /b 0
 
 :error
-cd "%curdir%"
+cd "%currdir%"
 exit /b 1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+#
+# Run test cases
+#
+function usage() {
+    echo "Usage: `basename $0` [-t <Release|Debug>]"
+    echo "Run test cases"
+    echo "-t <Release/Debug> : Test with Release or Debug builds"
+    exit 2
+}
+
+set -o pipefail
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+target=Debug
+source $DIR/_init.sh $@
+source $DIR/env.sh
+
+pushd $DIR/../cmake-build-$target
+    $CTEST -V -E "valgrind.*"
+popd
+

--- a/tests/test_column_fetch.c
+++ b/tests/test_column_fetch.c
@@ -946,9 +946,6 @@ void test_column_as_timestamp_windows_helper(sf_bool use_arrow) {
                         ? "alter session set C_API_QUERY_RESULT_FORMAT=ARROW_FORCE"
                         : "alter session set C_API_QUERY_RESULT_FORMAT=JSON");
 
-    sf_setenv("TZ", "UTC");
-    sf_tzset();
-
     snowflake_query(sfstmt, "select "
                             "NULL, "
                             "to_timestamp_tz('2018-10-10 12:34:56 -7:00'), "

--- a/tests/test_column_fetch.c
+++ b/tests/test_column_fetch.c
@@ -946,6 +946,9 @@ void test_column_as_timestamp_windows_helper(sf_bool use_arrow) {
                         ? "alter session set C_API_QUERY_RESULT_FORMAT=ARROW_FORCE"
                         : "alter session set C_API_QUERY_RESULT_FORMAT=JSON");
 
+    sf_setenv("TZ", "UTC");
+    sf_tzset();
+
     snowflake_query(sfstmt, "select "
                             "NULL, "
                             "to_timestamp_tz('2018-10-10 12:34:56 -7:00'), "

--- a/tests/test_perf_string_reads_and_writes.c
+++ b/tests/test_perf_string_reads_and_writes.c
@@ -139,6 +139,7 @@ void test_col_buffer_copy_unknown_size_dynamic_memory_helper(sf_bool use_arrow) 
 }
 
 void test_col_buffer_copy_concat_multiple_rows_helper(sf_bool use_arrow) {
+    SF_STATUS status;
     SF_CONNECT *sf = NULL;
     SF_STMT *sfstmt = NULL;
     struct timespec begin, end;
@@ -158,7 +159,14 @@ void test_col_buffer_copy_concat_multiple_rows_helper(sf_bool use_arrow) {
                         ? "alter session set C_API_QUERY_RESULT_FORMAT=ARROW_FORCE"
                         : "alter session set C_API_QUERY_RESULT_FORMAT=JSON");
 
-    snowflake_query(sfstmt, "select * from public_domain_books order by id, text_part;", 0);
+    status = snowflake_query(sfstmt, "select * from public_domain_books order by id, text_part;", 0);
+    if (SF_STATUS_SUCCESS != status)
+    {
+        // skip if no access
+        snowflake_stmt_term(sfstmt);
+        snowflake_term(sf);
+        return;
+    }
 
     // Begin timing
     clock_gettime(clk_id, &begin);

--- a/tests/test_unit_logger.c
+++ b/tests/test_unit_logger.c
@@ -124,7 +124,7 @@ void test_mask_secret_log(void **unused) {
         fseek(fp, 0, SEEK_SET);
         log_trace("%s", logtext[i][0]);
         fseek(fp, 0, SEEK_SET);
-        getline(&line, &len, fp);
+        len = getline(&line, &len, fp);
         if (i != 0)
         {
             assert_null(strstr(line, logtext[i][0]));

--- a/tests/test_unit_put_fast_fail.cpp
+++ b/tests/test_unit_put_fast_fail.cpp
@@ -422,7 +422,7 @@ static int gr_teardown(void **unused)
   system(rmCmd);
 #else
   sprintf(rmCmd, "rm -rf %s", testDir.c_str());
-  int ret = system(rmCmd);
+  (void)system(rmCmd);
 #endif
   return 0;
 }

--- a/tests/test_unit_put_fast_fail.cpp
+++ b/tests/test_unit_put_fast_fail.cpp
@@ -422,7 +422,7 @@ static int gr_teardown(void **unused)
   system(rmCmd);
 #else
   sprintf(rmCmd, "rm -rf %s", testDir.c_str());
-  system(rmCmd);
+  int ret = system(rmCmd);
 #endif
   return 0;
 }


### PR DESCRIPTION
teamwork issue 534
Update build/test scripts and instruction.

Tested on Windows VS14/VS17, Linux x86 Centos7+gcc8.3, Linux arm64 Ubuntu24.04+gcc13.2, MacOS13+Xcode14.2
The major changes are:
- Fixed warnings in source code with higher version of compiler
- Fixed issues with environment variable settings in build script (e.g. setting `curdir` could break build with VS14, setting `AR` in `build_oob.sh` could break curl build afterwards with Xcode14)
- Fix test failures
- Update build/test instruction