### PR TITLE
exclude \0 from the serialized CJSON

### DIFF
--- a/cpp/jwt/Util.cpp
+++ b/cpp/jwt/Util.cpp
@@ -22,8 +22,7 @@ std::vector<char> CJSONOperation::serialize(cJSON *root)
   if (json_str == nullptr) throw JwtException("Error serializing JSon object");
   size_t json_str_len = strlen(json_str.get());
 
-  // include the final '/0'
-  std::vector<char> result(json_str.get(), json_str.get() + json_str_len + 1);
+  std::vector<char> result(json_str.get(), json_str.get() + json_str_len);
 
   return result;
 }


### PR DESCRIPTION
During `vector<char>` serialisation we keep the trailing `\0` symbol but it seems that the result is only used as vector so there's no need to keep the end of string as a separate character. Currently this char is being passed to Base64 encode [function] (https://github.com/snowflakedb/libsnowflakeclient/blob/2da838e17a28f1c5d23c8435f2cfe1fb1bcf02e3/cpp/jwt/ClaimSet.hpp#L91) during JWT creation which results in invalid JWT that cannot be processed properly by the new library that backend is going to use (https://connect2id.com/products/nimbus-jose-jwt).