### PR TITLE
NO-SNOW: Install cmake during windows build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,6 +69,12 @@ jobs:
                 cloud_provider: [ 'AWS', 'AZURE', 'GCP' ]
         steps:
             - uses: actions/checkout@v4
+            - name: Install CMake
+              shell: cmd
+              run: |
+                curl -L "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-windows-x86_64.zip" -o cmake.zip
+                tar -xf cmake.zip
+                echo %cd%\cmake-3.31.6-windows-x86_64\bin>> %GITHUB_PATH%
             - name: Restore cached deps
               id: cache-restore-deps
               uses: actions/cache/restore@v4


### PR DESCRIPTION
Windows runner upgrade causes windows builds to fail (Cmake version is too high), this PR downgrades Cmake and fixes the issues