### PR TITLE
SNOW-4007740: zero-initialize Stopwatch to fix uptime-scale timing logs

### DIFF
--- a/include/snowflake/Stopwatch.h
+++ b/include/snowflake/Stopwatch.h
@@ -7,11 +7,22 @@ extern "C" {
 
 typedef struct Stopwatch
 {
+#ifdef __cplusplus
+  /* Default member initializers protect C++ callers from uninitialized use
+   * (SNOW-4007740); rationale and regression coverage live in
+   * tests/test_unit_stopwatch.cpp. C callers must still init at the call site. */
+  bool isStarted = false;
+
+  long startTime = 0;
+
+  long elapsedTime = 0;
+#else
   bool isStarted;
 
   long startTime;
 
   long elapsedTime;
+#endif
 } Stopwatch;
 
   void stopwatch_start(Stopwatch* s);

--- a/lib/client.c
+++ b/lib/client.c
@@ -1326,7 +1326,7 @@ SF_STATUS STDCALL snowflake_term(SF_CONNECT *sf) {
     }
     cJSON *resp = NULL;
     char *s_resp = NULL;
-    Stopwatch stopwatch;
+    Stopwatch stopwatch = {0};
     stopwatch_start(&stopwatch);
     clear_snowflake_error(&sf->error);
 
@@ -1439,7 +1439,7 @@ SF_STATUS STDCALL snowflake_connect(SF_CONNECT* sf) {
         return SF_STATUS_ERROR_GENERAL;
     }
 
-    Stopwatch stopwatch;
+    Stopwatch stopwatch = {0};
     stopwatch_start(&stopwatch);
 
     // Reset error context
@@ -3277,7 +3277,7 @@ SF_STATUS STDCALL snowflake_query(
     if (!sfstmt) {
         return SF_STATUS_ERROR_STATEMENT_NOT_EXIST;
     }
-    Stopwatch stopwatch;
+    Stopwatch stopwatch = {0};
     stopwatch_start(&stopwatch);
     log_debug("Starting snowflake query");
     clear_snowflake_error(&sfstmt->error);
@@ -3456,7 +3456,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
     // If no more results, set return to SF_STATUS_EOF
     if (sfstmt->chunk_rowcount == 0) {
         if (sfstmt->chunk_downloader) {
-            Stopwatch stopwatch;
+            Stopwatch stopwatch = {0};
             stopwatch_start(&stopwatch);
             log_debug("Fetching next chunk from chunk downloader.");
             _critical_section_lock(&sfstmt->chunk_downloader->queue_lock);
@@ -4032,7 +4032,7 @@ SF_STATUS STDCALL _snowflake_execute_ex(SF_STMT *sfstmt,
         return _snowflake_execute_put_get_native(sfstmt, NULL, 0, 0, result_capture);
     }
 
-    Stopwatch stopwatch;
+    Stopwatch stopwatch = {0};
     stopwatch_start(&stopwatch);
 
     clear_snowflake_error(&sfstmt->error);

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -171,7 +171,7 @@ sf_bool STDCALL http_perform(CURL *curl,
       djb.cap = SF_NEW_STRATEGY_BACKOFF_CAP;
     }
     log_debug("Starting http_perform");
-    Stopwatch stopwatch;
+    Stopwatch stopwatch = {0};
     stopwatch_start(&stopwatch);
 
     retry_timeout = (retry_timeout > 0) ? retry_timeout : SF_RETRY_TIMEOUT;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ SET(TESTS_CXX
         test_create_wif_attestation
         test_crl
         test_unit_ocsp_cache
+        test_unit_stopwatch
 )
 
 if (LINUX)

--- a/tests/test_unit_stopwatch.cpp
+++ b/tests/test_unit_stopwatch.cpp
@@ -25,7 +25,7 @@
 
 // A default-declared Stopwatch (no explicit reset) must be stopped and read
 // exactly 0 -- never an uptime-scale value.
-void test_default_initialized_is_zero() {
+void test_default_initialized_is_zero(void **unused) {
   Stopwatch stopwatch;  // relies on Part A default member initializers
   assert_false(stopwatch_isStarted(&stopwatch));
   assert_int_equal(stopwatch_elapsedMillis(&stopwatch), 0);
@@ -33,7 +33,7 @@ void test_default_initialized_is_zero() {
 
 // Start/stop on a default-declared Stopwatch (again, no explicit reset) must
 // measure a small, sane interval -- not host uptime.
-void test_default_initialized_start_is_sane() {
+void test_default_initialized_start_is_sane(void **unused) {
   Stopwatch stopwatch;  // no stopwatch_reset() on purpose
   stopwatch_start(&stopwatch);
   assert_true(stopwatch_isStarted(&stopwatch));

--- a/tests/test_unit_stopwatch.cpp
+++ b/tests/test_unit_stopwatch.cpp
@@ -25,7 +25,7 @@
 
 // A default-declared Stopwatch (no explicit reset) must be stopped and read
 // exactly 0 -- never an uptime-scale value.
-void test_default_initialized_is_zero(void **unused) {
+void test_default_initialized_is_zero(void **) {
   Stopwatch stopwatch;  // relies on Part A default member initializers
   assert_false(stopwatch_isStarted(&stopwatch));
   assert_int_equal(stopwatch_elapsedMillis(&stopwatch), 0);
@@ -33,7 +33,7 @@ void test_default_initialized_is_zero(void **unused) {
 
 // Start/stop on a default-declared Stopwatch (again, no explicit reset) must
 // measure a small, sane interval -- not host uptime.
-void test_default_initialized_start_is_sane(void **unused) {
+void test_default_initialized_start_is_sane(void **) {
   Stopwatch stopwatch;  // no stopwatch_reset() on purpose
   stopwatch_start(&stopwatch);
   assert_true(stopwatch_isStarted(&stopwatch));

--- a/tests/test_unit_stopwatch.cpp
+++ b/tests/test_unit_stopwatch.cpp
@@ -7,6 +7,10 @@
 /*
  * Regression test for SNOW-4007740.
  *
+ * Symptom in the field: a DEBUG timing line reports an uptime-scale value,
+ * e.g. "HttpPerform took 26228609 ms." for a request that actually took a
+ * few milliseconds.
+ *
  * The C `Stopwatch` struct is routinely declared as a bare `Stopwatch s;`
  * local and then started without an explicit stopwatch_reset(). Before the
  * fix, an uninitialized (garbage-truthy) `isStarted` byte turned

--- a/tests/test_unit_stopwatch.cpp
+++ b/tests/test_unit_stopwatch.cpp
@@ -1,0 +1,56 @@
+#include <chrono>
+#include <thread>
+
+#include "utils/test_setup.h"
+#include "snowflake/Stopwatch.h"
+
+/*
+ * Regression test for SNOW-4007740.
+ *
+ * The C `Stopwatch` struct is routinely declared as a bare `Stopwatch s;`
+ * local and then started without an explicit stopwatch_reset(). Before the
+ * fix, an uninitialized (garbage-truthy) `isStarted` byte turned
+ * stopwatch_start()'s idempotent-start guard (`!s->isStarted`) into a no-op,
+ * leaving startTime at stack garbage; stopwatch_elapsedMillis() then returned
+ * (steady_clock_now - garbage), i.e. a CLOCK_MONOTONIC-since-boot value that
+ * grows with host uptime.
+ *
+ * Part A of the fix adds C++ default member initializers to the struct, so a
+ * default-declared Stopwatch in any C++ translation unit is guaranteed to
+ * start zeroed. These tests exercise that guarantee. A C test cannot cover it
+ * (the initializers are guarded by `#ifdef __cplusplus`), so this test lives
+ * in a .cpp. The existing C-side semantics are covered by test_stopwatch.c,
+ * which is intentionally left unchanged.
+ */
+
+// A default-declared Stopwatch (no explicit reset) must be stopped and read
+// exactly 0 -- never an uptime-scale value.
+void test_default_initialized_is_zero() {
+  Stopwatch stopwatch;  // relies on Part A default member initializers
+  assert_false(stopwatch_isStarted(&stopwatch));
+  assert_int_equal(stopwatch_elapsedMillis(&stopwatch), 0);
+}
+
+// Start/stop on a default-declared Stopwatch (again, no explicit reset) must
+// measure a small, sane interval -- not host uptime.
+void test_default_initialized_start_is_sane() {
+  Stopwatch stopwatch;  // no stopwatch_reset() on purpose
+  stopwatch_start(&stopwatch);
+  assert_true(stopwatch_isStarted(&stopwatch));
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  stopwatch_stop(&stopwatch);
+  assert_false(stopwatch_isStarted(&stopwatch));
+  long elapsed = stopwatch_elapsedMillis(&stopwatch);
+  assert_true(elapsed >= 100);   // at least the time we slept (generous margin)
+  assert_true(elapsed < 60000);  // uptime-scale garbage would blow past this
+}
+
+int main(void) {
+  initialize_test(SF_BOOLEAN_FALSE);
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_default_initialized_is_zero),
+      cmocka_unit_test(test_default_initialized_start_is_sane),
+  };
+  int ret = cmocka_run_group_tests(tests, NULL, NULL);
+  return ret;
+}


### PR DESCRIPTION
## Problem

The `Stopwatch` primitive (`include/snowflake/Stopwatch.h`, `cpp/util/Stopwatch.cpp`) is a plain C struct whose members are not initialized at its call sites, which declare it simply as `Stopwatch stopwatch;`. `stopwatch_start()` intentionally guards against restarting a running watch with `if (s != NULL && !s->isStarted) { ... }`. When the uninitialized `isStarted` byte happens to hold a non-zero (truthy) value, `stopwatch_start()` becomes a no-op: `startTime` is never assigned and keeps its indeterminate value, which in practice is frequently `0`. Because `stopwatch_elapsedMillis()` returns `steady_clock::now() - startTime` and `std::chrono::steady_clock` is `CLOCK_MONOTONIC` (whose epoch is roughly system boot), the reported "elapsed" time degenerates to approximately the host's uptime.

## Impact

DEBUG-level timing logs report implausibly large values that grow with host uptime instead of request duration. This was reported on the ODBC driver (3.19.0) as `RestRequest::run HttpPerform took <uptime> ms`, and the same pattern appears on `RestRequest::postJson` and `InbandTelemetryEvent::flush`. The requests themselves succeed and behave normally — this is a cosmetic, log-only defect — but the misleading numbers waste time during log review and can send latency investigations down false trails. The defect is intermittent because it depends on whatever the stack happens to contain, and it affects every C++ consumer of the shared header (including ODBC and PDO), not only the three logging sites originally reported.

For example, a call that completes in a few milliseconds (and returns `Code: 200`) emits a DEBUG line whose value instead tracks the host's uptime:

```
RestRequest::run  HttpPerform took 97936550 ms
```

That is roughly 27 hours — on a host that had been up for about 27 hours — for a request that actually took single-digit milliseconds.

We got a customer complaint due to this. 

## Fix

The fix is minimal and preserves both the struct's layout/ABI and the intentional idempotent-start guard:

- In the shared header, add C++ default member initializers (`isStarted = false; startTime = 0; elapsedTime = 0;`) guarded by `#ifdef __cplusplus`, keeping the plain C POD in the `#else` branch. Every C++ consumer therefore gets a zero-initialized `Stopwatch stopwatch;` transitively, with no change required in ODBC or PDO and no change to the struct's binary layout.
- At libsnowflakeclient's own C call sites — which are compiled as C99 and cannot see the C++ initializers — zero-initialize explicitly with `= {0}` (five sites in `lib/client.c`, one in `lib/http_perform.c`).

The guard in `stopwatch_start()` is deliberately left unchanged: the bug is an uninitialized read at the call site, not the guard, so the guard's tested contract is preserved.

## Tests

- Added `tests/test_unit_stopwatch.cpp` (registered in `tests/CMakeLists.txt`) with two cases: a default-initialized `Stopwatch` reports not-started with zero elapsed time, and a started-then-stopped watch reports a sane interval that is at least the slept duration and far below host uptime. The existing `test_start_already_started` guard contract is unchanged and continues to pass.
- Verified locally with a standalone harness that compiles the real `cpp/util/Stopwatch.cpp` against the pre-fix and fixed headers. The pre-fix build reproduces the uptime-scale value, while the fixed build reports the true interval:

```
# pre-fix header (current shipping behavior)
HttpPerform took 97936550 ms      # equals /proc/uptime (97936550 ms) at run time
# fixed header
HttpPerform took 5 ms
```

A self-contained reproducer — a small standalone program plus a README, deliberately not bundling libsnowflakeclient — is attached to the internal Jira.