### PR TITLE
SNOW-2111927: fix thread handle leak from event loop

### DIFF
--- a/crt/aws-crt-cpp/crt/aws-c-common/source/windows/thread.c
+++ b/crt/aws-crt-cpp/crt/aws-c-common/source/windows/thread.c
@@ -110,6 +110,14 @@ static DWORD WINAPI thread_wrapper_fn(LPVOID arg) {
     if (is_managed_thread) {
         aws_thread_pending_join_add(&wrapper_ptr->node);
     }
+    /*
+     * SNOW-2111927 custom changes to keep, fixing thread handle leak from event loop.
+     * For threads manually joined, the thread handle in thread_copy is unused.
+     * Close at the end.
+     */
+    else {
+        CloseHandle(thread_wrapper.thread_copy.thread_handle);
+    }
 
     return 0;
 }

--- a/crt/aws-crt-cpp/crt/aws-c-common/source/windows/thread.c
+++ b/crt/aws-crt-cpp/crt/aws-c-common/source/windows/thread.c
@@ -88,12 +88,12 @@ static DWORD WINAPI thread_wrapper_fn(LPVOID arg) {
      */
     bool is_managed_thread = wrapper_ptr->thread_copy.detach_state == AWS_THREAD_MANAGED;
     if (!is_managed_thread) {
-      /*
-       * SNOW-2111927 custom changes to keep, fixing thread handle leak .
-       * For threads manually joined, close the thread handle in wrapper before
-       * releasing it.
-       */
-        CloseHandle(wrapper_ptr->thread_copy.thread_handle);
+        /*
+         * SNOW-2111927 custom changes to keep, fixing thread handle leak .
+         * For threads manually joined, close the thread handle in wrapper before
+         * releasing it.
+         */
+        aws_thread_clean_up(&wrapper_ptr->thread_copy);
         aws_mem_release(allocator, arg);
     }
 

--- a/crt/aws-crt-cpp/crt/aws-c-io/source/event_loop.c
+++ b/crt/aws-crt-cpp/crt/aws-c-io/source/event_loop.c
@@ -120,6 +120,8 @@ static struct aws_event_loop_group *s_event_loop_group_new(
         /* Don't pin to hyper-threads if a user cared enough to specify a NUMA node */
         if (!pin_threads || (i < group_cpu_count && !usable_cpus[i].suspected_hyper_thread)) {
             struct aws_thread_options thread_options = *aws_default_thread_options();
+            // SNOW-2111927 custom changes to keep, fixing thread handle leak from event loop.
+            thread_options.join_strategy = AWS_TJS_MANAGED;
 
             struct aws_event_loop_options options = {
                 .clock = clock,

--- a/crt/aws-crt-cpp/crt/aws-c-io/source/event_loop.c
+++ b/crt/aws-crt-cpp/crt/aws-c-io/source/event_loop.c
@@ -120,7 +120,7 @@ static struct aws_event_loop_group *s_event_loop_group_new(
         /* Don't pin to hyper-threads if a user cared enough to specify a NUMA node */
         if (!pin_threads || (i < group_cpu_count && !usable_cpus[i].suspected_hyper_thread)) {
             struct aws_thread_options thread_options = *aws_default_thread_options();
-            // SNOW-2111927 custom changes to keep, fixing thread handle leak from event loop.
+            /* SNOW-2111927 custom changes to keep, fixing thread handle leak from event loop. */
             thread_options.join_strategy = AWS_TJS_MANAGED;
 
             struct aws_event_loop_options options = {

--- a/crt/aws-crt-cpp/crt/aws-c-io/source/event_loop.c
+++ b/crt/aws-crt-cpp/crt/aws-c-io/source/event_loop.c
@@ -120,8 +120,6 @@ static struct aws_event_loop_group *s_event_loop_group_new(
         /* Don't pin to hyper-threads if a user cared enough to specify a NUMA node */
         if (!pin_threads || (i < group_cpu_count && !usable_cpus[i].suspected_hyper_thread)) {
             struct aws_thread_options thread_options = *aws_default_thread_options();
-            /* SNOW-2111927 custom changes to keep, fixing thread handle leak from event loop. */
-            thread_options.join_strategy = AWS_TJS_MANAGED;
 
             struct aws_event_loop_options options = {
                 .clock = clock,


### PR DESCRIPTION
teamwork issue 1265
The handle leak is from event loop having a duplicated thread handle opened in thread itself.