### PR TITLE
NO-SNOW: Refresh build caches by running actions each week

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,8 @@ on:
     pull_request:
         branches:
             - '**'
+    schedule:
+        - cron: '0 0 * * 0'
 
 concurrency:
     # older builds for the same pull request numer or branch should be cancelled

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - '**'
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   check-warnings:


### PR DESCRIPTION
Build caches get wiped after a week of not being used. When development is slow the caches can get wiped - this causes:
- slow builds
- code quality fails since Extra Warnings compares its result with master