### PR TITLE
ci: make Extra-Warnings-Linux non-blocking until cache is seeded

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,6 +16,7 @@ jobs:
   check-warnings:
     name: Extra-Warnings-Linux
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The warning-diff job fails on all PRs when the GitHub Actions cache for the base SHA is missing (never populated on master, or expired). Add continue-on-error: true so the check shows as informational (yellow) rather than blocking merges until a master build seeds the baseline.