### PR TITLE
SNOW-3649681 harden openssl build install paths

### DIFF
--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -32,17 +32,34 @@ OPENSSL_BUILD_DIR=$DEPENDENCY_DIR/openssl
 rm -rf $OPENSSL_BUILD_DIR
 mkdir -p $OPENSSL_BUILD_DIR
 
+# SNOW-3649681: configure OpenSSL with standard root-owned --prefix/--openssldir
+# (so the build directory is not compiled into the library), and redirect only
+# the install destinations back into the build tree via the INSTALLTOP/OPENSSLDIR
+# overrides below so the staged artifact layout is unchanged. See SNOW-3649681.
+OPENSSL_RUNTIME_PREFIX=/usr/local
+OPENSSL_RUNTIME_SSLDIR=/usr/local/ssl
+
 openssl_config_opts=()
 openssl_config_opts+=(
     "no-shared"
     "enable-fips"
-    "--prefix=$OPENSSL_BUILD_DIR"
-    "--openssldir=$OPENSSL_BUILD_DIR"
+    "--prefix=$OPENSSL_RUNTIME_PREFIX"
+    "--openssldir=$OPENSSL_RUNTIME_SSLDIR"
     "--libdir=lib"
 )
 if [[ "$target" != "Release" ]]; then
     openssl_config_opts+=("--debug")
 fi
+
+# Override the install destinations (not the compiled-in paths) so the build
+# artifacts are still staged under $OPENSSL_BUILD_DIR exactly as before. These
+# make variables only control where "make install_*" copies files; the
+# OPENSSLDIR/ENGINESDIR/MODULESDIR values baked into the libraries during the
+# preceding "make" keep the safe defaults configured above.
+openssl_install_opts=(
+    "INSTALLTOP=$OPENSSL_BUILD_DIR"
+    "OPENSSLDIR=$OPENSSL_BUILD_DIR"
+)
 
 cd $OPENSSL_SOURCE_DIR
 if [[ "$PLATFORM" == "linux" ]]; then
@@ -50,8 +67,8 @@ if [[ "$PLATFORM" == "linux" ]]; then
     make distclean clean &> /dev/null || true
     perl ./Configure linux-$(uname -m) "${openssl_config_opts[@]}"
     make depend > /dev/null
-    make > /dev/null
-    make install_sw install_ssldirs install_fips > /dev/null
+    make -j 4 > /dev/null
+    make install_sw install_ssldirs install_fips "${openssl_install_opts[@]}" > /dev/null
 elif [[ "$PLATFORM" == "darwin" ]]; then
     openssl_config_opts+=("-mmacosx-version-min=${MACOSX_VERSION_MIN}")
     # Check to see if we are doing a universal build or not.
@@ -62,12 +79,17 @@ elif [[ "$PLATFORM" == "darwin" ]]; then
         echo "[INFO] Building Universal Binary"
         make distclean clean &> /dev/null || true
         perl ./Configure darwin64-arm64-cc "${openssl_config_opts[@]}"
-        make build_libs > /dev/null
-        make install_sw install_ssldirs install_fips > /dev/null
+        make -j 4 build_libs > /dev/null
+        make install_sw install_ssldirs install_fips "${openssl_install_opts[@]}" > /dev/null
         mv $OPENSSL_BUILD_DIR/lib $OPENSSL_BUILD_DIR/libarm64
         make distclean clean &> /dev/null || true
         perl ./Configure darwin64-x86_64-cc "${openssl_config_opts[@]}"
-        make install_sw install_ssldirs install_fips > /dev/null
+        # Build the libraries (which bake in OPENSSLDIR/ENGINESDIR/MODULESDIR)
+        # with the safe configured paths *before* the install step applies the
+        # build-dir overrides, so the x86_64 slice gets the same hardened paths
+        # as the arm64 slice above.
+        make -j 4 build_libs > /dev/null
+        make install_sw install_ssldirs install_fips "${openssl_install_opts[@]}" > /dev/null
         lipo -create $OPENSSL_BUILD_DIR/lib/libssl.a    $OPENSSL_BUILD_DIR/libarm64/libssl.a    -output $OPENSSL_BUILD_DIR/lib/../libssl.a
         lipo -create $OPENSSL_BUILD_DIR/lib/libcrypto.a $OPENSSL_BUILD_DIR/libarm64/libcrypto.a -output $OPENSSL_BUILD_DIR/lib/../libcrypto.a
         lipo -create $OPENSSL_BUILD_DIR/lib/ossl-modules/fips.dylib $OPENSSL_BUILD_DIR/libarm64/ossl-modules/fips.dylib -output $OPENSSL_BUILD_DIR/lib/../fips.dylib
@@ -94,8 +116,8 @@ elif [[ "$PLATFORM" == "darwin" ]]; then
             echo "[INFO] Building $ARCH binary"
             perl ./Configure darwin64-$ARCH-cc "${openssl_config_opts[@]}"
         fi
-        make > /dev/null
-        make install_sw install_ssldirs install_fips > /dev/null
+        make -j 4 > /dev/null
+        make install_sw install_ssldirs install_fips "${openssl_install_opts[@]}" > /dev/null
     fi
 else
     echo "[ERROR] Unknown platform: $PLATFORM"


### PR DESCRIPTION
Configures OpenSSL with standard --prefix/--openssldir values instead of the local build directory, so the paths compiled into the static library are the conventional system defaults rather than a path specific to the build environment. The staged output layout is unchanged — install steps now redirect to the build directory via INSTALLTOP/OPENSSLDIR make overrides, applied after the libraries are built.

Also parallelizes the build (make -j 4) for faster CI runs.

No functional change to the resulting artifacts' locations or contents beyond the compiled-in default paths.