### PR TITLE
SNOW-3781573: fix sf_getaddrinfo_mutex leak on getaddrinfo() error path

### DIFF
--- a/patches/curl-8.20.0.patch
+++ b/patches/curl-8.20.0.patch
@@ -400,7 +400,7 @@ index fd26c5f0bc..38c79131d7 100644
  int Curl_getaddrinfo_ex(const char *nodename,
                          const char *servname,
                          const struct addrinfo *hints,
-@@ -104,9 +129,22 @@ int Curl_getaddrinfo_ex(const char *nodename,
+@@ -104,9 +129,36 @@ int Curl_getaddrinfo_ex(const char *nodename,
    struct Curl_addrinfo *ca;
    size_t ss_size;
    int error;
@@ -421,25 +421,22 @@ index fd26c5f0bc..38c79131d7 100644
 +#endif
 +
    error = CURL_GETADDRINFO(nodename, servname, hints, &aihead);
-   if(error)
-     return error;
-@@ -174,6 +212,16 @@ int Curl_getaddrinfo_ex(const char *nodename,
-   if(aihead)
-     CURL_FREEADDRINFO(aihead);
- 
++
 +#if defined(HAVE_THREADS_POSIX)
++  /* SNOW-119090: only the system getaddrinfo() call above needs to be
++     serialized (it may trigger a lazy libnss_*.so load). Release the lock
++     here, before any early return below, so it can never be orphaned on an
++     error path -- e.g. EAI_AGAIN from a slow/overloaded resolver, which
++     would otherwise deadlock all name resolution in the process. */
 +  if(sf_enable_getaddrinfo_lock == 1) {
 +    mutex_error = pthread_mutex_unlock(&sf_getaddrinfo_mutex);
-+    if(mutex_error) {
++    if(mutex_error)
 +      Curl_print_pthread_error(mutex_error);
-+      error = mutex_error;
-+    }
 +  }
 +#endif
 +
-   /* if we failed, also destroy the Curl_addrinfo list */
-   if(error) {
-     Curl_freeaddrinfo(cafirst);
+   if(error)
+     return error;
 diff --git a/deps/curl/lib/setopt.c b/deps/curl/lib/setopt.c
 index b8a632748c..5de2d73b55 100644
 --- a/deps/curl/lib/setopt.c


### PR DESCRIPTION
## Summary
The SNOW-119090 patch in `patches/curl-8.20.0.patch` locks a process-global mutex (`sf_getaddrinfo_mutex`) around the system `getaddrinfo()` call but only unlocks it on the success path. **Any error return from `getaddrinfo()` leaks the mutex** — and since it's process-global and non-robust, one failed lookup deadlocks *all* subsequent DNS in the process on `pthread_mutex_lock()`. Deterministic hang, not a race.

The lock is gated by `sf_enable_getaddrinfo_lock` (default `0`); clients such as the ODBC driver enable it.

## Why it appears on RHEL 8 but not RHEL 7
The driver didn't change — glibc did (2.17 → 2.28), plus `ipv6.disable=1`. Slow/overloaded upstream DNS → `EAI_AGAIN`; NXDOMAIN → `EAI_NONAME`; `AF_UNSPEC` with IPv6 disabled → `EAI_ADDRFAMILY`/`EAI_NODATA`. All non-zero, all hit the leaking return. RHEL 8's resolver stack surfaces these where RHEL 7 masked them, and the global mutex serializes all DNS, so a slow resolver + the ~48-thread chunk downloader pile up and make an error return (hence the leak) far more likely.

This is **not** the glibc `__check_pf`/`pthread_cancel` theory: libcurl *detaches* resolver threads (`Curl_thread_destroy` = `pthread_detach`), never cancels them, so no glibc lock is orphaned.

## Fix
Narrow the critical section to just the `getaddrinfo()` call and unlock immediately after it, before any early return. Single unlock site that every exit passes through → no path can orphan the lock; also shrinks the serialized region. The following list construction is thread-local and doesn't need the lock. Unlock-failure handling is now report-only so a spurious unlock error can't fail a good resolve or leak `aihead`.

## Testing
- `git apply --check` clean against `curl-8.20.0`.
- Resulting `Curl_getaddrinfo_ex()`: exactly one lock + one unlock, `aihead` still freed, braces balanced.
- Standalone reproducer: lock enabled + one failed resolve → all later resolves hang (reproduced); same flow with the fix → no deadlock.
