### PR TITLE
SNOW-3856959: Revert the AWS WIF behavior to the old style and gate new one with envvar

### DIFF
--- a/cpp/AwsAttestation.cpp
+++ b/cpp/AwsAttestation.cpp
@@ -116,7 +116,7 @@ namespace Snowflake::Client {
         return boost::none;
       }
       const auto &jwt = jwtOpt.get();
-      CXX_LOG_DEBUG("AWS WIF JWT token prefix: %.10s", jwt.c_str());
+      CXX_LOG_DEBUG("AWS WIF JWT token obtained (length=%zu)", jwt.size());
       return Attestation::makeAws(jwt);
     }
 
@@ -152,7 +152,7 @@ namespace Snowflake::Client {
     std::string json = picojson::value(obj).serialize(true);
     std::string base64;
     Util::Base64::encodePadding(json.begin(), json.end(), std::back_inserter(base64));
-    CXX_LOG_DEBUG("AWS WIF legacy credential prefix: %.10s", base64.c_str());
+    CXX_LOG_DEBUG("AWS WIF legacy credential obtained (length=%zu)", base64.size());
     return Attestation::makeAws(base64);
   }
 }

--- a/cpp/AwsAttestation.cpp
+++ b/cpp/AwsAttestation.cpp
@@ -5,29 +5,12 @@
 #include "logger/SFLogger.hpp"
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
-#include <algorithm>
-#include <cctype>
-#include <cstdlib>
 #include <sstream>
 #include <string>
 
 namespace Snowflake::Client {
   namespace {
-    // Opt-in env var that switches AWS WIF from the legacy
-    // base64(GetCallerIdentity-presigned-URL) format to a JWT obtained via
-    // STS:GetWebIdentityToken.
-    constexpr const char* AWS_OUTBOUND_TOKEN_ENV_VAR =
-        "SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN";
     constexpr const char* AWS_WIF_SIGNING_ALGORITHM = "ES384";
-
-    bool isAwsOutboundTokenEnabled() {
-      const char* raw = std::getenv(AWS_OUTBOUND_TOKEN_ENV_VAR);
-      if (!raw) return false;
-      std::string s(raw);
-      std::transform(s.begin(), s.end(), s.begin(),
-                     [](unsigned char c) { return std::tolower(c); });
-      return s == "true";
-    }
   }
 
   // STS rejects x-amz-content-sha256 on empty-body requests ("unacceptable headers"),
@@ -122,7 +105,7 @@ namespace Snowflake::Client {
       creds = assumedCredsOpt.get();
     }
 
-    if (isAwsOutboundTokenEnabled()) {
+    if (config.awsUseOutboundToken) {
       CXX_LOG_INFO(
           "Requesting AWS WIF JWT (STS:GetWebIdentityToken) in region %s",
           region.c_str());

--- a/cpp/AwsAttestation.cpp
+++ b/cpp/AwsAttestation.cpp
@@ -1,17 +1,43 @@
 #include "snowflake/AWSUtils.hpp"
 #include "snowflake/WifAttestation.hpp"
+#include <picojson.h>
+#include "util/Base64.hpp"
 #include "logger/SFLogger.hpp"
+#include <aws/core/Aws.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <sstream>
 #include <string>
-#include <vector>
 
 namespace Snowflake::Client {
   namespace {
-    // AWS WIF (SNOW-2919437): the JWT obtained from STS:GetWebIdentityToken is
-    // bound to this audience and signed with this algorithm. GS verifies both
-    // when validating the inbound JWT.
+    // Opt-in env var that switches AWS WIF from the legacy
+    // base64(GetCallerIdentity-presigned-URL) format to a JWT obtained via
+    // STS:GetWebIdentityToken.
+    constexpr const char* AWS_OUTBOUND_TOKEN_ENV_VAR =
+        "SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN";
     constexpr const char* AWS_WIF_SIGNING_ALGORITHM = "ES384";
+
+    bool isAwsOutboundTokenEnabled() {
+      const char* raw = std::getenv(AWS_OUTBOUND_TOKEN_ENV_VAR);
+      if (!raw) return false;
+      std::string s(raw);
+      std::transform(s.begin(), s.end(), s.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      return s == "true";
+    }
   }
+
+  // STS rejects x-amz-content-sha256 on empty-body requests ("unacceptable headers"),
+  // so we subclass AWSAuthV4Signer to suppress that header.
+  class AWS_CORE_API AWSAuthV4SignerNoPayload : public Aws::Client::AWSAuthV4Signer
+  {
+  public:
+    AWSAuthV4SignerNoPayload(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider, const char* serviceName, const Aws::String& region)
+        : AWSAuthV4Signer(credentialsProvider, serviceName, region) { m_includeSha256HashHeader = false; }
+  };
 
   // Splits comma-separated role ARN impersonation path
   std::vector<std::string> parseRoleArnChain(const std::string &path) {
@@ -96,17 +122,54 @@ namespace Snowflake::Client {
       creds = assumedCredsOpt.get();
     }
 
-    CXX_LOG_INFO(
-        "Requesting AWS WIF JWT (STS:GetWebIdentityToken) in region %s",
-        region.c_str());
-    auto jwtOpt = config.awsSdkWrapper->getWebIdentityToken(
-        creds, region, config.getAudience(), AWS_WIF_SIGNING_ALGORITHM, config.getWifHostForAws());
-    if (!jwtOpt) {
-      CXX_LOG_ERROR("Failed to obtain AWS WIF JWT token");
+    if (isAwsOutboundTokenEnabled()) {
+      CXX_LOG_INFO(
+          "Requesting AWS WIF JWT (STS:GetWebIdentityToken) in region %s",
+          region.c_str());
+      auto jwtOpt = config.awsSdkWrapper->getWebIdentityToken(
+          creds, region, config.getAudience(), AWS_WIF_SIGNING_ALGORITHM, config.getWifHostForAws());
+      if (!jwtOpt) {
+        CXX_LOG_ERROR("Failed to obtain AWS WIF JWT token");
+        return boost::none;
+      }
+      const auto &jwt = jwtOpt.get();
+      CXX_LOG_DEBUG("AWS WIF JWT token prefix: %.10s", jwt.c_str());
+      return Attestation::makeAws(jwt);
+    }
+
+    const std::string domain = AwsUtils::getDomainSuffixForRegionalUrl(region);
+    const std::string host = std::string("sts") + "." + region + "." + domain;
+    const std::string url = std::string("https://") + host + "/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    auto request = Aws::Http::CreateHttpRequest(
+      Aws::String(url),
+      Aws::Http::HttpMethod::HTTP_POST,
+      Aws::Utils::Stream::DefaultResponseStreamFactoryMethod
+    );
+
+    request->SetHeaderValue("Host", host);
+    request->SetHeaderValue("X-Snowflake-Audience", config.getAudience());
+
+    auto simpleCredProvider = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(creds);
+    AWSAuthV4SignerNoPayload signer(simpleCredProvider, "sts", region);
+
+    if (!signer.SignRequest(*request)) {
+      CXX_LOG_ERROR("Failed to sign GetCallerIdentity request");
       return boost::none;
     }
-    const auto &jwt = jwtOpt.get();
-    CXX_LOG_DEBUG("AWS WIF JWT token prefix: %.10s", jwt.c_str());
-    return Attestation::makeAws(jwt);
+
+    picojson::object obj;
+    obj["url"] = picojson::value(request->GetURIString());
+    obj["method"] = picojson::value(Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod()));
+    picojson::object headers;
+    for (const auto &h: request->GetHeaders()) {
+      headers[h.first] = picojson::value(h.second);
+    }
+    obj["headers"] = picojson::value(headers);
+    std::string json = picojson::value(obj).serialize(true);
+    std::string base64;
+    Util::Base64::encodePadding(json.begin(), json.end(), std::back_inserter(base64));
+    CXX_LOG_DEBUG("AWS WIF legacy credential prefix: %.10s", base64.c_str());
+    return Attestation::makeAws(base64);
   }
 }

--- a/cpp/WifAttestation.cpp
+++ b/cpp/WifAttestation.cpp
@@ -121,6 +121,8 @@ namespace Snowflake {
             log_debug("Using explicit WIF host: %s", conn->wif_host);
         }
 
+        awsUseOutboundToken = (conn->wif_aws_use_outbound_token == SF_BOOLEAN_TRUE);
+
         return SF_STATUS_SUCCESS;
     }
 

--- a/include/snowflake/WifAttestation.hpp
+++ b/include/snowflake/WifAttestation.hpp
@@ -86,6 +86,10 @@ namespace Client {
 
     boost::optional<std::string> wifHost;
 
+    // When true, AWS WIF uses STS:GetWebIdentityToken (JWT) instead of the
+    // legacy GetCallerIdentity presigned-URL credential format.
+    bool awsUseOutboundToken = false;
+
     SF_STATUS configureWIFAttestation(SF_CONNECT* conn);
 
     std::string getAudience() const {

--- a/include/snowflake/client.h
+++ b/include/snowflake/client.h
@@ -410,6 +410,12 @@ typedef enum SF_ATTRIBUTE {
     *          appended automatically; a full URL is used as-is.
     */
     SF_CON_WIF_HOST,
+    /**
+    * When set to SF_BOOLEAN_TRUE, AWS WIF uses STS:GetWebIdentityToken (JWT).
+    * Defaults to SF_BOOLEAN_FALSE, which uses the GetCallerIdentity
+    * presigned-URL credential format.
+    */
+    SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN,
 } SF_ATTRIBUTE;
 
 /**
@@ -633,6 +639,7 @@ typedef struct SF_CONNECT {
 
     char* wif_audience;
     char* wif_host;
+    sf_bool wif_aws_use_outbound_token;
 } SF_CONNECT;
 
 /**

--- a/lib/client.c
+++ b/lib/client.c
@@ -1274,6 +1274,7 @@ SF_CONNECT *STDCALL snowflake_init() {
         sf->wif_token = NULL;
         sf->wif_azure_resource = NULL;
         sf->wif_audience = NULL;
+        sf->wif_aws_use_outbound_token = SF_BOOLEAN_FALSE;
 
         sf->use_s3_regional_url = SF_BOOLEAN_FALSE;
         sf->put_use_urand_dev = SF_BOOLEAN_FALSE;
@@ -2042,6 +2043,9 @@ SF_STATUS STDCALL snowflake_set_attribute(
         case SF_CON_WIF_HOST:
             alloc_buffer_and_copy(&sf->wif_host, value);
             break;
+        case SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN:
+            sf->wif_aws_use_outbound_token = value ? *((sf_bool*)value) : SF_BOOLEAN_FALSE;
+            break;
         default:
             SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_ATTRIBUTE_TYPE,
                                 "Invalid attribute type",
@@ -2304,6 +2308,9 @@ SF_STATUS STDCALL snowflake_get_attribute(
             break;
         case SF_CON_WIF_HOST:
             *value = sf->wif_host;
+            break;
+        case SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN:
+            *value = &sf->wif_aws_use_outbound_token;
             break;
         default:
             SET_SNOWFLAKE_ERROR(&sf->error, SF_STATUS_ERROR_BAD_ATTRIBUTE_TYPE,

--- a/lib/connection.c
+++ b/lib/connection.c
@@ -1822,6 +1822,13 @@ void handle_single_param(SF_CONNECT* sf, const char* key,const char* value)
     {
         snowflake_set_attribute(sf, SF_CON_WIF_AUDIENCE, value);
     }
+    else if (strcasecmp(key, "WIF_AWS_USE_OUTBOUND_TOKEN") == 0)
+    {
+        if (parse_bool(value, &v))
+        {
+            snowflake_set_attribute(sf, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &v);
+        }
+    }
     else if (strcasecmp(key, "LOG_QUERY_TEXT") == 0)
     {
         if (parse_bool(value, &v))

--- a/tests/test_auth/test_runner.c
+++ b/tests/test_auth/test_runner.c
@@ -12,6 +12,7 @@ extern void test_external_browser_mismatched_username(void **state);
 extern void test_external_browser_wrong_credentials(void **state);
 extern void test_mfa_totp_authentication(void **state);
 extern void test_aws_wif_authentication(void **state);
+extern void test_aws_wif_outbound_jwt_authentication(void **state);
 extern void test_gcp_wif_authentication(void **state);
 extern void test_azure_wif_authentication(void **state);
 extern void test_wif_no_cloud_credentials(void **state);
@@ -42,6 +43,7 @@ int main(void) {
             cmocka_unit_test(test_external_browser_wrong_credentials),
             cmocka_unit_test(test_mfa_totp_authentication),
             cmocka_unit_test(test_aws_wif_authentication),
+            cmocka_unit_test(test_aws_wif_outbound_jwt_authentication),
             cmocka_unit_test(test_gcp_wif_authentication),
             cmocka_unit_test(test_azure_wif_authentication),
             cmocka_unit_test(test_wif_no_cloud_credentials),

--- a/tests/test_auth/test_wif.c
+++ b/tests/test_auth/test_wif.c
@@ -92,6 +92,57 @@ void test_aws_wif_authentication(void **unused) {
     snowflake_term(sf);
 }
 
+void test_aws_wif_outbound_jwt_authentication(void **unused) {
+    SF_UNUSED(unused);
+
+    if (!is_cloud_env(SF_WIF_PROVIDER_AWS)) {
+        fprintf(stderr,
+                "Not running AWS WIF outbound JWT test. "
+                "SNOWFLAKE_WIF_ATTESTATION_TEST_TYPE is not AWS\n");
+        skip();
+        return;
+    }
+
+    fprintf(stderr, "Testing AWS WIF outbound JWT authentication via C API\n");
+
+#ifdef _WIN32
+    _putenv_s("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "true");
+#else
+    setenv("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "true", 1);
+#endif
+
+    SF_CONNECT *sf = snowflake_init();
+    set_all_snowflake_attributes(sf);
+
+    snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_WORKLOAD_IDENTITY);
+    snowflake_set_attribute(sf, SF_CON_WIF_PROVIDER, SF_WIF_PROVIDER_AWS);
+
+    const SF_STATUS status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        dump_error(&(sf->error));
+    }
+
+#ifdef _WIN32
+    _putenv_s("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "");
+#else
+    unsetenv("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN");
+#endif
+
+    assert_int_equal(status, SF_STATUS_SUCCESS);
+
+    fprintf(stderr, "AWS WIF outbound JWT connection successful\n");
+
+    verify_connection_works(sf);
+
+    char *user = get_current_user(sf);
+    fprintf(stderr, "Authenticated as: %s\n", user);
+    assert_non_null(user);
+    assert_true(strlen(user) > 0);
+    free(user);
+
+    snowflake_term(sf);
+}
+
 void test_gcp_wif_authentication(void **unused) {
     SF_UNUSED(unused);
     

--- a/tests/test_auth/test_wif.c
+++ b/tests/test_auth/test_wif.c
@@ -105,28 +105,18 @@ void test_aws_wif_outbound_jwt_authentication(void **unused) {
 
     fprintf(stderr, "Testing AWS WIF outbound JWT authentication via C API\n");
 
-#ifdef _WIN32
-    _putenv_s("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "true");
-#else
-    setenv("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "true", 1);
-#endif
-
     SF_CONNECT *sf = snowflake_init();
     set_all_snowflake_attributes(sf);
 
+    sf_bool use_outbound = SF_BOOLEAN_TRUE;
     snowflake_set_attribute(sf, SF_CON_AUTHENTICATOR, SF_AUTHENTICATOR_WORKLOAD_IDENTITY);
     snowflake_set_attribute(sf, SF_CON_WIF_PROVIDER, SF_WIF_PROVIDER_AWS);
+    snowflake_set_attribute(sf, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &use_outbound);
 
     const SF_STATUS status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
         dump_error(&(sf->error));
     }
-
-#ifdef _WIN32
-    _putenv_s("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "");
-#else
-    unsetenv("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN");
-#endif
 
     assert_int_equal(status, SF_STATUS_SUCCESS);
 

--- a/tests/test_create_wif_attestation.cpp
+++ b/tests/test_create_wif_attestation.cpp
@@ -13,8 +13,9 @@
 #include "snowflake/HttpClient.hpp"
 #include "snowflake/WifAttestation.hpp"
 #include "util/Base64.hpp"
-#include <curl/curl.h>
+#include "../lib/connection.h"
 #include <jwt/Jwt.hpp>
+#include <cstring>
 
 using namespace Snowflake::Client;
 
@@ -120,118 +121,24 @@ const std::string AWS_TEST_REGION = "us-east-1";
 const Aws::Auth::AWSCredentials AWS_TEST_CREDS = Aws::Auth::AWSCredentials("AKIAEXAMPLE12345678",
                                                                            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"); // pragma: allowlist secret
 
-long run_request_curl(
-    const std::string &url,
-    const std::string &method,
-    const std::map<std::string, std::string> &headers) {
-  CURL *curl = curl_easy_init();
-  assert_true(curl != nullptr);
-
-  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());
-
-  const char *ca_bundle = std::getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
-  if (ca_bundle) {
-    curl_easy_setopt(curl, CURLOPT_CAINFO, ca_bundle);
+namespace {
+  boost::optional<std::string> getHeaderIgnoreCase(const picojson::object &headers,
+                                                   const char *name) {
+    for (const auto &header : headers) {
+      if (strcasecmp(header.first.c_str(), name) == 0 &&
+          header.second.is<std::string>()) {
+        return header.second.get<std::string>();
+      }
+    }
+    return boost::none;
   }
-
-  struct curl_slist *header_list = nullptr;
-  for (const auto &h: headers) {
-    std::string hdr = h.first + ": " + h.second;
-    header_list = curl_slist_append(header_list, hdr.c_str());
-  }
-  if (header_list) {
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
-  }
-
-  CURLcode res = curl_easy_perform(curl);
-  long response_code = 0;
-  if (res == CURLE_OK) {
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-  }
-
-  if (header_list) {
-    curl_slist_free_all(header_list);
-  }
-  curl_easy_cleanup(curl);
-  return response_code;
-}
-
-// Integration test: requires real AWS credentials in the environment.
-// Exercises the legacy GetCallerIdentity presigned-URL path end-to-end.
-void test_integration_aws_attestation(void **) {
-  if (std::getenv("GITHUB_ACTIONS")) {
-    std::cerr << "Skipping test_integration_aws_attestation on GitHub Actions since it requires AWS credentials" << std::endl;
-    return;
-  }
-
-  AttestationConfig config;
-  config.type = AttestationType::AWS;
-  auto attestationOpt = Snowflake::Client::createAttestation(config);
-  assert_true(attestationOpt.has_value());
-  auto &attestation = attestationOpt.value();
-  assert_true(attestation.type == Snowflake::Client::AttestationType::AWS);
-  assert_false(attestation.credential.empty());
-  std::string json_string;
-  Snowflake::Client::Util::Base64::decodePadding(attestation.credential.begin(), attestation.credential.end(),
-                                                 std::back_inserter(json_string));
-  picojson::value json;
-  picojson::parse(json, json_string);
-  assert_true(json.is<picojson::object>());
-  assert_true(json.get("url").is<std::string>());
-  assert_true(json.get("method").is<std::string>());
-  std::string method = json.get("method").get<std::string>();
-  assert_true(json.get("headers").is<picojson::object>());
-  std::map<std::string, std::string> headers;
-  for (auto &header: json.get("headers").get<picojson::object>()) {
-    assert_true(header.second.is<std::string>());
-    headers[header.first] = header.second.get<std::string>();
-  }
-  assert_true(
-      run_request_curl(json.get("url").get<std::string>(), method, headers) ==
-      200
-  );
 }
 
 // Helper used by legacy-path unit tests: decodes the base64(JSON) credential
-// and asserts it contains the expected STS regional host.
-void test_attestation_success(const char *region, const char *expectedHost) {
-  AttestationConfig config;
-  config.type = AttestationType::AWS;
-  auto awsSdkWrapper = FakeAwsSdkWrapper(std::string(region), AWS_TEST_CREDS);
-  config.awsSdkWrapper = &awsSdkWrapper;
-
-  auto attestationOpt = Snowflake::Client::createAttestation(config);
-  assert_true(attestationOpt.has_value());
-  auto &attestation = attestationOpt.value();
-  assert_true(attestation.type == Snowflake::Client::AttestationType::AWS);
-  assert_true(!attestation.credential.empty());
-  assert_true(!attestation.subject);
-  assert_true(!attestation.issuer);
-
-  std::string json_string;
-  Snowflake::Client::Util::Base64::decodePadding(attestation.credential.begin(), attestation.credential.end(),
-                                                 std::back_inserter(json_string));
-  picojson::value json;
-  picojson::parse(json, json_string);
-  assert_true(json.is<picojson::object>());
-
-  auto headers = json.get("headers").get<picojson::object>();
-  auto host = headers["host"].get<std::string>();
-  assert_true(host == expectedHost);
-}
-
-void test_unit_aws_attestation_success(void **) {
-  test_attestation_success("us-east-1", "sts.us-east-1.amazonaws.com");
-}
-
-void test_unit_aws_attestation_china_region_success(void **) {
-  test_attestation_success("cn-northwest-1", "sts.cn-northwest-1.amazonaws.com.cn");
-}
-
-// Helper: assert the attestation used the legacy base64(JSON) path.
+// and asserts the signed GetCallerIdentity request shape.
 void assertAwsLegacyPresignedAttestation(const boost::optional<Attestation> &attestationOpt,
-                                         const std::string &expectedHost) {
+                                         const std::string &expectedHost,
+                                         const std::string &expectedAudience = SF_SNOWFLAKE_WIF_AUDIENCE) {
   assert_true(attestationOpt.has_value());
   const auto &attestation = attestationOpt.get();
   assert_true(attestation.type == AttestationType::AWS);
@@ -244,8 +151,51 @@ void assertAwsLegacyPresignedAttestation(const boost::optional<Attestation> &att
   picojson::value json;
   picojson::parse(json, json_string);
   assert_true(json.is<picojson::object>());
-  auto headers = json.get("headers").get<picojson::object>();
-  assert_true(headers["host"].get<std::string>() == expectedHost);
+
+  assert_true(json.get("method").is<std::string>());
+  assert_string_equal(json.get("method").get<std::string>().c_str(), "POST");
+
+  assert_true(json.get("url").is<std::string>());
+  const std::string url = json.get("url").get<std::string>();
+  assert_true(url.find("https://" + expectedHost) == 0);
+  assert_true(url.find("Action=GetCallerIdentity") != std::string::npos);
+  assert_true(url.find("Version=2011-06-15") != std::string::npos);
+
+  assert_true(json.get("headers").is<picojson::object>());
+  const auto headers = json.get("headers").get<picojson::object>();
+
+  const auto host = getHeaderIgnoreCase(headers, "host");
+  assert_true(host.has_value());
+  assert_string_equal(host.get().c_str(), expectedHost.c_str());
+
+  const auto audience = getHeaderIgnoreCase(headers, "X-Snowflake-Audience");
+  assert_true(audience.has_value());
+  assert_string_equal(audience.get().c_str(), expectedAudience.c_str());
+
+  const auto authorization = getHeaderIgnoreCase(headers, "Authorization");
+  assert_true(authorization.has_value());
+  assert_true(!authorization.get().empty());
+}
+
+void test_attestation_success(const char *region, const char *expectedHost) {
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  auto awsSdkWrapper = FakeAwsSdkWrapper(std::string(region), AWS_TEST_CREDS);
+  config.awsSdkWrapper = &awsSdkWrapper;
+
+  const auto attestationOpt = Snowflake::Client::createAttestation(config);
+  assert_true(attestationOpt.has_value());
+  assert_true(!attestationOpt.get().subject);
+  assert_true(!attestationOpt.get().issuer);
+  assertAwsLegacyPresignedAttestation(attestationOpt, expectedHost);
+}
+
+void test_unit_aws_attestation_success(void **) {
+  test_attestation_success("us-east-1", "sts.us-east-1.amazonaws.com");
+}
+
+void test_unit_aws_attestation_china_region_success(void **) {
+  test_attestation_success("cn-northwest-1", "sts.cn-northwest-1.amazonaws.com.cn");
 }
 
 void test_unit_aws_attestation_failed(FakeAwsSdkWrapper *awsSdkWrapper) {
@@ -549,6 +499,51 @@ void test_unit_aws_attestation_impersonation_empty_path_fallback(void **) {
 
   assert_int_equal(awsSdkWrapper.assumeRoleCallCount, 0);
   // Legacy path must NOT call getWebIdentityToken.
+  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
+}
+
+// Empty impersonation path with JWT enabled: no assumeRole, initial creds reach
+// getWebIdentityToken unchanged.
+void test_unit_aws_attestation_impersonation_empty_path_jwt(void **) {
+  auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
+  awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
+
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = true;
+  config.workloadIdentityImpersonationPath = std::string("");
+
+  const auto attestationOpt = createAttestation(config);
+  assert_true(attestationOpt.has_value());
+  assert_true(attestationOpt.get().credential == FAKE_WEB_IDENTITY_TOKEN);
+
+  assert_int_equal(awsSdkWrapper.assumeRoleCallCount, 0);
+  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 1);
+  assert_string_equal(
+      awsSdkWrapper.lastGetWebIdentityTokenCreds.GetAWSAccessKeyId().c_str(),
+      AWS_TEST_CREDS.GetAWSAccessKeyId().c_str());
+}
+
+// Legacy path with impersonation: assumeRole runs, then a base64 GetCallerIdentity
+// credential is produced (no getWebIdentityToken).
+void test_unit_aws_attestation_legacy_with_impersonation(void **) {
+  auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
+  const std::string roleArn = "arn:aws:iam::123456789012:role/TestRole";
+  const Aws::Auth::AWSCredentials assumedCreds(
+      "ASSUMED_ACCESS_KEY", "ASSUMED_SECRET_KEY", "ASSUMED_SESSION_TOKEN");
+  awsSdkWrapper.assumeRoleResults[roleArn] = assumedCreds;
+
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  config.awsSdkWrapper = &awsSdkWrapper;
+  config.workloadIdentityImpersonationPath = roleArn;
+
+  const auto attestationOpt = createAttestation(config);
+  assertAwsLegacyPresignedAttestation(attestationOpt, "sts." + AWS_TEST_REGION + ".amazonaws.com");
+
+  assert_int_equal(awsSdkWrapper.assumeRoleCallCount, 1);
+  assert_string_equal(awsSdkWrapper.assumeRoleArns[0].c_str(), roleArn.c_str());
   assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
 }
 
@@ -1372,13 +1367,46 @@ void test_unit_wif_attestation_config(void**)
     assert_int_equal(config.configureWIFAttestation(conn), SF_STATUS_SUCCESS);
     assert_true(config.awsUseOutboundToken);
 
+    void *value = NULL;
+    assert_int_equal(
+        snowflake_get_attribute(conn, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &value),
+        SF_STATUS_SUCCESS);
+    assert_true(*((sf_bool *) value) == SF_BOOLEAN_TRUE);
+
     // Set back to false and verify.
     sf_bool use_outbound_false = SF_BOOLEAN_FALSE;
     snowflake_set_attribute(conn, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &use_outbound_false);
     assert_int_equal(config.configureWIFAttestation(conn), SF_STATUS_SUCCESS);
     assert_false(config.awsUseOutboundToken);
 
+    value = NULL;
+    assert_int_equal(
+        snowflake_get_attribute(conn, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &value),
+        SF_STATUS_SUCCESS);
+    assert_true(*((sf_bool *) value) == SF_BOOLEAN_FALSE);
+
     snowflake_term(conn);
+}
+
+void test_unit_wif_aws_use_outbound_token_connection_string(void **) {
+  SF_CONNECT *conn = snowflake_init();
+
+  handle_single_param(conn, "WIF_AWS_USE_OUTBOUND_TOKEN", "true");
+
+  void *value = NULL;
+  assert_int_equal(
+      snowflake_get_attribute(conn, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &value),
+      SF_STATUS_SUCCESS);
+  assert_true(*((sf_bool *) value) == SF_BOOLEAN_TRUE);
+
+  handle_single_param(conn, "WIF_AWS_USE_OUTBOUND_TOKEN", "false");
+  value = NULL;
+  assert_int_equal(
+      snowflake_get_attribute(conn, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &value),
+      SF_STATUS_SUCCESS);
+  assert_true(*((sf_bool *) value) == SF_BOOLEAN_FALSE);
+
+  snowflake_term(conn);
 }
 
 void test_unit_wif_host_normalization(void**) {
@@ -1420,6 +1448,8 @@ int main() {
       cmocka_unit_test(test_unit_aws_attestation_jwt_impersonation_failure),
       cmocka_unit_test(test_unit_aws_attestation_impersonation_whitespace_trimming),
       cmocka_unit_test(test_unit_aws_attestation_impersonation_empty_path_fallback),
+      cmocka_unit_test(test_unit_aws_attestation_impersonation_empty_path_jwt),
+      cmocka_unit_test(test_unit_aws_attestation_legacy_with_impersonation),
       cmocka_unit_test(test_unit_aws_attestation_impersonation_with_missing_region),
       cmocka_unit_test(test_unit_aws_attestation_impersonation_with_missing_credentials),
       cmocka_unit_test(test_unit_gcp_attestation_success),
@@ -1449,6 +1479,7 @@ int main() {
       cmocka_unit_test(test_unit_oidc_attestation_success),
       cmocka_unit_test(test_unit_oidc_attestation_missing_token),
       cmocka_unit_test(test_unit_wif_attestation_config),
+      cmocka_unit_test(test_unit_wif_aws_use_outbound_token_connection_string),
       cmocka_unit_test(test_unit_wif_host_normalization),
   };
 

--- a/tests/test_create_wif_attestation.cpp
+++ b/tests/test_create_wif_attestation.cpp
@@ -19,6 +19,10 @@
 
 using namespace Snowflake::Client;
 
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#endif
+
 namespace {
   EVP_PKEY *generate_key() {
     EVP_PKEY *key = nullptr;

--- a/tests/test_create_wif_attestation.cpp
+++ b/tests/test_create_wif_attestation.cpp
@@ -12,6 +12,8 @@
 #include "snowflake/AWSUtils.hpp"
 #include "snowflake/HttpClient.hpp"
 #include "snowflake/WifAttestation.hpp"
+#include "util/Base64.hpp"
+#include <curl/curl.h>
 #include <jwt/Jwt.hpp>
 
 using namespace Snowflake::Client;
@@ -118,6 +120,136 @@ const std::string AWS_TEST_REGION = "us-east-1";
 const Aws::Auth::AWSCredentials AWS_TEST_CREDS = Aws::Auth::AWSCredentials("AKIAEXAMPLE12345678",
                                                                            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"); // pragma: allowlist secret
 
+const std::string AWS_OUTBOUND_TOKEN_ENV = "SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN";
+
+long run_request_curl(
+    const std::string &url,
+    const std::string &method,
+    const std::map<std::string, std::string> &headers) {
+  CURL *curl = curl_easy_init();
+  assert_true(curl != nullptr);
+
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());
+
+  const char *ca_bundle = std::getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+  if (ca_bundle) {
+    curl_easy_setopt(curl, CURLOPT_CAINFO, ca_bundle);
+  }
+
+  struct curl_slist *header_list = nullptr;
+  for (const auto &h: headers) {
+    std::string hdr = h.first + ": " + h.second;
+    header_list = curl_slist_append(header_list, hdr.c_str());
+  }
+  if (header_list) {
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+  }
+
+  CURLcode res = curl_easy_perform(curl);
+  long response_code = 0;
+  if (res == CURLE_OK) {
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+  }
+
+  if (header_list) {
+    curl_slist_free_all(header_list);
+  }
+  curl_easy_cleanup(curl);
+  return response_code;
+}
+
+// Integration test: requires real AWS credentials in the environment.
+// Exercises the legacy GetCallerIdentity presigned-URL path end-to-end.
+void test_integration_aws_attestation(void **) {
+  if (std::getenv("GITHUB_ACTIONS")) {
+    std::cerr << "Skipping test_integration_aws_attestation on GitHub Actions since it requires AWS credentials" << std::endl;
+    return;
+  }
+
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  auto attestationOpt = Snowflake::Client::createAttestation(config);
+  assert_true(attestationOpt.has_value());
+  auto &attestation = attestationOpt.value();
+  assert_true(attestation.type == Snowflake::Client::AttestationType::AWS);
+  assert_false(attestation.credential.empty());
+  std::string json_string;
+  Snowflake::Client::Util::Base64::decodePadding(attestation.credential.begin(), attestation.credential.end(),
+                                                 std::back_inserter(json_string));
+  picojson::value json;
+  picojson::parse(json, json_string);
+  assert_true(json.is<picojson::object>());
+  assert_true(json.get("url").is<std::string>());
+  assert_true(json.get("method").is<std::string>());
+  std::string method = json.get("method").get<std::string>();
+  assert_true(json.get("headers").is<picojson::object>());
+  std::map<std::string, std::string> headers;
+  for (auto &header: json.get("headers").get<picojson::object>()) {
+    assert_true(header.second.is<std::string>());
+    headers[header.first] = header.second.get<std::string>();
+  }
+  assert_true(
+      run_request_curl(json.get("url").get<std::string>(), method, headers) ==
+      200
+  );
+}
+
+// Helper used by legacy-path unit tests: decodes the base64(JSON) credential
+// and asserts it contains the expected STS regional host.
+void test_attestation_success(const char *region, const char *expectedHost) {
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  auto awsSdkWrapper = FakeAwsSdkWrapper(std::string(region), AWS_TEST_CREDS);
+  config.awsSdkWrapper = &awsSdkWrapper;
+
+  auto attestationOpt = Snowflake::Client::createAttestation(config);
+  assert_true(attestationOpt.has_value());
+  auto &attestation = attestationOpt.value();
+  assert_true(attestation.type == Snowflake::Client::AttestationType::AWS);
+  assert_true(!attestation.credential.empty());
+  assert_true(!attestation.subject);
+  assert_true(!attestation.issuer);
+
+  std::string json_string;
+  Snowflake::Client::Util::Base64::decodePadding(attestation.credential.begin(), attestation.credential.end(),
+                                                 std::back_inserter(json_string));
+  picojson::value json;
+  picojson::parse(json, json_string);
+  assert_true(json.is<picojson::object>());
+
+  auto headers = json.get("headers").get<picojson::object>();
+  auto host = headers["host"].get<std::string>();
+  assert_true(host == expectedHost);
+}
+
+void test_unit_aws_attestation_success(void **) {
+  test_attestation_success("us-east-1", "sts.us-east-1.amazonaws.com");
+}
+
+void test_unit_aws_attestation_china_region_success(void **) {
+  test_attestation_success("cn-northwest-1", "sts.cn-northwest-1.amazonaws.com.cn");
+}
+
+// Helper: assert the attestation used the legacy base64(JSON) path.
+void assertAwsLegacyPresignedAttestation(const boost::optional<Attestation> &attestationOpt,
+                                         const std::string &expectedHost) {
+  assert_true(attestationOpt.has_value());
+  const auto &attestation = attestationOpt.get();
+  assert_true(attestation.type == AttestationType::AWS);
+  assert_true(!attestation.credential.empty());
+
+  std::string json_string;
+  Snowflake::Client::Util::Base64::decodePadding(
+      attestation.credential.begin(), attestation.credential.end(),
+      std::back_inserter(json_string));
+  picojson::value json;
+  picojson::parse(json, json_string);
+  assert_true(json.is<picojson::object>());
+  auto headers = json.get("headers").get<picojson::object>();
+  assert_true(headers["host"].get<std::string>() == expectedHost);
+}
+
 void test_unit_aws_attestation_failed(FakeAwsSdkWrapper *awsSdkWrapper) {
   AttestationConfig config;
   config.type = AttestationType::AWS;
@@ -139,7 +271,54 @@ void test_unit_aws_attestation_cred_missing(void **) {
 
 const std::string FAKE_WEB_IDENTITY_TOKEN = "fake.jwt.token-for-testing-only";
 
+// env=false → legacy path; getWebIdentityToken must NOT be called.
+void test_unit_aws_attestation_outbound_jwt_env_false(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "false");
+  auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
+  awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
+
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  config.awsSdkWrapper = &awsSdkWrapper;
+
+  const auto attestationOpt = createAttestation(config);
+  assertAwsLegacyPresignedAttestation(attestationOpt, "sts." + AWS_TEST_REGION + ".amazonaws.com");
+  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
+}
+
+// env unset (absent) → legacy path; getWebIdentityToken must NOT be called.
+void test_unit_aws_attestation_outbound_jwt_env_unset(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, boost::none);
+  auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
+  awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
+
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  config.awsSdkWrapper = &awsSdkWrapper;
+
+  const auto attestationOpt = createAttestation(config);
+  assertAwsLegacyPresignedAttestation(attestationOpt, "sts." + AWS_TEST_REGION + ".amazonaws.com");
+  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
+}
+
+// env value is case-insensitive: "TRUE" must activate the JWT path.
+void test_unit_aws_attestation_outbound_jwt_case_insensitive(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "TRUE");
+  auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
+  awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
+
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  config.awsSdkWrapper = &awsSdkWrapper;
+
+  const auto attestationOpt = createAttestation(config);
+  assert_true(attestationOpt.has_value());
+  assert_true(attestationOpt.get().credential == FAKE_WEB_IDENTITY_TOKEN);
+  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 1);
+}
+
 void test_unit_aws_attestation_jwt_success(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
@@ -172,6 +351,7 @@ void test_unit_aws_attestation_jwt_success(void **) {
 }
 
 void test_unit_aws_attestation_jwt_success_with_custom_wif_config(void**) {
+    EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
     auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
     awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
@@ -210,6 +390,7 @@ void test_unit_aws_attestation_jwt_success_with_custom_wif_config(void**) {
 // SF_CON_WIF_HOST may also be supplied as a full URL (GCP's native format);
 // AWS must still extract the bare host from it.
 void test_unit_aws_attestation_jwt_success_with_full_url_wif_host(void**) {
+    EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
     auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
     awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
@@ -226,6 +407,7 @@ void test_unit_aws_attestation_jwt_success_with_full_url_wif_host(void**) {
 }
 
 void test_unit_aws_attestation_jwt_sdk_failure(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   // STS call returns no token (e.g. HTTP error, malformed response).
   awsSdkWrapper.webIdentityTokenResult = boost::none;
@@ -244,6 +426,7 @@ void test_unit_aws_attestation_jwt_sdk_failure(void **) {
 // getWebIdentityToken. Otherwise we'd bypass impersonation and use the
 // initial creds for the JWT — a security bug.
 void test_unit_aws_attestation_jwt_with_impersonation(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   const std::string roleArn = "arn:aws:iam::123456789012:role/TestRole";
   const Aws::Auth::AWSCredentials assumedCreds(
@@ -284,6 +467,7 @@ void test_unit_aws_attestation_jwt_with_impersonation(void **) {
 // Chain variant: each step's output feeds the next step's input, and the
 // final step's output is what reaches getWebIdentityToken.
 void test_unit_aws_attestation_jwt_with_impersonation_chain(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   const std::string arn1 = "arn:aws:iam::111111111111:role/Role1";
   const std::string arn2 = "arn:aws:iam::222222222222:role/Role2";
@@ -323,6 +507,7 @@ void test_unit_aws_attestation_jwt_with_impersonation_chain(void **) {
 // fetched and the attestation fails — we never silently fall back to the
 // initial creds.
 void test_unit_aws_attestation_jwt_impersonation_failure(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   // No entry in assumeRoleResults -> assumeRole returns boost::none.
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
@@ -343,6 +528,7 @@ void test_unit_aws_attestation_jwt_impersonation_failure(void **) {
 // chaining, cross-account ARNs, and end-to-end success / failure paths; this
 // one only verifies the trimming property.
 void test_unit_aws_attestation_impersonation_whitespace_trimming(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   const std::string arn1 = "arn:aws:iam::123456789012:role/Role1";
   const std::string arn2 = "arn:aws:iam::123456789012:role/Role2";
@@ -364,9 +550,10 @@ void test_unit_aws_attestation_impersonation_whitespace_trimming(void **) {
 }
 
 // An empty impersonation path is treated as "no impersonation": no
-// assumeRole calls, and getWebIdentityToken receives the initial creds
-// unchanged.
+// assumeRole calls are made. Without SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN,
+// the default legacy path is taken (base64 presigned GetCallerIdentity).
 void test_unit_aws_attestation_impersonation_empty_path_fallback(void **) {
+  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, boost::none);
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
@@ -376,14 +563,11 @@ void test_unit_aws_attestation_impersonation_empty_path_fallback(void **) {
   config.workloadIdentityImpersonationPath = std::string("");
 
   auto attestationOpt = createAttestation(config);
-  assert_true(attestationOpt.has_value());
-  assert_true(attestationOpt.get().type == AttestationType::AWS);
+  assertAwsLegacyPresignedAttestation(attestationOpt, "sts." + AWS_TEST_REGION + ".amazonaws.com");
 
   assert_int_equal(awsSdkWrapper.assumeRoleCallCount, 0);
-  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 1);
-  assert_string_equal(
-      awsSdkWrapper.lastGetWebIdentityTokenCreds.GetAWSAccessKeyId().c_str(),
-      AWS_TEST_CREDS.GetAWSAccessKeyId().c_str());
+  // Legacy path must NOT call getWebIdentityToken.
+  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
 }
 
 void test_unit_aws_attestation_impersonation_with_missing_region(void **) {
@@ -1225,8 +1409,13 @@ void test_unit_wif_host_normalization(void**) {
 
 int main() {
   const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_unit_aws_attestation_success),
+      cmocka_unit_test(test_unit_aws_attestation_china_region_success),
       cmocka_unit_test(test_unit_aws_attestation_region_missing),
       cmocka_unit_test(test_unit_aws_attestation_cred_missing),
+      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_env_false),
+      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_env_unset),
+      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_case_insensitive),
       cmocka_unit_test(test_unit_aws_attestation_jwt_success),
       cmocka_unit_test(test_unit_aws_attestation_jwt_success_with_custom_wif_config),
       cmocka_unit_test(test_unit_aws_attestation_jwt_success_with_full_url_wif_host),

--- a/tests/test_create_wif_attestation.cpp
+++ b/tests/test_create_wif_attestation.cpp
@@ -120,8 +120,6 @@ const std::string AWS_TEST_REGION = "us-east-1";
 const Aws::Auth::AWSCredentials AWS_TEST_CREDS = Aws::Auth::AWSCredentials("AKIAEXAMPLE12345678",
                                                                            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"); // pragma: allowlist secret
 
-const std::string AWS_OUTBOUND_TOKEN_ENV = "SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN";
-
 long run_request_curl(
     const std::string &url,
     const std::string &method,
@@ -271,60 +269,44 @@ void test_unit_aws_attestation_cred_missing(void **) {
 
 const std::string FAKE_WEB_IDENTITY_TOKEN = "fake.jwt.token-for-testing-only";
 
-// env=false → legacy path; getWebIdentityToken must NOT be called.
-void test_unit_aws_attestation_outbound_jwt_env_false(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "false");
+// awsUseOutboundToken=false (explicit) → getWebIdentityToken must NOT be called.
+void test_unit_aws_attestation_outbound_jwt_disabled(void **) {
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = false;
 
   const auto attestationOpt = createAttestation(config);
   assertAwsLegacyPresignedAttestation(attestationOpt, "sts." + AWS_TEST_REGION + ".amazonaws.com");
   assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
 }
 
-// env unset (absent) → legacy path; getWebIdentityToken must NOT be called.
-void test_unit_aws_attestation_outbound_jwt_env_unset(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, boost::none);
+// awsUseOutboundToken defaults to false → getWebIdentityToken must NOT be called.
+void test_unit_aws_attestation_outbound_jwt_default(void **) {
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  // awsUseOutboundToken is false by default - no explicit set.
 
   const auto attestationOpt = createAttestation(config);
   assertAwsLegacyPresignedAttestation(attestationOpt, "sts." + AWS_TEST_REGION + ".amazonaws.com");
   assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
-}
-
-// env value is case-insensitive: "TRUE" must activate the JWT path.
-void test_unit_aws_attestation_outbound_jwt_case_insensitive(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "TRUE");
-  auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
-  awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
-
-  AttestationConfig config;
-  config.type = AttestationType::AWS;
-  config.awsSdkWrapper = &awsSdkWrapper;
-
-  const auto attestationOpt = createAttestation(config);
-  assert_true(attestationOpt.has_value());
-  assert_true(attestationOpt.get().credential == FAKE_WEB_IDENTITY_TOKEN);
-  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 1);
 }
 
 void test_unit_aws_attestation_jwt_success(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = true;
 
   const auto attestationOpt = createAttestation(config);
   assert_true(attestationOpt.has_value());
@@ -351,13 +333,13 @@ void test_unit_aws_attestation_jwt_success(void **) {
 }
 
 void test_unit_aws_attestation_jwt_success_with_custom_wif_config(void**) {
-    EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
     auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
     awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
     AttestationConfig config;
     config.type = AttestationType::AWS;
     config.awsSdkWrapper = &awsSdkWrapper;
+    config.awsUseOutboundToken = true;
     config.audience = "custom-audience-for-testing";
     config.wifHost = "custom-wif-host-for-testing";
 
@@ -390,13 +372,13 @@ void test_unit_aws_attestation_jwt_success_with_custom_wif_config(void**) {
 // SF_CON_WIF_HOST may also be supplied as a full URL (GCP's native format);
 // AWS must still extract the bare host from it.
 void test_unit_aws_attestation_jwt_success_with_full_url_wif_host(void**) {
-    EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
     auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
     awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
     AttestationConfig config;
     config.type = AttestationType::AWS;
     config.awsSdkWrapper = &awsSdkWrapper;
+    config.awsUseOutboundToken = true;
     config.wifHost = "https://sts.custom.example.com/";
 
     const auto attestationOpt = createAttestation(config);
@@ -407,7 +389,6 @@ void test_unit_aws_attestation_jwt_success_with_full_url_wif_host(void**) {
 }
 
 void test_unit_aws_attestation_jwt_sdk_failure(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   // STS call returns no token (e.g. HTTP error, malformed response).
   awsSdkWrapper.webIdentityTokenResult = boost::none;
@@ -415,6 +396,7 @@ void test_unit_aws_attestation_jwt_sdk_failure(void **) {
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = true;
 
   const auto attestationOpt = createAttestation(config);
   // Must fail closed: no silent fallback to a different credential format.
@@ -426,7 +408,6 @@ void test_unit_aws_attestation_jwt_sdk_failure(void **) {
 // getWebIdentityToken. Otherwise we'd bypass impersonation and use the
 // initial creds for the JWT — a security bug.
 void test_unit_aws_attestation_jwt_with_impersonation(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   const std::string roleArn = "arn:aws:iam::123456789012:role/TestRole";
   const Aws::Auth::AWSCredentials assumedCreds(
@@ -437,6 +418,7 @@ void test_unit_aws_attestation_jwt_with_impersonation(void **) {
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = true;
   config.workloadIdentityImpersonationPath = roleArn;
 
   const auto attestationOpt = createAttestation(config);
@@ -467,7 +449,6 @@ void test_unit_aws_attestation_jwt_with_impersonation(void **) {
 // Chain variant: each step's output feeds the next step's input, and the
 // final step's output is what reaches getWebIdentityToken.
 void test_unit_aws_attestation_jwt_with_impersonation_chain(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   const std::string arn1 = "arn:aws:iam::111111111111:role/Role1";
   const std::string arn2 = "arn:aws:iam::222222222222:role/Role2";
@@ -480,6 +461,7 @@ void test_unit_aws_attestation_jwt_with_impersonation_chain(void **) {
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = true;
   config.workloadIdentityImpersonationPath = arn1 + "," + arn2;
 
   const auto attestationOpt = createAttestation(config);
@@ -507,7 +489,6 @@ void test_unit_aws_attestation_jwt_with_impersonation_chain(void **) {
 // fetched and the attestation fails — we never silently fall back to the
 // initial creds.
 void test_unit_aws_attestation_jwt_impersonation_failure(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   // No entry in assumeRoleResults -> assumeRole returns boost::none.
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
@@ -515,6 +496,7 @@ void test_unit_aws_attestation_jwt_impersonation_failure(void **) {
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = true;
   config.workloadIdentityImpersonationPath = "arn:aws:iam::123456789012:role/TestRole";
 
   const auto attestationOpt = createAttestation(config);
@@ -528,7 +510,6 @@ void test_unit_aws_attestation_jwt_impersonation_failure(void **) {
 // chaining, cross-account ARNs, and end-to-end success / failure paths; this
 // one only verifies the trimming property.
 void test_unit_aws_attestation_impersonation_whitespace_trimming(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, "true");
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   const std::string arn1 = "arn:aws:iam::123456789012:role/Role1";
   const std::string arn2 = "arn:aws:iam::123456789012:role/Role2";
@@ -539,6 +520,7 @@ void test_unit_aws_attestation_impersonation_whitespace_trimming(void **) {
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  config.awsUseOutboundToken = true;
   config.workloadIdentityImpersonationPath = "  " + arn1 + "  , " + arn2 + " ";
 
   const auto attestationOpt = createAttestation(config);
@@ -550,16 +532,16 @@ void test_unit_aws_attestation_impersonation_whitespace_trimming(void **) {
 }
 
 // An empty impersonation path is treated as "no impersonation": no
-// assumeRole calls are made. Without SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN,
-// the default legacy path is taken (base64 presigned GetCallerIdentity).
+// assumeRole calls are made. With awsUseOutboundToken=false (default),
+// the legacy path is taken (base64 presigned GetCallerIdentity).
 void test_unit_aws_attestation_impersonation_empty_path_fallback(void **) {
-  EnvOverride envOverride(AWS_OUTBOUND_TOKEN_ENV, boost::none);
   auto awsSdkWrapper = FakeAwsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
   awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
 
   AttestationConfig config;
   config.type = AttestationType::AWS;
   config.awsSdkWrapper = &awsSdkWrapper;
+  // awsUseOutboundToken defaults to false → legacy path
   config.workloadIdentityImpersonationPath = std::string("");
 
   auto attestationOpt = createAttestation(config);
@@ -1382,6 +1364,20 @@ void test_unit_wif_attestation_config(void**)
     assert_string_equal(config.snowflakeEntraResource.get().c_str(), "dummy_resource");
     assert_string_equal(config.getWifHost().c_str(), "dummy_host");
 
+    // Verify awsUseOutboundToken is plumbed: default is false, set to true.
+    assert_false(config.awsUseOutboundToken);
+    sf_bool use_outbound = SF_BOOLEAN_TRUE;
+    snowflake_set_attribute(conn, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &use_outbound);
+    snowflake_set_attribute(conn, SF_CON_WIF_PROVIDER, "AWS");
+    assert_int_equal(config.configureWIFAttestation(conn), SF_STATUS_SUCCESS);
+    assert_true(config.awsUseOutboundToken);
+
+    // Set back to false and verify.
+    sf_bool use_outbound_false = SF_BOOLEAN_FALSE;
+    snowflake_set_attribute(conn, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &use_outbound_false);
+    assert_int_equal(config.configureWIFAttestation(conn), SF_STATUS_SUCCESS);
+    assert_false(config.awsUseOutboundToken);
+
     snowflake_term(conn);
 }
 
@@ -1413,9 +1409,8 @@ int main() {
       cmocka_unit_test(test_unit_aws_attestation_china_region_success),
       cmocka_unit_test(test_unit_aws_attestation_region_missing),
       cmocka_unit_test(test_unit_aws_attestation_cred_missing),
-      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_env_false),
-      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_env_unset),
-      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_case_insensitive),
+      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_disabled),
+      cmocka_unit_test(test_unit_aws_attestation_outbound_jwt_default),
       cmocka_unit_test(test_unit_aws_attestation_jwt_success),
       cmocka_unit_test(test_unit_aws_attestation_jwt_success_with_custom_wif_config),
       cmocka_unit_test(test_unit_aws_attestation_jwt_success_with_full_url_wif_host),

--- a/tests/test_manual_wif.cpp
+++ b/tests/test_manual_wif.cpp
@@ -1,19 +1,93 @@
 #include <cstring>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <openssl/rsa.h>
+#include <picojson.h>
+#include <curl/curl.h>
 #include "utils/test_setup.h"
 #include "utils/TestSetup.hpp"
 #include "snowflake/WifAttestation.hpp"
+#include "util/Base64.hpp"
 
 using namespace Snowflake::Client;
 
-// AWS attestation is exercised end-to-end through snowflake_connect() in
-// tests/test_auth/test_wif.c::test_aws_wif_authentication (gated on the same
-// SNOWFLAKE_WIF_ATTESTATION_TEST_TYPE=AWS env var). The credential format is
-// now a raw JWT, so the legacy "base64-decode + re-POST" reconstruction
-// pattern below no longer applies; the auth-suite cloud test is the canonical
-// AWS WIF runtime check.
+static long run_request_curl(
+    const std::string& url,
+    const std::string& method,
+    const std::map<std::string, std::string>& headers)
+{
+  CURL* curl = curl_easy_init();
+  assert_true(curl != nullptr);
+
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());
+
+  const char* ca_bundle = std::getenv("SNOWFLAKE_TEST_CA_BUNDLE_FILE");
+  if (ca_bundle) {
+    curl_easy_setopt(curl, CURLOPT_CAINFO, ca_bundle);
+  }
+
+  struct curl_slist* header_list = nullptr;
+  for (const auto& h : headers) {
+    std::string hdr = h.first + ": " + h.second;
+    header_list = curl_slist_append(header_list, hdr.c_str());
+  }
+  if (header_list) {
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+  }
+
+  CURLcode res = curl_easy_perform(curl);
+  long response_code = 0;
+  if (res == CURLE_OK) {
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+  }
+
+  if (header_list) {
+    curl_slist_free_all(header_list);
+  }
+  curl_easy_cleanup(curl);
+  return response_code;
+}
+
+// Manual AWS WIF attestation test: exercises the default legacy path
+// (base64-encoded GetCallerIdentity presigned URL). Requires real AWS
+// credentials; gated on SNOWFLAKE_WIF_ATTESTATION_TEST_TYPE=AWS.
+void test_aws_attestation(void**)
+{
+  auto type = std::getenv("SNOWFLAKE_WIF_ATTESTATION_TEST_TYPE");
+  if (!type || strcmp(type, "AWS") != 0) {
+    std::cerr << "Not running AWS attestation test. SNOWFLAKE_WIF_ATTESTATION_TEST_TYPE is not AWS" << std::endl;
+    return;
+  }
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  auto attestationOpt = Snowflake::Client::createAttestation(config);
+  assert_true(attestationOpt.has_value());
+  auto& attestation = attestationOpt.value();
+  assert_true(attestation.type == Snowflake::Client::AttestationType::AWS);
+  assert_true(!attestation.credential.empty());
+  std::string json_string;
+  Snowflake::Client::Util::Base64::decodePadding(
+      attestation.credential.begin(), attestation.credential.end(),
+      std::back_inserter(json_string));
+  picojson::value json;
+  picojson::parse(json, json_string);
+  assert_true(json.is<picojson::object>());
+  assert_true(json.get("url").is<std::string>());
+  assert_true(json.get("method").is<std::string>());
+  std::string method = json.get("method").get<std::string>();
+  assert_true(json.get("headers").is<picojson::object>());
+  std::map<std::string, std::string> headers;
+  for (auto& header: json.get("headers").get<picojson::object>()) {
+    assert_true(header.second.is<std::string>());
+    headers[header.first] = header.second.get<std::string>();
+  }
+  assert_true(
+      run_request_curl(json.get("url").get<std::string>(), method, headers) ==
+      200
+  );
+}
 
 void test_gcp_attestation(void**)
 {
@@ -61,15 +135,16 @@ void test_azure_attestation(void**)
   std::cerr << "Credential: " << attestation.credential << std::endl;
   assert_true(attestation.issuer.has_value());
   assert_true(!attestation.issuer->empty());
-  std::cerr << "Issuer: " << attestation.credential << std::endl;
-  assert_true(!attestation.subject->empty());
+  std::cerr << "Issuer: " << attestation.issuer.get() << std::endl;
   assert_true(attestation.subject.has_value());
+  assert_true(!attestation.subject->empty());
   std::cerr << "Subject: " << attestation.subject.get() << std::endl;
 }
 
 int main()
 {
   const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_aws_attestation),
       cmocka_unit_test(test_gcp_attestation),
       cmocka_unit_test(test_azure_attestation)
   };

--- a/tests/test_unit_set_get_attributes.cpp
+++ b/tests/test_unit_set_get_attributes.cpp
@@ -51,6 +51,7 @@ std::vector<sf_bool_attributes> boolAttributes = {
     { SF_CON_INSECURE_MODE, false },
     { SF_CON_OCSP_FAIL_OPEN, true },
     { SF_CON_AUTOCOMMIT, true },
+    { SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, true },
 };
 
 typedef struct sf_int_attributes {


### PR DESCRIPTION
## Summary
- Replaces `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN` env-var gate with a typed connection attribute `SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN` (`sf_bool`, default `SF_BOOLEAN_FALSE`), following the existing `SF_CON_WIF_*` naming convention
- Legacy `GetCallerIdentity` presigned-URL path remains the default; `STS:GetWebIdentityToken` (JWT) is opt-in via `snowflake_set_attribute(sf, SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN, &SF_BOOLEAN_TRUE)` or the connection-string key `WIF_AWS_USE_OUTBOUND_TOKEN=true`
- Removes partial credential material from debug logs (`%.10s` → length-only diagnostic)

## Context
Initial gating in this PR used an environment variable. Switching to a connection attribute aligns with the driver's existing config model (`SF_CON_WIF_AUDIENCE`, `SF_CON_WIF_HOST`, etc.) and avoids process-global state that could affect unrelated connections in the same process.

## Test plan
- **Unit (`test_create_wif_attestation.cpp`):** `EnvOverride` gate replaced with `config.awsUseOutboundToken`; added `_outbound_jwt_disabled` and `_outbound_jwt_default` tests asserting legacy path when flag is unset/false; `test_unit_wif_attestation_config` extended to round-trip `SF_CON_WIF_AWS_USE_OUTBOUND_TOKEN` through `snowflake_set_attribute` → `configureWIFAttestation` → `AttestationConfig.awsUseOutboundToken`
- **Cloud E2E (`test_wif.c`):** `test_aws_wif_outbound_jwt_authentication` uses `snowflake_set_attribute` instead of `setenv`/`unsetenv`; `test_aws_wif_authentication` exercises the legacy path with no flag set
- **Manual (`test_manual_wif.cpp`)**