### PR TITLE
SNOW-3887909 bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -57,17 +57,17 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: ci/scripts/warning_report.sh
       - name: Upload build log
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: build log
           path: build.log
       - name: Upload warning report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: report
           path: report.md
       - name: Upload warnings
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: warnings
           path: warnings.json


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` from `@v5` → `@v7` in `.github/workflows/code-quality.yml` (3 usages).
- Scanned all `.github/workflows`; remaining actions already use Node-24-safe majors (`checkout@v5`, `setup-python@v6`, `cache@v5`). No other Node 20 majors found.

This avoids GitHub Actions Node.js 20 runtime deprecation warnings on runners.

## Test plan
- [ ] Confirm Actions workflows still start and `upload-artifact` steps succeed on CI
- [ ] Confirm no Node.js 20 deprecation annotations remain for these workflows