### PR TITLE
SNOW-4053693: Fix auth tests

### DIFF
--- a/tests/test_auth/test_oauth.c
+++ b/tests/test_auth/test_oauth.c
@@ -67,7 +67,8 @@ void test_oauth_invalid_token(void **unused) {
     SF_STATUS status = snowflake_connect(sf);
     assert_int_equal(status, SF_STATUS_ERROR_GENERAL);
     SF_ERROR_STRUCT* error = snowflake_error(sf);
-    assert_string_equal(error->msg, "Invalid OAuth access token. ");
+    // The server appends a request id to the message, so match on the message only.
+    assert_non_null(strstr(error->msg, "Invalid OAuth access token."));
 
     snowflake_term(sf);
 }
@@ -87,7 +88,8 @@ void test_oauth_mismatched_username(void **unused) {
     SF_STATUS status = snowflake_connect(sf);
     assert_int_equal(status, SF_STATUS_ERROR_GENERAL);
     SF_ERROR_STRUCT* error = snowflake_error(sf);
-    assert_string_equal(error->msg, "The user you were trying to authenticate as differs from the user tied to the access token.");
+    // The server appends a request id to the message, so match on the message only.
+    assert_non_null(strstr(error->msg, "The user you were trying to authenticate as differs from the user tied to the access token."));
 
     snowflake_term(sf);
     free(token);


### PR DESCRIPTION
Snowflake appends requestId in the return message. This PR changes the way that assertion is done.