### PR TITLE
NO-SNOW: Add missing chrono import

### DIFF
--- a/cpp/util/SnowflakeCommon.cpp
+++ b/cpp/util/SnowflakeCommon.cpp
@@ -10,7 +10,7 @@
 #include "snowflake/platform.h"
 #include "snowflake/Proxy.hpp"
 #include "../logger/SFLogger.hpp"
-#include <stdexcept>
+#include <chrono>
 #include "SnowflakeCommon.hpp"
 
 using namespace Snowflake;


### PR DESCRIPTION
Master branch fails to compile (on vs2022) due to missing import and minor compiler version upgrade.
[logs](https://productionresultssa9.blob.core.windows.net/actions-results/a4986b37-268f-4a80-b021-3248f88f0424/workflow-job-run-18a4ea19-b0c5-57fc-dc31-e67404c6b25e/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-04T14%3A35%3A34Z&sig=n2ad2x%2BXafmSKuP7axfPBa8xda1iB0XVjAba%2BpJITIY%3D&ske=2025-03-05T01%3A02%3A18Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-04T13%3A02%3A18Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-04T14%3A25%3A29Z&sv=2025-01-05)