### PR TITLE
SNOW-3649749 account host url validation

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -599,6 +599,110 @@ static void STDCALL log_term() {
 }
 
 /**
+ * Returns SF_BOOLEAN_TRUE if every character in value is safe to embed into the
+ * authority (scheme://host:port) portion of a request URL, i.e. it cannot alter
+ * the URL structure. Only ASCII letters, digits and the host/identifier
+ * punctuation '-', '_' and '.' are allowed. Characters such as '/', '?', '#',
+ * '@', ':', '\\', whitespace or control bytes are rejected so the value
+ * cannot alter the URL structure. NULL and empty strings are treated as valid;
+ * callers separately enforce required-ness.
+ */
+static sf_bool is_valid_url_authority_component(const char *value) {
+    const char *p;
+    if (value == NULL) {
+        return SF_BOOLEAN_TRUE;
+    }
+    for (p = value; *p != '\0'; ++p) {
+        char c = *p;
+        sf_bool is_alpha = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+        sf_bool is_digit = (c >= '0' && c <= '9');
+        if (!(is_alpha || is_digit || c == '-' || c == '_' || c == '.')) {
+            return SF_BOOLEAN_FALSE;
+        }
+    }
+    return SF_BOOLEAN_TRUE;
+}
+
+/**
+ * Returns SF_BOOLEAN_TRUE if protocol is one of the supported URL schemes
+ * (http/https, case-insensitive) so the protocol attribute cannot alter
+ * the URL structure.
+ */
+static sf_bool is_valid_url_protocol(const char *protocol) {
+    return (strcasecmp(protocol, "https") == 0 ||
+            strcasecmp(protocol, "http") == 0) ? SF_BOOLEAN_TRUE : SF_BOOLEAN_FALSE;
+}
+
+/**
+ * Returns SF_BOOLEAN_TRUE if port is a decimal number in the range 1-65535.
+ * Anything else (non-digits, empty, out of range) is rejected so the port
+ * attribute cannot alter the URL structure.
+ */
+static sf_bool is_valid_url_port(const char *port) {
+    const char *p;
+    long value;
+    char *end = NULL;
+    if (port == NULL || *port == '\0') {
+        return SF_BOOLEAN_FALSE;
+    }
+    for (p = port; *p != '\0'; ++p) {
+        if (*p < '0' || *p > '9') {
+            return SF_BOOLEAN_FALSE;
+        }
+    }
+    value = strtol(port, &end, 10);
+    return (end != NULL && *end == '\0' && value >= 1 && value <= 65535) ?
+           SF_BOOLEAN_TRUE : SF_BOOLEAN_FALSE;
+}
+
+/**
+ * Validates the connection attributes that are embedded into the request URL
+ * authority (account, region, host, protocol, port) so they cannot alter the
+ * URL structure. Validation runs before the host is derived from the
+ * account/region so it covers both caller-supplied and derived URL components.
+ * See SNOW-3649749.
+ */
+static SF_STATUS STDCALL
+_snowflake_validate_url_components(SF_CONNECT *sf) {
+    if (!is_valid_url_authority_component(sf->account)) {
+        log_error(ERR_MSG_ACCOUNT_PARAMETER_INVALID);
+        SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                            ERR_MSG_ACCOUNT_PARAMETER_INVALID,
+                            SF_SQLSTATE_UNABLE_TO_CONNECT);
+        return SF_STATUS_ERROR_GENERAL;
+    }
+    if (!is_valid_url_authority_component(sf->region)) {
+        log_error(ERR_MSG_REGION_PARAMETER_INVALID);
+        SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                            ERR_MSG_REGION_PARAMETER_INVALID,
+                            SF_SQLSTATE_UNABLE_TO_CONNECT);
+        return SF_STATUS_ERROR_GENERAL;
+    }
+    if (!is_valid_url_authority_component(sf->host)) {
+        log_error(ERR_MSG_HOST_PARAMETER_INVALID);
+        SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                            ERR_MSG_HOST_PARAMETER_INVALID,
+                            SF_SQLSTATE_UNABLE_TO_CONNECT);
+        return SF_STATUS_ERROR_GENERAL;
+    }
+    if (!is_string_empty(sf->protocol) && !is_valid_url_protocol(sf->protocol)) {
+        log_error(ERR_MSG_PROTOCOL_PARAMETER_INVALID);
+        SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                            ERR_MSG_PROTOCOL_PARAMETER_INVALID,
+                            SF_SQLSTATE_UNABLE_TO_CONNECT);
+        return SF_STATUS_ERROR_GENERAL;
+    }
+    if (!is_string_empty(sf->port) && !is_valid_url_port(sf->port)) {
+        log_error(ERR_MSG_PORT_PARAMETER_INVALID);
+        SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                            ERR_MSG_PORT_PARAMETER_INVALID,
+                            SF_SQLSTATE_UNABLE_TO_CONNECT);
+        return SF_STATUS_ERROR_GENERAL;
+    }
+    return SF_STATUS_SUCCESS;
+}
+
+/**
  * Process connection parameters
  * @param sf SF_CONNECT
  */
@@ -636,8 +740,14 @@ _snowflake_check_connection_parameters(SF_CONNECT *sf) {
         return SF_STATUS_ERROR_GENERAL;
     }
 
-    if (!(auth_type == AUTH_EXTERNALBROWSER && sf->disable_console_login) && 
-        auth_type != AUTH_WIF && 
+    // Validate account/region/host/protocol/port before they are used to
+    // derive the host and build request URLs (SNOW-3649749).
+    if (_snowflake_validate_url_components(sf) != SF_STATUS_SUCCESS) {
+        return SF_STATUS_ERROR_GENERAL;
+    }
+
+    if (!(auth_type == AUTH_EXTERNALBROWSER && sf->disable_console_login) &&
+        auth_type != AUTH_WIF &&
         is_string_empty(sf->user)) {
         // Invalid user name
         log_error(ERR_MSG_USER_PARAMETER_IS_MISSING);

--- a/lib/error.h
+++ b/lib/error.h
@@ -38,6 +38,11 @@ void STDCALL copy_snowflake_error(SF_ERROR_STRUCT *dst, SF_ERROR_STRUCT *src);
 #define ERR_MSG_OAUTH_PARAMETER_IS_MISSING "OAuth 2.0 Auth parameter is missing"
 #define ERR_MSG_PAT_PARAMETER_IS_MISSING "programmatic_access_token parameter is missing"
 #define ERR_MSG_WIF_PROVIDER_PARAMETER_IS_MISSING "workload_identity_provider parameter is required for WIF authentication. Valid values: AWS, AZURE, GCP, OIDC"
+#define ERR_MSG_ACCOUNT_PARAMETER_INVALID "account parameter contains invalid characters"
+#define ERR_MSG_REGION_PARAMETER_INVALID "region parameter contains invalid characters"
+#define ERR_MSG_HOST_PARAMETER_INVALID "host parameter contains invalid characters"
+#define ERR_MSG_PROTOCOL_PARAMETER_INVALID "protocol parameter must be http or https"
+#define ERR_MSG_PORT_PARAMETER_INVALID "port parameter must be a number between 1 and 65535"
 
 #ifdef __cplusplus
 }

--- a/tests/test_unit_connect_parameters.c
+++ b/tests/test_unit_connect_parameters.c
@@ -257,6 +257,113 @@ void test_connect_with_renew(void** unused) {
 }
 
 /**
+ * Regression test for SNOW-3649749: connection attributes embedded into the
+ * request URL authority must reject characters that are not part of a valid
+ * host/identifier, so they cannot alter the URL structure.
+ */
+void test_connection_parameters_url_injection(void **unused) {
+    SF_UNUSED(unused);
+
+    // Account values containing characters outside the allowed set must be
+    // rejected before the host is derived.
+    const char *bad_accounts[] = {
+        "badhost.example.com/x?",   // '/' and '?'
+        "badhost.example.com/x",    // '/'
+        "user@example.com",         // '@'
+        "host:443",                 // ':'
+        "bad value",                // whitespace
+        "bad\\value",               // backslash
+        "bad%2evalue",              // percent-encoding
+    };
+    size_t i;
+    for (i = 0; i < sizeof(bad_accounts) / sizeof(bad_accounts[0]); i++) {
+        SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+        sf->account = (char *) bad_accounts[i];
+        sf->user = "testuser";
+        sf->password = "testpassword";
+        assert_int_equal(
+            _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+        // Nothing should have been derived from the rejected input.
+        assert_int_equal(sf->host, NULL);
+        SF_FREE(sf);
+    }
+
+    // A caller-supplied host with URL metacharacters must be rejected too.
+    {
+        SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+        sf->account = "testaccount";
+        sf->host = "badhost.example.com/x?.snowflakecomputing.com";
+        sf->user = "testuser";
+        sf->password = "testpassword";
+        assert_int_equal(
+            _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+        SF_FREE(sf);
+    }
+
+    // A caller-supplied region with URL metacharacters must be rejected.
+    {
+        SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+        sf->account = "testaccount";
+        sf->region = "badregion.example.com/x?";
+        sf->user = "testuser";
+        sf->password = "testpassword";
+        assert_int_equal(
+            _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+        SF_FREE(sf);
+    }
+
+    // Invalid protocol / port values must be rejected.
+    {
+        SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+        sf->account = "testaccount";
+        sf->protocol = "https://evil";
+        sf->user = "testuser";
+        sf->password = "testpassword";
+        assert_int_equal(
+            _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+        SF_FREE(sf);
+    }
+    {
+        SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+        sf->account = "testaccount";
+        sf->port = "443/evil";
+        sf->user = "testuser";
+        sf->password = "testpassword";
+        assert_int_equal(
+            _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+        SF_FREE(sf);
+    }
+    {
+        SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+        sf->account = "testaccount";
+        sf->port = "99999"; // out of range
+        sf->user = "testuser";
+        sf->password = "testpassword";
+        assert_int_equal(
+            _snowflake_check_connection_parameters(sf), SF_STATUS_ERROR_GENERAL);
+        SF_FREE(sf);
+    }
+
+    // Legitimate values (dots, dashes, privatelink, explicit host/protocol/port)
+    // must still be accepted.
+    {
+        SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
+        sf->account = (char *) SF_CALLOC(1, 128);
+        strcpy(sf->account, "test-account.us-east-1.privatelink");
+        sf->user = "testuser";
+        sf->password = "testpassword";
+        sf->protocol = "HTTPS";
+        sf->port = "8443";
+        assert_int_equal(
+            _snowflake_check_connection_parameters(sf), SF_STATUS_SUCCESS);
+        assert_string_equal(sf->host,
+            "test-account.us-east-1.privatelink.snowflakecomputing.com");
+        SF_FREE(sf->account);
+        SF_FREE(sf);
+    }
+}
+
+/**
  * Test account including cn region
  */
 void test_connection_parameters_including_cn_region(void **unused) {
@@ -290,6 +397,7 @@ int main(void) {
         cmocka_unit_test(test_connection_parameters_for_global_url_basic),
         cmocka_unit_test(test_connection_parameters_for_global_url_full),
         cmocka_unit_test(test_connection_parameters_application),
+        cmocka_unit_test(test_connection_parameters_url_injection),
         cmocka_unit_test(test_connect_with_renew),
         cmocka_unit_test(test_connection_parameters_including_cn_region),
     };


### PR DESCRIPTION
Adds validation for the connection attributes that are embedded into the request URL authority — account, region, host, protocol, port — before they're used to build request URLs. Values containing characters outside a normal hostname/identifier set (e.g. /, @, :, whitespace) are now rejected at connection time with a clear parameter error, instead of being passed through as-is.

protocol and port are similarly constrained to http/https and 1–65535 respectively.

Existing valid configurations (dashes, dots, privatelink hosts, explicit protocol/port) are unaffected — covered by the added regression test test_connection_parameters_url_injection.