### PR TITLE
NO-SNOW: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,10 +26,10 @@ jobs:
           matrix:
             build_type: [ 'Debug', 'Release' ]
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v5
           - name: Restore cached deps
             id: cache-restore-deps
-            uses: actions/cache/restore@v4
+            uses: actions/cache/restore@v5
             with:
               path: dep-cache
               key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Linux-dep-cache
@@ -40,7 +40,7 @@ jobs:
               BUILD_TYPE: ${{ matrix.build_type }}
               ENABLE_MOCK_OBJECTS: 'true'
             run: ci/build_linux.sh
-          - uses: actions/setup-python@v5
+          - uses: actions/setup-python@v6
             with:
               python-version: '>=3.13.5' # temporary bound until it becomes the default, https://github.com/python/cpython/issues/135151
               architecture: 'x64'
@@ -61,10 +61,10 @@ jobs:
                 build_type: [ 'Debug', 'Release' ]
                 cloud_provider: [ 'AWS', 'AZURE', 'GCP' ]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Restore cached deps
               id: cache-restore-deps
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Linux-dep-cache
@@ -76,12 +76,12 @@ jobs:
               run: ci/build_linux.sh
             - name: Cache deps
               id: cache-save-deps
-              uses: actions/cache/save@v4
+              uses: actions/cache/save@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ github.sha }}-Linux-dep-cache
               if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                 python-version: '>=3.13.5' # temporary bound until it becomes the default, https://github.com/python/cpython/issues/135151
                 architecture: 'x64'
@@ -104,7 +104,7 @@ jobs:
                 vs_version: [ 'VS17' ]
                 cloud_provider: [ 'AWS', 'AZURE', 'GCP' ]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Install CMake
               shell: cmd
               run: |
@@ -122,7 +122,7 @@ jobs:
                 reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
             - name: Restore cached deps
               id: cache-restore-deps
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ matrix.platform }}-${{ matrix.vs_version }}-${{ github.event.pull_request.base.sha }}-Win-dep-cache
@@ -136,12 +136,12 @@ jobs:
               run: ci\build_win.bat
             - name: Cache deps
               id: cache-save-deps
-              uses: actions/cache/save@v4
+              uses: actions/cache/save@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ matrix.platform }}-${{ matrix.vs_version }}-${{ github.sha }}-Win-dep-cache
               if: github.ref_name == github.event.repository.default_branch && matrix.cloud_provider == 'AWS'
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                 python-version: '>=3.13.5' # temporary bound until it becomes the default, https://github.com/python/cpython/issues/135151
                 architecture: 'x64'
@@ -163,7 +163,7 @@ jobs:
                 build_type: [ 'Debug', 'Release' ]
                 cloud_provider: [ 'AWS', 'AZURE', 'GCP' ]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Install Homebrew Bash
               shell: bash
               run: brew install bash
@@ -176,7 +176,7 @@ jobs:
                 cmake --version
             - name: Restore cached deps
               id: cache-restore-deps
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Mac-dep-cache
@@ -188,7 +188,7 @@ jobs:
               run: ./ci/build_mac.sh
             - name: Cache deps
               id: cache-save-deps
-              uses: actions/cache/save@v4
+              uses: actions/cache/save@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ github.sha }}-Mac-dep-cache
@@ -208,10 +208,10 @@ jobs:
             matrix:
                 build_type: [ 'Release' ]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Restore cached deps
               id: cache-restore-deps
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Linux-dep-cache
@@ -222,7 +222,7 @@ jobs:
                   BUILD_TYPE: ${{ matrix.build_type }}
                   CLIENT_CODE_COVERAGE: 1
               run: ci/build_linux.sh
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                 python-version: '>=3.13.5' # temporary bound until it becomes the default, https://github.com/python/cpython/issues/135151
                 architecture: 'x64'
@@ -235,7 +235,7 @@ jobs:
                   PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
               run: ci/test_linux.sh
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v6
               with:
                 # without the token code cov may fail because of Github limits https://github.com/codecov/codecov-action/issues/557
                 token: ${{ secrets.CODE_COV_UPLOAD_TOKEN }}
@@ -248,10 +248,10 @@ jobs:
             matrix:
                 build_type: [ 'Release' ]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Restore cached deps
               id: cache-restore-deps
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Linux-dep-cache
@@ -262,7 +262,7 @@ jobs:
                   BUILD_TYPE: ${{ matrix.build_type }}
                   CLIENT_CODE_COVERAGE: 1
               run: ci/build_linux.sh
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                 python-version: '>=3.13.5' # temporary bound until it becomes the default, https://github.com/python/cpython/issues/135151
                 architecture: 'x64'
@@ -275,7 +275,7 @@ jobs:
                   PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
               run: ci/test_linux.sh
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v6
               with:
                 # without the token code cov may fail because of Github limits https://github.com/codecov/codecov-action/issues/557
                 token: ${{ secrets.CODE_COV_UPLOAD_TOKEN }}
@@ -288,10 +288,10 @@ jobs:
             matrix:
                 build_type: [ 'Release' ]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Restore cached deps
               id: cache-restore-deps
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v5
               with:
                 path: dep-cache
                 key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Linux-dep-cache
@@ -302,7 +302,7 @@ jobs:
                   BUILD_TYPE: ${{ matrix.build_type }}
                   CLIENT_CODE_COVERAGE: 1
               run: ci/build_linux.sh
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                 python-version: '>=3.13.5' # temporary bound until it becomes the default, https://github.com/python/cpython/issues/135151
                 architecture: 'x64'
@@ -315,7 +315,7 @@ jobs:
                   PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
               run: ci/test_linux.sh
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v6
               with:
                 # without the token code cov may fail because of Github limits https://github.com/codecov/codecov-action/issues/557
                 token: ${{ secrets.CODE_COV_UPLOAD_TOKEN }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -18,7 +18,7 @@ jobs:
     name: Bump Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: setup git config

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -22,14 +22,14 @@ jobs:
       matrix:
         build_type: [ 'Release' ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '>=3.13.5' # temporary bound until it becomes the default, https://github.com/python/cpython/issues/135151
           architecture: 'x64'
       - name: Restore cached deps
         id: cache-restore-deps
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: dep-cache
           key: ${{ matrix.build_type }}-${{ github.event.pull_request.base.sha }}-Linux-dep-cache
@@ -42,7 +42,7 @@ jobs:
         run: ci/build_linux.sh
       - name: Restore cached warnings
         id: cache-restore-warnings
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: warnings.json
           key: ${{ github.event.pull_request.base.sha }}-compile-warnings
@@ -57,23 +57,23 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: ci/scripts/warning_report.sh
       - name: Upload build log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: build log
           path: build.log
       - name: Upload warning report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: report
           path: report.md
       - name: Upload warnings
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: warnings
           path: warnings.json
       - name: Cache warnings
         id: cache-save-warnings
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: warnings.json
           key: ${{ github.sha }}-compile-warnings


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v5 (first node24 major; avoids v6/v7 credential-storage behavior changes)
- `actions/setup-python` v5 → v6
- `actions/cache/restore` & `actions/cache/save` v4 → v5
- `actions/upload-artifact` v4 → v5
- `codecov/codecov-action` v5 → v6

All GitHub-hosted runners used in these workflows (`ubuntu-latest`, `windows-2022`, `macos-14`) already exceed the required runner v2.327.1, so these are runtime-only bumps with no infrastructure changes needed.

## Files changed

- `.github/workflows/build-test.yml`
- `.github/workflows/bump_version.yml`
- `.github/workflows/code-quality.yml`

Made with [Cursor](https://cursor.com)