### PR TITLE
NO-SNOW: fix build issue on mac by using xcode 15.2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,7 +148,7 @@ jobs:
               run: ci\test_win.bat
     build-test-mac:
         name: Build-Test-Mac
-        runs-on: macos-14
+        runs-on: macos-15
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,7 +148,7 @@ jobs:
               run: ci\test_win.bat
     build-test-mac:
         name: Build-Test-Mac
-        runs-on: macos-15
+        runs-on: macos-14
         strategy:
             fail-fast: false
             matrix:
@@ -166,6 +166,8 @@ jobs:
                 tar -xzf cmake.tar.gz
                 echo "$PWD/cmake-3.31.6-macos-universal/CMake.app/Contents/bin" >> $GITHUB_PATH
                 cmake --version
+            - name: Set Xcode version
+              run: sudo xcode-select -s /Applications/Xcode_15.2.app
             - name: Restore cached deps
               id: cache-restore-deps
               uses: actions/cache/restore@v4


### PR DESCRIPTION
Starting today getting build errors on Mac such as `use of undeclared identifier 'LSOpenCFURLRef'` which seems weird as we've had necessary headers included.
It seems due to compiler change on github hosted runner (was clang/LLVM 15.0.7 now it's AppleClang 15.0.0.15000309 which corresponds to Xcode 15.4).
Sounds like xcode setup issue on github hosted runner switching to xcode15.2 could fix the issue.