### PR TITLE
SNOW-2004104 variable initialization

### DIFF
--- a/cpp/lib/Authenticator.cpp
+++ b/cpp/lib/Authenticator.cpp
@@ -685,6 +685,7 @@ namespace Client
    */
   void AuthWebServer::start()
   {
+      m_socket_desc_web_client = 0;
       m_socket_descriptor = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
       if ((int)m_socket_descriptor < 0)
       {


### PR DESCRIPTION
The variable m_socket_desc_web_client is not initialized, and if browser timeout or other exceptions occur when starting it can lead to unpredictable results.