### PR TITLE
Fix OpenSSL pkg-config metadata after install-path hardening

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,6 +16,7 @@ jobs:
   check-warnings:
     name: Extra-Warnings-Linux
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -129,5 +129,24 @@ if [[ ! -d "$OPENSSL_BUILD_DIR/lib" ]] && [[ -d "$OPENSSL_BUILD_DIR/lib64" ]]; t
     mv $OPENSSL_BUILD_DIR/lib64 $OPENSSL_BUILD_DIR/lib
 fi
 
+# SNOW-3649681 configured OpenSSL with --prefix=$OPENSSL_RUNTIME_PREFIX so the
+# build directory is not compiled into libcrypto/libssl. That same prefix is,
+# however, baked into the generated pkg-config (.pc) files, whose absolute
+# prefix/libdir/includedir are NOT relocated by the INSTALLTOP install override.
+# curl's ./configure discovers OpenSSL via pkg-config, so a stale
+# "$OPENSSL_RUNTIME_PREFIX/lib" makes it emit -L$OPENSSL_RUNTIME_PREFIX/lib,
+# fail to find libcrypto in the staged tree, and abort with "OpenSSL could not
+# be detected". Repoint the .pc metadata at the real staged tree. (The CMake
+# config files compute their prefix relative to their own location, so they are
+# already relocatable and need no fixup.) These are build-time inputs only (not
+# shipped), so the hardened paths compiled into the libraries are unchanged.
+if compgen -G "$OPENSSL_BUILD_DIR/lib/pkgconfig/*.pc" > /dev/null; then
+    perl -pi \
+        -e "s{^prefix=\Q$OPENSSL_RUNTIME_PREFIX\E(?=/|\$)}{prefix=$OPENSSL_BUILD_DIR};" \
+        -e "s{^libdir=\Q$OPENSSL_RUNTIME_PREFIX\E/}{libdir=$OPENSSL_BUILD_DIR/};" \
+        -e "s{^includedir=\Q$OPENSSL_RUNTIME_PREFIX\E/}{includedir=$OPENSSL_BUILD_DIR/};" \
+        "$OPENSSL_BUILD_DIR"/lib/pkgconfig/*.pc
+fi
+
 echo === zip_file "openssl" "$OPENSSL_VERSION" "$target"
 zip_file "openssl" "$OPENSSL_VERSION" "$target"


### PR DESCRIPTION
#1031 (SNOW-3649681) configured OpenSSL with --prefix=/usr/local so the build directory is no longer compiled into libcrypto/libssl. That prefix is also baked into the generated pkg-config (.pc) files, whose libdir therefore points at /usr/local/lib instead of the staged build tree.

curl's ./configure discovers OpenSSL via pkg-config and consequently emits -L/usr/local/lib, cannot find libcrypto there, and aborts every build with "--with-openssl was given but OpenSSL could not be detected". This broke all CI on master (and every PR branched off it) even though the staged artifact still contains lib/libcrypto.a.

Repoint prefix/libdir/includedir in the installed .pc files back to $OPENSSL_BUILD_DIR after install. These are build-time inputs only (not shipped), so the hardened paths compiled into the libraries are unchanged.

Additional change:
ci: made Extra-Warnings-Linux non-blocking until cache is seeded (https://github.com/snowflakedb/libsnowflakeclient/pull/1036)
The warning-diff job fails on all PRs when the GitHub Actions cache for
the base SHA is missing (never populated on master, or expired). Add
continue-on-error: true so the check shows as informational (yellow)
rather than blocking merges until a master build seeds the baseline.