### PR TITLE
NO-SNOW: add vswhere fallback for VS2022 path detection in _init.bat

### DIFF
--- a/scripts/_init.bat
+++ b/scripts/_init.bat
@@ -73,8 +73,12 @@ if /I "%vs_version%"=="VS17" (
         ) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC" (
             set VCINSTALLDIR=C:\Program Files ^(x86^)\Microsoft Visual Studio\2022\BuildTools\VC
         ) else (
-            echo Set environment variable VCINSTALLDIR to sepecify Visual Studio 2022 install path.
-            goto :error
+            set "VCINSTALLDIR="
+            for /f "usebackq delims=" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2^>nul`) do set "VCINSTALLDIR=%%i\VC"
+            if not defined VCINSTALLDIR (
+                echo Set environment variable VCINSTALLDIR to sepecify Visual Studio 2022 install path.
+                goto :error
+            )
         )
     )
 )


### PR DESCRIPTION
## Summary

- `scripts/_init.bat` checks three hard-coded VS 2022 install paths (Community, Enterprise, BuildTools). On fresh Jenkins AMIs where VS 2022 is installed at a non-standard location and `VCINSTALLDIR` is unset, all three checks fail and the build errors out immediately.
- This PR adds a `vswhere.exe` fallback in the final `else` branch: if none of the known paths exist, the script queries `vswhere.exe` to dynamically discover the VS 2022 installation before giving up with an error message.
- The three existing hard-coded path checks are unchanged and still run first; `vswhere` is purely an additional safety net.

## Notes

- This fix is only effective when the agent has a genuine VS 17.x (2022) toolset installed at a non-standard path. If the AMI has moved to VS 18.x, a separate change to the CMake generator will also be required.
- `if not defined VCINSTALLDIR` evaluates at runtime inside the `else` block — no delayed expansion needed.
- `2^>nul` suppresses errors if `vswhere.exe` itself is missing.

## Test plan

- [ ] Smoke-test on one Windows Jenkins agent with VS 2022 at a non-standard path to confirm `VCINSTALLDIR` is resolved correctly
- [ ] Verify existing agents with Community/Enterprise/BuildTools paths are unaffected

Made with [Cursor](https://cursor.com)