### PR TITLE
remove UNUSED macro from tests, use SF_UNUSED instead

### DIFF
--- a/tests/test_bind_params.c
+++ b/tests/test_bind_params.c
@@ -9,7 +9,7 @@
 #define INPUT_ARRAY_SIZE 3
 
 void test_bind_parameters(void **unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     /* init */
     SF_STATUS status;
     SF_BIND_INPUT input_array[INPUT_ARRAY_SIZE];
@@ -354,17 +354,17 @@ void test_array_binding_core(unsigned int array_size, sf_bool fallback, int64 st
 }
 
 void test_array_binding_normal(void** unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     test_array_binding_core(1000, SF_BOOLEAN_FALSE, 0, SF_BOOLEAN_FALSE);
 }
 
 void test_array_binding_stage(void** unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     test_array_binding_core(100000, SF_BOOLEAN_FALSE, 0, SF_BOOLEAN_FALSE);
 }
 
 void test_array_binding_stage_fallback(void** unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     // Azure SDK take too long (14min) to fail with invalid proxy
     char* cenv = getenv("CLOUD_PROVIDER");
     if (cenv && !strncmp(cenv, "AZURE", 5))
@@ -376,14 +376,14 @@ void test_array_binding_stage_fallback(void** unused) {
 }
 
 void test_array_binding_threshold(void** unused) {
-  UNUSED(unused);
+  SF_UNUSED(unused);
   test_array_binding_core(1000, SF_BOOLEAN_FALSE, 500, SF_BOOLEAN_FALSE);
 }
 
 // test threshold with fallback so we can ensure stage binding
 // is actually used with lower threshold and disabled after fallback
 void test_array_binding_threshold_fallback(void** unused) {
-  UNUSED(unused);
+  SF_UNUSED(unused);
   // Azure SDK take too long (14min) to fail with invalid proxy
   char* cenv = getenv("CLOUD_PROVIDER");
   if (cenv && !strncmp(cenv, "AZURE", 5))
@@ -395,12 +395,12 @@ void test_array_binding_threshold_fallback(void** unused) {
 }
 
 void test_array_binding_disable(void** unused) {
-  UNUSED(unused);
+  SF_UNUSED(unused);
   test_array_binding_core(1000, SF_BOOLEAN_FALSE, 500, SF_BOOLEAN_TRUE);
 }
 
 void test_array_binding_supported_false_update(void** unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     SF_STATUS status;
     char bind_data_b[2][4] = { "2.3", "3.4" };
     char bind_data_c[2][7] = { "bind", "insert" };
@@ -517,7 +517,7 @@ void test_array_binding_supported_false_update(void** unused) {
 }
 
 void test_array_binding_supported_false_insert(void** unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
 
 // SNOW-1878297 TODO: disable for now due to server issue.
 // Sever returns arrayBindSupported=true while it's not really supported.
@@ -574,7 +574,7 @@ void test_array_binding_supported_false_insert(void** unused) {
 }
 
 void test_array_binding_supported_false_select(void** unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     SF_STATUS status;
     char bind_data[2][2] = { "1", "2" };
 

--- a/tests/test_column_fetch.c
+++ b/tests/test_column_fetch.c
@@ -1518,12 +1518,12 @@ void test_column_length_with_bundle_202408_helper(sf_bool enabled)
 }
 
 void test_column_length_with_bundle_202408_disabled(void** unused) {
-  UNUSED(unused);
+  SF_UNUSED(unused);
   test_column_length_with_bundle_202408_helper(SF_BOOLEAN_FALSE);
 }
 
 void test_column_length_with_bundle_202408_enabled(void** unused) {
-  UNUSED(unused);
+  SF_UNUSED(unused);
   test_column_length_with_bundle_202408_helper(SF_BOOLEAN_TRUE);
 }
 

--- a/tests/test_unit_connect_parameters.c
+++ b/tests/test_unit_connect_parameters.c
@@ -227,7 +227,7 @@ void test_connection_parameters_application(void **unused) {
 
 extern sf_bool STDCALL renew_session(CURL* curl, SF_CONNECT* sf, SF_ERROR_STRUCT* error);
 void test_connect_with_renew(void** unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
 
     SF_CONNECT* sf = setup_snowflake_connection();
 

--- a/tests/test_unit_pat.c
+++ b/tests/test_unit_pat.c
@@ -12,7 +12,7 @@
  * Test auth connection when the token was not provided.
  */
 void test_pat_with_no_token(void **unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     SF_CONNECT *sf = snowflake_init();
     snowflake_set_attribute(sf, SF_CON_ACCOUNT, "test_account");
     snowflake_set_attribute(sf, SF_CON_USER, "test_user");
@@ -32,7 +32,7 @@ void test_pat_with_no_token(void **unused) {
  * Test the request body with pat connection.
  */
 void test_json_data_in_pat(void **unused) {
-    UNUSED(unused);
+    SF_UNUSED(unused);
     SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
     sf->account = "testaccount";
     sf->host = "testaccount.snowflakecomputing.com";

--- a/tests/utils/test_setup.h
+++ b/tests/utils/test_setup.h
@@ -20,9 +20,6 @@ extern "C" {
 #include <snowflake/client.h>
 #include <snowflake/platform.h>
 
-// Defined for unused function parameters.
-#define UNUSED(x) (void)(x)
-
 #define SKIP_IF_PROXY_ENV_IS_SET \
 {                                                                                                               \
     char envbuf[1024];                                                                                          \


### PR DESCRIPTION
1. Remove UNUSED macro from test_setup.h.
2. Replace UNUSED usages with SF_UNUSED