### PR TITLE
NO-SNOW: Use Artifactory for WireMock downloads in Jenkins CI

### DIFF
--- a/ci/test_linux.sh
+++ b/ci/test_linux.sh
@@ -50,6 +50,7 @@ docker run \
         -e BUILD_TYPE \
         -e JOB_NAME \
         -e BUILD_NUMBER \
+        -e JENKINS_HOME \
         -e PARAMETERS_SECRET \
         -e AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_ACCESS_KEY \

--- a/scripts/setup_wiremock.sh
+++ b/scripts/setup_wiremock.sh
@@ -3,8 +3,12 @@ set -o pipefail
 
 WIREMOCK_VERSION="3.13.2"
 WIREMOCK_JAR="${HOME}/.m2/repository/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
-WIREMOCK_URL="https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
 WIREMOCK_SHA256="d097b19bd483c5038479b13a5c71e9faf8f2f5106584f0c120a7770ab0bdb367" # pragma: allowlist secret
+WIREMOCK_ARTIFACT_PATH="org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
+WIREMOCK_ARTIFACTORY_BASE_URL="https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual"
+WIREMOCK_MAVEN_CENTRAL_BASE_URL="https://repo1.maven.org/maven2"
+CURL_RETRY_COUNT="${WIREMOCK_CURL_RETRY_COUNT:-5}"
+CURL_RETRY_DELAY="${WIREMOCK_CURL_RETRY_DELAY:-2}"
 
 mkdir -p "$(dirname "$WIREMOCK_JAR")"
 
@@ -21,15 +25,53 @@ verify_wiremock_jar() {
   [[ "$(jar_sha256 "$WIREMOCK_JAR")" == "$WIREMOCK_SHA256" ]]
 }
 
+wiremock_download_base_urls() {
+  if [[ -n "${WIREMOCK_BASE_URL:-}" ]]; then
+    echo "${WIREMOCK_BASE_URL}"
+    return
+  fi
+
+  if [[ -n "${JENKINS_HOME:-}" ]] || [[ -n "${JOB_NAME:-}" ]]; then
+    echo "${WIREMOCK_ARTIFACTORY_BASE_URL}"
+    return
+  fi
+
+  echo "${WIREMOCK_MAVEN_CENTRAL_BASE_URL}"
+}
+
 download_wiremock_jar() {
-  echo "Downloading WireMock JAR from ${WIREMOCK_URL}"
-  curl -L --fail -o "${WIREMOCK_JAR}" "${WIREMOCK_URL}"
+  local temp_jar="${WIREMOCK_JAR}.tmp"
+  local base_url url
+
+  rm -f "${temp_jar}"
+
+  for base_url in $(wiremock_download_base_urls); do
+    url="${base_url}/${WIREMOCK_ARTIFACT_PATH}"
+    echo "Downloading WireMock JAR from ${url}"
+    if curl -L --fail \
+      --retry "${CURL_RETRY_COUNT}" \
+      --retry-delay "${CURL_RETRY_DELAY}" \
+      --retry-all-errors \
+      -o "${temp_jar}" "${url}"; then
+      mv "${temp_jar}" "${WIREMOCK_JAR}"
+      return 0
+    fi
+
+    echo "WARNING: Failed to download WireMock JAR from ${url}"
+    rm -f "${temp_jar}"
+  done
+
+  return 1
 }
 
 if ! verify_wiremock_jar; then
   echo "WireMock JAR missing or checksum mismatch; redownloading."
   rm -f "$WIREMOCK_JAR"
-  download_wiremock_jar
+  if ! download_wiremock_jar; then
+    echo "ERROR: Failed to download WireMock JAR from all configured sources."
+    rm -f "$WIREMOCK_JAR"
+    exit 1
+  fi
   if ! verify_wiremock_jar; then
     echo "ERROR: WireMock JAR checksum failed after download."
     rm -f "$WIREMOCK_JAR"
@@ -67,7 +109,11 @@ DOWNLOAD_DIR="${HOME}/java17.tar.gz"
 
 mkdir -p $INSTALL_DIR
 
-curl -L --fail $JAVA_URL -o "${DOWNLOAD_DIR}"
+curl -L --fail \
+  --retry "${CURL_RETRY_COUNT}" \
+  --retry-delay "${CURL_RETRY_DELAY}" \
+  --retry-all-errors \
+  "$JAVA_URL" -o "${DOWNLOAD_DIR}"
 
 tar -xzf "${DOWNLOAD_DIR}" -C $INSTALL_DIR --strip-components=1
 

--- a/scripts/setup_wiremock.sh
+++ b/scripts/setup_wiremock.sh
@@ -7,10 +7,34 @@ WIREMOCK_SHA256="d097b19bd483c5038479b13a5c71e9faf8f2f5106584f0c120a7770ab0bdb36
 WIREMOCK_ARTIFACT_PATH="org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
 WIREMOCK_ARTIFACTORY_BASE_URL="https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual"
 WIREMOCK_MAVEN_CENTRAL_BASE_URL="https://repo1.maven.org/maven2"
-CURL_RETRY_COUNT="${WIREMOCK_CURL_RETRY_COUNT:-5}"
-CURL_RETRY_DELAY="${WIREMOCK_CURL_RETRY_DELAY:-2}"
+DOWNLOAD_ATTEMPTS="${WIREMOCK_DOWNLOAD_ATTEMPTS:-5}"
+DOWNLOAD_RETRY_DELAY="${WIREMOCK_DOWNLOAD_RETRY_DELAY:-2}"
 
 mkdir -p "$(dirname "$WIREMOCK_JAR")"
+
+# Retries are implemented here rather than with curl's --retry-all-errors,
+# which is unavailable in the curl 7.61 shipped by the RHEL8/Rocky8 images.
+download_with_retries() {
+  local url="$1"
+  local output="$2"
+  local attempt=1
+  local delay="${DOWNLOAD_RETRY_DELAY}"
+
+  while true; do
+    if curl -L --fail -o "${output}" "${url}"; then
+      return 0
+    fi
+
+    if [ "${attempt}" -ge "${DOWNLOAD_ATTEMPTS}" ]; then
+      return 1
+    fi
+
+    echo "WARNING: Download attempt ${attempt}/${DOWNLOAD_ATTEMPTS} failed for ${url}; retrying in ${delay}s"
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
 
 jar_sha256() {
   if command -v sha256sum >/dev/null 2>&1; then
@@ -33,6 +57,7 @@ wiremock_download_base_urls() {
 
   if [[ -n "${JENKINS_HOME:-}" ]] || [[ -n "${JOB_NAME:-}" ]]; then
     echo "${WIREMOCK_ARTIFACTORY_BASE_URL}"
+    echo "${WIREMOCK_MAVEN_CENTRAL_BASE_URL}"
     return
   fi
 
@@ -48,11 +73,7 @@ download_wiremock_jar() {
   for base_url in $(wiremock_download_base_urls); do
     url="${base_url}/${WIREMOCK_ARTIFACT_PATH}"
     echo "Downloading WireMock JAR from ${url}"
-    if curl -L --fail \
-      --retry "${CURL_RETRY_COUNT}" \
-      --retry-delay "${CURL_RETRY_DELAY}" \
-      --retry-all-errors \
-      -o "${temp_jar}" "${url}"; then
+    if download_with_retries "${url}" "${temp_jar}"; then
       mv "${temp_jar}" "${WIREMOCK_JAR}"
       return 0
     fi
@@ -109,11 +130,10 @@ DOWNLOAD_DIR="${HOME}/java17.tar.gz"
 
 mkdir -p $INSTALL_DIR
 
-curl -L --fail \
-  --retry "${CURL_RETRY_COUNT}" \
-  --retry-delay "${CURL_RETRY_DELAY}" \
-  --retry-all-errors \
-  "$JAVA_URL" -o "${DOWNLOAD_DIR}"
+if ! download_with_retries "$JAVA_URL" "${DOWNLOAD_DIR}"; then
+  echo "ERROR: Failed to download JDK from ${JAVA_URL}"
+  exit 1
+fi
 
 tar -xzf "${DOWNLOAD_DIR}" -C $INSTALL_DIR --strip-components=1
 


### PR DESCRIPTION
Move into Artifactory to mitigate HTTP 429 errors.