### PR TITLE
NO-SNOW: Update python version to fix build issue

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
               if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
             - uses: actions/setup-python@v5
               with:
-                python-version: '3.7'
+                python-version: '3.13'
                 architecture: 'x64'
             - name: Test
               shell: bash
@@ -92,7 +92,7 @@ jobs:
               if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
             - uses: actions/setup-python@v5
               with:
-                python-version: '3.7'
+                python-version: '3.13'
                 architecture: 'x64'
             - name: Test
               shell: cmd
@@ -138,7 +138,7 @@ jobs:
               if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
             - uses: actions/setup-python@v5
               with:
-                python-version: '3.7'
+                python-version: '3.13'
                 architecture: 'x64'
             - name: Test
               shell: cmd
@@ -206,7 +206,7 @@ jobs:
               run: ci/build_linux.sh
             - uses: actions/setup-python@v5
               with:
-                python-version: '3.7'
+                python-version: '3.13'
                 architecture: 'x64'
             - name: Test on AWS
               shell: bash


### PR DESCRIPTION
Start to get build error on Linux:
https://github.com/snowflakedb/libsnowflakeclient/actions/runs/12637669839/job/35212346592?pr=757
```
Run actions/setup-python@v5
Installed versions
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

Update python version from 3.7 to 3.13 to fix the issue