### PR TITLE
SNOW-3648676 base 64 overflow fix

### DIFF
--- a/cpp/EncryptionProvider.cpp
+++ b/cpp/EncryptionProvider.cpp
@@ -3,6 +3,7 @@
 #include "EncryptionProvider.hpp"
 #include "crypto/Cryptor.hpp"
 #include "util/Base64.hpp"
+#include "logger/SFLogger.hpp"
 
 void Snowflake::Client::EncryptionProvider::encryptFileKey(
   FileMetadata *fileMetadata, EncryptionMaterial *encryptionMaterial, Crypto::CryptoRandomDevice randomDevice)
@@ -15,7 +16,7 @@ void Snowflake::Client::EncryptionProvider::encryptFileKey(
   ::std::string &qsmkEncoded = encryptionMaterial->queryStageMasterKey;
 
   Util::Base64::decode(qsmkEncoded.data(), qsmkEncoded.size(),
-                       queryStageMasterKey.data);
+                       queryStageMasterKey.data, sizeof(queryStageMasterKey.data));
   queryStageMasterKey.nbBits = Util::Base64::decodedLength(
     qsmkEncoded.data(), qsmkEncoded.size()) * 8;
 
@@ -44,7 +45,7 @@ void Snowflake::Client::EncryptionProvider::encryptFileKey(
     ::std::string(encryptedFileKeyEncoded, encryptedFileKeyEncodedSize);
 }
 
-void Snowflake::Client::EncryptionProvider::decryptFileKey(
+bool Snowflake::Client::EncryptionProvider::decryptFileKey(
   FileMetadata *fileMetadata, EncryptionMaterial *encryptionMaterial, Crypto::CryptoRandomDevice randomDevice)
 {
   const char *encryptedFileKeyEncoded = fileMetadata
@@ -53,11 +54,16 @@ void Snowflake::Client::EncryptionProvider::decryptFileKey(
     ->encryptionMetadata.enKekEncoded.size();
 
   char encryptedFileKey[128];
-  Util::Base64::decode(encryptedFileKeyEncoded, encryptedFileKeyEncodedSize,
-                       encryptedFileKey);
-  size_t encryptedFileKeySize = Util::Base64::decodedLength(
-    encryptedFileKeyEncoded,
-    encryptedFileKeyEncodedSize);
+  size_t encryptedFileKeySize = Util::Base64::decode(
+    encryptedFileKeyEncoded, encryptedFileKeyEncodedSize,
+    encryptedFileKey, sizeof(encryptedFileKey));
+  if (encryptedFileKeySize == static_cast<size_t>(-1L))
+  {
+    CXX_LOG_ERROR("Failed to decode wrapped file key: invalid or oversized "
+                  "encryption metadata (enKekEncoded length=%zu).",
+                  encryptedFileKeyEncodedSize);
+    return false;
+  }
 
   Crypto::CryptoIV iv;
   Crypto::CryptoKey queryStageMasterKey;
@@ -66,10 +72,16 @@ void Snowflake::Client::EncryptionProvider::decryptFileKey(
 
   ::std::string &qsmkEncoded = encryptionMaterial->queryStageMasterKey;
 
-  Util::Base64::decode(qsmkEncoded.data(), qsmkEncoded.size(),
-                       queryStageMasterKey.data);
-  queryStageMasterKey.nbBits = Util::Base64::decodedLength(
-    qsmkEncoded.data(), qsmkEncoded.size()) * 8;
+  size_t qsmkSize = Util::Base64::decode(qsmkEncoded.data(), qsmkEncoded.size(),
+                                         queryStageMasterKey.data,
+                                         sizeof(queryStageMasterKey.data));
+  if (qsmkSize == static_cast<size_t>(-1L))
+  {
+    CXX_LOG_ERROR("Failed to decode query stage master key: invalid or "
+                  "oversized value (length=%zu).", qsmkEncoded.size());
+    return false;
+  }
+  queryStageMasterKey.nbBits = qsmkSize * 8;
 
   Crypto::CipherContext context =
     Crypto::Cryptor::getInstance().createCipherContext(Crypto::CryptoAlgo::AES,
@@ -84,6 +96,7 @@ void Snowflake::Client::EncryptionProvider::decryptFileKey(
                                  encryptedFileKeySize);
   size_t finalizeSize = context.finalize(fileKey.data + nextSize);
   fileKey.nbBits = (nextSize + finalizeSize) *8;
+  return true;
 }
 
 void Snowflake::Client::EncryptionProvider::populateFileKeyAndIV(

--- a/cpp/EncryptionProvider.hpp
+++ b/cpp/EncryptionProvider.hpp
@@ -27,9 +27,14 @@ public:
   static void encryptFileKey(FileMetadata *fileMetadata,
                              EncryptionMaterial *encryptionMaterial, Crypto::CryptoRandomDevice randomDevice);
   /**
-   * Encrypt file key with query stage master key using AES EBC mode
+   * Decrypt file key with query stage master key using AES EBC mode.
+   *
+   * @return
+   *    true on success; false if the encryption metadata is invalid (e.g.
+   *    a wrapped file key or query stage master key whose base64 form does
+   *    not fit the expected buffer.
    */
-  static void decryptFileKey(FileMetadata *fileMetadata,
+  static bool decryptFileKey(FileMetadata *fileMetadata,
                              EncryptionMaterial *encryptionMaterial, Crypto::CryptoRandomDevice randomDevice);
 
   /**

--- a/cpp/FileMetadataInitializer.cpp
+++ b/cpp/FileMetadataInitializer.cpp
@@ -276,7 +276,14 @@ populateSrcLocDownloadMetadata(std::string &sourceLocation,
     metaListToPush.back().destFileName = dstFileName;
     if (encMat)
     {
-      EncryptionProvider::decryptFileKey(&(metaListToPush.back()), encMat, getRandomDev());
+      if (!EncryptionProvider::decryptFileKey(&(metaListToPush.back()), encMat, getRandomDev()))
+      {
+        CXX_LOG_ERROR("Failed to decrypt file key for %s due to invalid "
+                      "encryption metadata; aborting download.",
+                      fullPath.c_str());
+        metaListToPush.pop_back();
+        return RemoteStorageRequestOutcome::FAILED;
+      }
     }
     else
     {

--- a/cpp/SnowflakeAzureClient.cpp
+++ b/cpp/SnowflakeAzureClient.cpp
@@ -379,7 +379,15 @@ RemoteStorageRequestOutcome SnowflakeAzureClient::GetRemoteFileMetadata(
         if ((std::string::npos != pos1) && (std::string::npos != pos2) && (pos2 >= pos1))
         {
           iv = encHdr.substr(pos1, pos2 - pos1);
-          Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->encryptionMetadata.iv.data);
+          if (Util::Base64::decode(iv.c_str(), iv.size(),
+                fileMetadata->encryptionMetadata.iv.data,
+                sizeof(fileMetadata->encryptionMetadata.iv.data))
+              == static_cast<size_t>(-1L))
+          {
+            CXX_LOG_ERROR("Invalid or oversized IV in blob metadata for %s; "
+                          "rejecting download.", blob.c_str());
+            return RemoteStorageRequestOutcome::FAILED;
+          }
         }
 
         fileMetadata->encryptionMetadata.cipherStreamSize = blobProperty.size;

--- a/cpp/SnowflakeGCSClient.cpp
+++ b/cpp/SnowflakeGCSClient.cpp
@@ -201,8 +201,15 @@ RemoteStorageRequestOutcome SnowflakeGCSClient::GetRemoteFileMetadata(
 
   std::string key, iv;
   parseEncryptionMetadataFromJSON(headers[GCS_ENCRYPTIONDATAPROP], key, iv);
-  Util::Base64::decode(iv.c_str(), iv.size(),
-                       fileMetadata->encryptionMetadata.iv.data);
+  if (Util::Base64::decode(iv.c_str(), iv.size(),
+        fileMetadata->encryptionMetadata.iv.data,
+        sizeof(fileMetadata->encryptionMetadata.iv.data))
+      == static_cast<size_t>(-1L))
+  {
+    CXX_LOG_ERROR("Invalid or oversized IV in object metadata for %s; "
+                  "rejecting download.", filePathFull->c_str());
+    return RemoteStorageRequestOutcome::FAILED;
+  }
   fileMetadata->encryptionMetadata.enKekEncoded = key;
 
   fileMetadata->srcFileSize = strtoull(headers["Content-Length"].c_str(), NULL, 10);

--- a/cpp/SnowflakeS3Client.cpp
+++ b/cpp/SnowflakeS3Client.cpp
@@ -599,8 +599,15 @@ RemoteStorageRequestOutcome SnowflakeS3Client::GetRemoteFileMetadata(
 
     std::string iv = outcome.GetResult().GetMetadata().at(AMZ_IV);
 
-    Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->
-      encryptionMetadata.iv.data);
+    if (Util::Base64::decode(iv.c_str(), iv.size(),
+          fileMetadata->encryptionMetadata.iv.data,
+          sizeof(fileMetadata->encryptionMetadata.iv.data))
+        == static_cast<size_t>(-1L))
+    {
+      CXX_LOG_ERROR("Invalid or oversized IV in object metadata for %s; "
+                    "rejecting download.", key.c_str());
+      return RemoteStorageRequestOutcome::FAILED;
+    }
     if (outcome.GetResult().GetMetadata().find(AMZ_KEY) !=
         outcome.GetResult().GetMetadata().end())
     {

--- a/cpp/util/Base64.cpp
+++ b/cpp/util/Base64.cpp
@@ -44,7 +44,8 @@ std::vector<char> Base64::decodeURLNoPadding(const std::string &text)
   // Base 64 decode text
   size_t decode_len = Client::Util::Base64::decodedLength(in_text.length());
   std::vector<char> decoded(decode_len);
-  decode_len = decodeUrl(in_text.c_str(), in_text.length(), decoded.data());
+  decode_len = decodeUrl(in_text.c_str(), in_text.length(), decoded.data(),
+                         decoded.size());
 
   if (decode_len == static_cast<size_t >(-1L))
   {
@@ -70,7 +71,8 @@ std::vector<char> Base64::decodePadding(const std::string &text)
   // Base 64 decode text
   size_t decode_len = Client::Util::Base64::decodedLength(text.length());
   std::vector<char> decoded(decode_len);
-  decode_len = decode(text.c_str(), text.length(), decoded.data());
+  decode_len = decode(text.c_str(), text.length(), decoded.data(),
+                      decoded.size());
 
   if (decode_len == static_cast<size_t >(-1L))
   {
@@ -143,10 +145,18 @@ size_t Base64::encodeHelper(const void *const vsrc,
 size_t Base64::decodeHelper(const void *const vsrc,
                             const size_t srcLength,
                             void *const vdst,
+                            const size_t dstLength,
                             const ReverseIndex &REV_INDEX) noexcept
 {
   // Check for correct padding.
   if (srcLength % 4)
+    return -1;
+
+  // Reject input whose decoded form would not fit in the destination buffer.
+  // decodedLength() returns the exact number of bytes decodeHelper writes for
+  // a (correctly padded) input, so this bound is precise.
+  const size_t outLength = decodedLength(vsrc, srcLength);
+  if ((outLength == static_cast<size_t>(-1L)) || (outLength > dstLength))
     return -1;
 
   const unsigned char *const src = static_cast<const unsigned char *>(vsrc);

--- a/cpp/util/Base64.hpp
+++ b/cpp/util/Base64.hpp
@@ -126,17 +126,21 @@ struct Base64 final
   /**
    * Decodes given source data of specified length with Base64 format.
    *
-   * The 'dst' buffer needs to have sufficient memory, see decodedLength.
+   * The decoded data is written into 'dst', which must be able to hold at
+   * least 'dstLength' bytes. Decoding fails (returns -1) when the decoded
+   * output would not fit.
    * Does not add a trailing zero.
    *
    * @return
-   *    Number of written bytes. -1 on error (invalid input).
+   *    Number of written bytes. -1 on error (invalid input or insufficient
+   *    destination capacity).
    */
   inline static size_t decode(const void *src,
                        size_t srcLength,
-                       void *dst) noexcept
+                       void *dst,
+                       size_t dstLength) noexcept
   {
-    return decodeHelper(src, srcLength, dst, BASE64_REV_INDEX);
+    return decodeHelper(src, srcLength, dst, dstLength, BASE64_REV_INDEX);
   }
 
   /**
@@ -158,17 +162,21 @@ struct Base64 final
   /**
    * Decodes given source data of specified length with Base64url format.
    *
-   * The 'dst' buffer needs to have sufficient memory, see decodedLength.
+   * The decoded data is written into 'dst', which must be able to hold at
+   * least 'dstLength' bytes. Decoding fails (returns -1) when the decoded
+   * output would not fit.
    * Does not add a trailing zero.
    *
    * @return
-   *    Number of written bytes. -1 on error (invalid input).
+   *    Number of written bytes. -1 on error (invalid input or insufficient
+   *    destination capacity).
    */
   inline static size_t decodeUrl(const void *src,
                        size_t srcLength,
-                       void *dst) noexcept
+                       void *dst,
+                       size_t dstLength) noexcept
   {
-    return decodeHelper(src, srcLength, dst, BASE64_URL_REV_INDEX);
+    return decodeHelper(src, srcLength, dst, dstLength, BASE64_URL_REV_INDEX);
   }
 
   // Reverse index, populated on first call.
@@ -230,14 +238,16 @@ private:
   /**
    * Decodes given source data of specified length.
    *
-   * The 'dst' buffer needs to have sufficient memory, see decodedLength.
+   * Writes at most 'dstLength' bytes into 'dst' and fails (returns -1) when
+   * the decoded output would exceed that capacity, see decodedLength.
    * Does not add a trailing zero.
    *
    * @return
-   *    Number of written bytes. -1 on error (invalid input).
+   *    Number of written bytes. -1 on error (invalid input or insufficient
+   *    destination capacity).
    */
   static size_t decodeHelper(const void *const src, const size_t srcLength, void *const dst,
-                             const ReverseIndex &) noexcept;
+                             const size_t dstLength, const ReverseIndex &) noexcept;
 
   // Not a real class. Just a namespace.
   Base64() = delete;

--- a/tests/test_unit_base64.cpp
+++ b/tests/test_unit_base64.cpp
@@ -178,10 +178,45 @@ void test_base64_coding(void **unused)
     assert_memory_equal(result, encodeExpect.data(), encodeExpect.size());
 
     // test decoding is correct
-    size_t actualDecodeSize = Base64::decode(encodeExpect.data(), encodeExpect.size(), result);
+    size_t actualDecodeSize = Base64::decode(encodeExpect.data(), encodeExpect.size(), result, sizeof(result));
     assert_int_equal(actualDecodeSize, decodeExpect.size());
     assert_memory_equal(result, decodeExpect.data(), decodeExpect.size());
   }
+}
+
+/**
+ * Verify that decode/decodeUrl refuse to write past the destination buffer.
+ * @param unused
+ */
+void test_base64_decode_bounds(void **)
+{
+  // "AAAA" (4 base64 chars) decodes to exactly 3 bytes.
+  const char encoded[] = "AAAAAAAAAAAA"; // 12 chars -> 9 decoded bytes
+  // NOTE: do not name this 'small' - it is a predefined macro on Windows
+  // (rpcndr.h defines `#define small char`).
+  char dstBuf[4];
+
+  // Fits exactly: 4 chars -> 3 bytes into a 3-byte buffer.
+  assert_int_equal(Base64::decode(encoded, 4, dstBuf, 3), 3);
+  // Would overflow: 12 chars -> 9 bytes into a 4-byte buffer -> rejected.
+  assert_int_equal(Base64::decode(encoded, 12, dstBuf, sizeof(dstBuf)),
+                   static_cast<size_t>(-1L));
+  // Zero capacity always rejects non-empty output.
+  assert_int_equal(Base64::decode(encoded, 4, dstBuf, 0),
+                   static_cast<size_t>(-1L));
+  // Same guarantees for the url-safe variant.
+  assert_int_equal(Base64::decodeUrl(encoded, 12, dstBuf, sizeof(dstBuf)),
+                   static_cast<size_t>(-1L));
+
+  // Simulate the IV sink: a 16-byte IV buffer must reject an oversized value.
+  char iv[16];
+  // 512 base64 chars -> 384 decoded bytes; must not touch the 16-byte buffer.
+  std::string oversized(512, 'A');
+  assert_int_equal(Base64::decode(oversized.c_str(), oversized.size(), iv, sizeof(iv)),
+                   static_cast<size_t>(-1L));
+  // A correctly-sized 16-byte IV (24 base64 chars with padding) is accepted.
+  const char ivEncoded[] = "AAAAAAAAAAAAAAAAAAAAAA==";
+  assert_int_equal(Base64::decode(ivEncoded, sizeof(ivEncoded) - 1, iv, sizeof(iv)), 16);
 }
 
 /**
@@ -251,7 +286,7 @@ void test_base64_url_coding(void **unused)
     assert_memory_equal(result, encodeExpect.data(), encodeExpect.size());
 
     // test decoding is correct
-    size_t actualDecodeSize = Base64::decodeUrl(encodeExpect.data(), encodeExpect.size(), result);
+    size_t actualDecodeSize = Base64::decodeUrl(encodeExpect.data(), encodeExpect.size(), result, sizeof(result));
     assert_int_equal(actualDecodeSize, decodeExpect.size());
     assert_memory_equal(result, decodeExpect.data(), decodeExpect.size());
   }
@@ -260,6 +295,7 @@ void test_base64_url_coding(void **unused)
 int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_base64_coding),
+    cmocka_unit_test(test_base64_decode_bounds),
     cmocka_unit_test(test_base64_cpp_coding),
     cmocka_unit_test(test_base64_url_coding),
     cmocka_unit_test(test_base64_url_cpp_coding),

--- a/tests/test_unit_cred_renew.cpp
+++ b/tests/test_unit_cred_renew.cpp
@@ -217,7 +217,8 @@ public:
     {
       std::string iv = "ZxQiil366wJ+QqrhDKckBQ==";
       Snowflake::Client::Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->
-        encryptionMetadata.iv.data);
+        encryptionMetadata.iv.data,
+        sizeof(fileMetadata->encryptionMetadata.iv.data));
       fileMetadata->encryptionMetadata.enKekEncoded = "rgANWKrHN14aKoHRxoIh9GtjXYScNdjseX4kmLZRnEc=";
       fileMetadata->srcFileSize = DOWNLOAD_DATA_SIZE_THRESHOLD + 1;
     }
@@ -287,7 +288,8 @@ public:
   {
     std::string iv = "ZxQiil366wJ+QqrhDKckBQ==";
     Snowflake::Client::Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->
-      encryptionMetadata.iv.data);
+      encryptionMetadata.iv.data,
+      sizeof(fileMetadata->encryptionMetadata.iv.data));
     fileMetadata->encryptionMetadata.enKekEncoded = "rgANWKrHN14aKoHRxoIh9GtjXYScNdjseX4kmLZRnEc=";
     // return small files to test exception in threads.
     fileMetadata->srcFileSize = DOWNLOAD_DATA_SIZE_THRESHOLD - 1;

--- a/tests/test_unit_put_fast_fail.cpp
+++ b/tests/test_unit_put_fast_fail.cpp
@@ -199,7 +199,8 @@ public:
     fileMetadata->srcFileSize = (size_t)filesize;
     std::string iv = "fDnCvS9AFFdXnyM9bsEXcA==";
     Util::Base64::decode(iv.c_str(), iv.size(), fileMetadata->
-                         encryptionMetadata.iv.data);
+                         encryptionMetadata.iv.data,
+                         sizeof(fileMetadata->encryptionMetadata.iv.data));
     fileMetadata->encryptionMetadata.enKekEncoded = "whKlah/HwHnm9RZw/h8gU5PLRg0IOXvwANx7cyLC4Fg=";
     return SUCCESS;
   }


### PR DESCRIPTION
Base64::decode/decodeUrl now take an explicit destination buffer size and return an error if the decoded output would exceed it, instead of writing past the buffer. Callers that decode into fixed-size fields (IV, wrapped file key, query stage master key) now pass their buffer size and handle a decode failure by logging and failing the download cleanly rather than proceeding with bad state.

EncryptionProvider::decryptFileKey now returns a bool to signal this failure to its callers.

No behavior change for well-formed inputs. Existing tests updated for the new signature; added test_base64_decode_bounds covering the new size-check paths.