### PR TITLE
SNOW-3954280,SNOW-3954279: logging: keep credentials out of diagnostic traces

### DIFF
--- a/cpp/lib/client_config_parser.cpp
+++ b/cpp/lib/client_config_parser.cpp
@@ -153,8 +153,7 @@ namespace
     if (config.is<picojson::object>()) {
       for (auto& kv : config.get<picojson::object>()) {
         if (!isKnownCommonEntry(kv.first)) {
-          CXX_LOG_WARN("Unknown configuration entry: %s with value: %s",
-            kv.first.c_str(), kv.second.to_str().c_str());
+          CXX_LOG_WARN("Unknown configuration entry: %s", kv.first.c_str());
         }
       }
     }

--- a/cpp/logger/SecretDetector.cpp
+++ b/cpp/logger/SecretDetector.cpp
@@ -14,7 +14,17 @@ namespace Client
 
   boost::regex SecretDetector::PRIVATE_KEY_DATA_PATTERN = boost::regex("\"privateKeyData\": \"([A-Za-z0-9/+=\\\\n]{10,})\"", boost::regex::extended | boost::regex::icase);
 
-  boost::regex SecretDetector::CONNECTION_TOKEN_PATTERN = boost::regex("(token|assertion content|queryStageMasterKey|aws_key_id|aws_secret_key|aws_token)(['\"\\s:=]+)([A-Za-z0-9=/_+-]{8,})", boost::regex::icase);
+  // The value class must contain ':' because every session token value starts
+  // with a "ver:<n>-" prefix. GlobalServices mints them as
+  // "ver:1-hint:<keyId>-<encrypted>", "ver:2-hint:<keyId>-did:<deployId>-<encrypted>"
+  // and the V3/V4 equivalents (SecurityToken.java:60-66), so V2 and V4 also carry
+  // a ':' in "-did:". Without ':' in the class the value match stops after "ver",
+  // which is three characters, below the {8,} minimum, and no session token of any
+  // version is masked. Keep ':' where it is: the trailing '-' has to stay the last
+  // character of the class so that it remains a literal hyphen, and ':' must not sit
+  // next to that '-' (a "+-:" sequence would be read as a range covering ',' '.' '/'
+  // and the digits).
+  boost::regex SecretDetector::CONNECTION_TOKEN_PATTERN = boost::regex("(token|assertion content|queryStageMasterKey|aws_key_id|aws_secret_key|aws_token)(['\"\\s:=]+)([A-Za-z0-9=/_:+-]{8,})", boost::regex::icase);
 
   boost::regex SecretDetector::PASSWORD_PATTERN = boost::regex("(password|passcode|pwd)(['\"\\s:=]+)([A-Za-z0-9!\"#$%&'\\()*+,-./:;<=>?@\\[\\]^_`\\{|\\}~]{6,})", boost::regex::icase);
 

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -178,6 +178,14 @@ typedef struct put_payload {
     size_t length;
 } PUT_PAYLOAD;
 
+/*
+ * Sanitize the HTTP header bytes received by curl's debug callback. Exposed
+ * internally so tests can verify that request targets and header values never
+ * reach verbose logs. The input does not need to be NUL terminated.
+ */
+size_t sf_trace_header_names_only(const char *data, size_t size, char *out,
+                                  size_t out_size);
+
 /**
  * Macro to get a custom error message to pass to the Snowflake Error object.
  */

--- a/lib/http_perform.c
+++ b/lib/http_perform.c
@@ -35,6 +35,17 @@ dump(const char *text, FILE *stream, unsigned char *ptr, size_t size,
 static int my_trace(CURL *handle, curl_infotype type, char *data, size_t size,
                     void *userp);
 
+static size_t trace_append(char *out, size_t out_size, size_t used,
+                           const char *text, size_t len);
+
+static size_t http_header_name_len(const char *line, size_t len);
+
+static int http_is_method_char(char c);
+
+static int http_request_line_parts(const char *line, size_t len,
+                                   size_t *method_len,
+                                   size_t *version_offset);
+
 /* Enable curl verbose logging when the environment variable SF_CURL_VERBOSE is set.
  * This allows turning on libcurl debug without recompiling with DEBUG. */
 
@@ -89,6 +100,197 @@ void dump(const char *text,
     fflush(stream);
 }
 
+/* Stands in for an HTTP header field value in the curl trace. */
+#define SF_TRACE_HEADER_VALUE "****"
+
+/*
+ * Append at most len bytes of text to out, stopping at the end of the buffer,
+ * and return the number of bytes out holds afterwards. out stays NUL
+ * terminated.
+ */
+static
+size_t trace_append(char *out, size_t out_size, size_t used,
+                    const char *text, size_t len) {
+    size_t room;
+
+    if (used + 1 >= out_size) {
+        return used;
+    }
+    room = out_size - used - 1;
+    if (len > room) {
+        len = room;
+    }
+    if (sf_memcpy(out + used, room, text, len) == NULL) {
+        return used;
+    }
+    used += len;
+    out[used] = '\0';
+    return used;
+}
+
+/*
+ * Length of the field name at the start of one HTTP header line, or 0 when the
+ * line does not start with a field name. The name is the text in front of the
+ * first colon; a field name is a token, so a colon that comes after whitespace
+ * (the target of a request line, for instance) does not end a name. The line
+ * does not have to be NUL terminated: only the first len bytes are read.
+ */
+static
+size_t http_header_name_len(const char *line, size_t len) {
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        if (line[i] == ':') {
+            return i;
+        }
+        if (line[i] == ' ' || line[i] == '\t') {
+            return 0;
+        }
+    }
+    return 0;
+}
+
+/*
+ * HTTP methods use the RFC 9110 token grammar. Restricting request-line
+ * recognition to that grammar prevents arbitrary header value text containing
+ * " HTTP/" from being mistaken for a request line and copied into the trace.
+ */
+static
+int http_is_method_char(char c) {
+    if ((c >= '0' && c <= '9') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= 'a' && c <= 'z')) {
+        return 1;
+    }
+    return c != '\0' && strchr("!#$%&'*+-.^_`|~", c) != NULL;
+}
+
+/*
+ * Parse METHOD SP request-target SP HTTP-version. On success, return the
+ * method length and the offset of HTTP-version. Request targets cannot contain
+ * a literal space, and HTTP-version must be the final token on the line.
+ */
+static
+int http_request_line_parts(const char *line, size_t len,
+                            size_t *method_len, size_t *version_offset) {
+    size_t first_space = 0;
+    size_t second_space;
+    size_t i;
+
+    if (len == 0 || line[0] == ' ' || line[0] == '\t') {
+        return 0;
+    }
+    while (first_space < len && line[first_space] != ' ') {
+        if (!http_is_method_char(line[first_space])) {
+            return 0;
+        }
+        first_space++;
+    }
+    if (first_space == 0 || first_space == len) {
+        return 0;
+    }
+
+    second_space = first_space + 1;
+    while (second_space < len && line[second_space] != ' ') {
+        second_space++;
+    }
+    if (second_space == first_space + 1 || second_space == len ||
+        second_space + 6 > len ||
+        strncmp(line + second_space + 1, "HTTP/", 5) != 0) {
+        return 0;
+    }
+    for (i = second_space + 1; i < len; i++) {
+        if (line[i] == ' ' || line[i] == '\t') {
+            return 0;
+        }
+    }
+
+    *method_len = first_space;
+    *version_offset = second_space + 1;
+    return 1;
+}
+
+/*
+ * Rewrite an HTTP header block so that it holds field names but no field
+ * values. CURLINFO_HEADER_OUT passes the whole request head in one call and
+ * CURLINFO_HEADER_IN one response line per call, so the input is split on
+ * newlines and each line is treated the same way:
+ *   - a line with a field name keeps the name, the value is replaced;
+ *   - a response status line is copied as-is;
+ *   - a request line keeps its method and HTTP version, while its target is
+ *     replaced because signed query parameters can contain credentials;
+ *   - the empty line that ends the head stays empty;
+ *   - anything else, including a line that continues the value of the line
+ *     before it, is value text as far as this function is concerned and none of
+ *     it is kept.
+ * Every emitted line ends with CRLF, as the header text does. data does not
+ * have to be NUL terminated: only the first size bytes are read. out is always
+ * NUL terminated. Returns the number of bytes written to out.
+ */
+size_t sf_trace_header_names_only(const char *data, size_t size, char *out,
+                                  size_t out_size) {
+    size_t pos = 0;
+    size_t used = 0;
+
+    if (out == NULL || out_size == 0) {
+        return 0;
+    }
+    out[0] = '\0';
+    if (data == NULL) {
+        return 0;
+    }
+
+    while (pos < size) {
+        size_t eol = pos;
+        size_t len;
+        size_t name_len;
+        size_t method_len;
+        size_t version_offset;
+
+        while (eol < size && data[eol] != '\n') {
+            eol++;
+        }
+        len = eol - pos;
+        if (len > 0 && data[pos + len - 1] == '\r') {
+            len--; /* the CR of a CRLF pair */
+        }
+
+        if (len > 0) {
+            name_len = 0;
+            /* A line that opens with whitespace continues the value of the
+             * line before it, and one that opens with a colon has no name. */
+            if (data[pos] != ' ' && data[pos] != '\t' && data[pos] != ':') {
+                name_len = http_header_name_len(data + pos, len);
+            }
+            if (name_len > 0) {
+                used = trace_append(out, out_size, used, data + pos, name_len);
+                used = trace_append(out, out_size, used, ": ", 2);
+                used = trace_append(out, out_size, used, SF_TRACE_HEADER_VALUE,
+                                    sizeof(SF_TRACE_HEADER_VALUE) - 1);
+            } else if (len >= 5 && strncmp(data + pos, "HTTP/", 5) == 0) {
+                used = trace_append(out, out_size, used, data + pos, len);
+            } else if (http_request_line_parts(data + pos, len, &method_len,
+                                               &version_offset)) {
+                used = trace_append(out, out_size, used, data + pos,
+                                    method_len);
+                used = trace_append(out, out_size, used, " ", 1);
+                used = trace_append(out, out_size, used, SF_TRACE_HEADER_VALUE,
+                                    sizeof(SF_TRACE_HEADER_VALUE) - 1);
+                used = trace_append(out, out_size, used, " ", 1);
+                used = trace_append(out, out_size, used,
+                                    data + pos + version_offset,
+                                    len - version_offset);
+            } else {
+                used = trace_append(out, out_size, used, SF_TRACE_HEADER_VALUE,
+                                    sizeof(SF_TRACE_HEADER_VALUE) - 1);
+            }
+        }
+        used = trace_append(out, out_size, used, "\r\n", 2);
+        pos = (eol < size) ? eol + 1 : size;
+    }
+    return used;
+}
+
 static
 int my_trace(CURL *handle, curl_infotype type,
              char *data, size_t size,
@@ -107,16 +309,26 @@ int my_trace(CURL *handle, curl_infotype type,
             return 0;
 
         case CURLINFO_HEADER_OUT:
-            text = "=> Send header";
-            break;
+            /* Header text is logged as field names only. The callback gets the
+             * header text as it goes on the wire, and field values such as
+             * Authorization, x-amz-server-side-encryption-customer-key,
+             * X-Amz-Security-Token or Set-Cookie carry credentials. */
+            sf_trace_header_names_only(data, size, masked, sizeof(masked));
+            dump("=> Send header", stderr, (unsigned char *) masked,
+                 strlen(masked), config->trace_ascii);
+            return 0;
+        case CURLINFO_HEADER_IN:
+            /* One response header line per call; names only, as above. */
+            sf_trace_header_names_only(data, size, masked, sizeof(masked));
+            dump("<= Recv header", stderr, (unsigned char *) masked,
+                 strlen(masked), config->trace_ascii);
+            return 0;
+
         case CURLINFO_DATA_OUT:
             text = "=> Send data";
             break;
         case CURLINFO_SSL_DATA_OUT:
             text = "=> Send SSL data";
-            break;
-        case CURLINFO_HEADER_IN:
-            text = "<= Recv header";
             break;
         case CURLINFO_DATA_IN:
             text = "<= Recv data";

--- a/tests/test_unit_logger.c
+++ b/tests/test_unit_logger.c
@@ -1,5 +1,6 @@
 #include "utils/test_setup.h"
 #include <snowflake/client_config_parser.h>
+#include "connection.h"
 #include "log_file_util.h"
 #include "memory.h"
 #include <stdio.h>
@@ -30,6 +31,57 @@ void test_log_str_to_level() {
     /* negative */
     assert_int_equal(log_from_str_to_level("hahahaha"), SF_LOG_FATAL);
     assert_int_equal(log_from_str_to_level(NULL), SF_LOG_FATAL);
+}
+
+static void assert_trace_headers(const char *input, size_t input_size,
+                                 const char *expected) {
+    char output[1024];
+    size_t output_size = sf_trace_header_names_only(
+        input, input_size, output, sizeof(output));
+
+    assert_int_equal(output_size, strlen(expected));
+    assert_string_equal(output, expected);
+}
+
+void test_curl_trace_header_sanitization() {
+    static const char gcs_request[] =
+        "GET /bucket/object?X-Goog-Algorithm=GOOG4-RSA-SHA256&"
+        "X-Goog-Signature=gcs-secret HTTP/1.1\r\n";
+    static const char aws_request[] =
+        "PUT /object?X-Amz-Credential=AKIAEXAMPLE&"
+        "X-Amz-Signature=aws-secret HTTP/1.1\r\n";
+    static const char azure_request[] =
+        "GET /container/blob?sv=2024-11-04&sp=r&sig=azure-secret "
+        "HTTP/1.1\r\n";
+    static const char connect_request[] =
+        "CONNECT proxy.example:443 HTTP/1.1\r\n";
+    static const char response[] = "HTTP/1.1 200 OK\r\n";
+    static const char header[] = "Authorization: Bearer secret\r\n";
+    static const char folded_value[] =
+        "X-Test: visible\r\n secret HTTP/1.1\r\n";
+    static const char malformed_header[] = "Set-Cookie : secret\r\n";
+    static const char bounded_request[] = {
+        'G', 'E', 'T', ' ', '/', '?', 's', 'i', 'g', '=', 's', 'e', 'c',
+        'r', 'e', 't', ' ', 'H', 'T', 'T', 'P', '/', '2', '\r', '\n'};
+
+    assert_trace_headers(gcs_request, sizeof(gcs_request) - 1,
+                         "GET **** HTTP/1.1\r\n");
+    assert_trace_headers(aws_request, sizeof(aws_request) - 1,
+                         "PUT **** HTTP/1.1\r\n");
+    assert_trace_headers(azure_request, sizeof(azure_request) - 1,
+                         "GET **** HTTP/1.1\r\n");
+    assert_trace_headers(connect_request, sizeof(connect_request) - 1,
+                         "CONNECT **** HTTP/1.1\r\n");
+    assert_trace_headers(response, sizeof(response) - 1,
+                         "HTTP/1.1 200 OK\r\n");
+    assert_trace_headers(header, sizeof(header) - 1,
+                         "Authorization: ****\r\n");
+    assert_trace_headers(folded_value, sizeof(folded_value) - 1,
+                         "X-Test: ****\r\n****\r\n");
+    assert_trace_headers(malformed_header, sizeof(malformed_header) - 1,
+                         "****\r\n");
+    assert_trace_headers(bounded_request, sizeof(bounded_request),
+                         "GET **** HTTP/2\r\n");
 }
 
 void test_null_log_path() {
@@ -188,7 +240,7 @@ void test_client_config_log() {
 }
 
 void test_client_config_log_unknown_entries() {
-  char clientConfigJSON[] = "{\"common\":{\"log_level\":\"warn\",\"log_path\":\"./test/\",\"unknownEntry\":\"fakeValue\"}}";
+  char clientConfigJSON[] = "{\"common\":{\"log_level\":\"warn\",\"log_path\":\"./test/\",\"unknownEntry\":\"credential-secret-not-for-logs\"}}";
   char configFilePath[] = "sf_client_config.json";
   char logPath[] = "./test/";
   char logLevel[] = "warn";
@@ -220,15 +272,20 @@ void test_client_config_log_unknown_entries() {
   // Check unknown entries is logged
   char line[1024];
   sf_bool unknown_found = 0;
+  sf_bool secret_found = 0;
   file = fopen(LOG_PATH, "r");
   while (fgets(line, sizeof(line), file)) {
-    if (strstr(line, "Unknown configuration entry:") != NULL) {
+    if (strstr(line, "Unknown configuration entry: unknownEntry") != NULL) {
       unknown_found = 1;
+    }
+    if (strstr(line, "credential-secret-not-for-logs") != NULL) {
+      secret_found = 1;
     }
   }
   fclose(file);
 
   assert_int_equal(unknown_found, 1);
+  assert_int_equal(secret_found, 0);
 
   // Cleanup
   remove(configFilePath);
@@ -440,6 +497,46 @@ void test_terminal_mask() {
   terminal_mask(token3, strlen(token3), masked, sizeof(masked));
   expected = "";
   assert_string_equal(masked, expected);
+}
+
+/* Test terminal masking of session tokens that are not wrapped in quotes.
+ * Session token values always start with a "ver:<n>-" prefix and the V2/V4
+ * forms hold a second colon in "-did:" (SecurityToken.java:60-66), so the value
+ * class of the connection token pattern has to accept ':'. */
+void test_terminal_mask_session_token_versions() {
+
+  char masked[450] = "\0";
+
+  char *v1 = "token=ver:1-hint:92019686956010-ETMsDgAAAZnuCZEqABRBRVMvQ0JDL1BLQ1M1UGFkZGluZwEAABAAEFvTRpZh3vTIN0ae";
+  terminal_mask(v1, strlen(v1), masked, sizeof(masked));
+  assert_string_equal(masked, "token=****");
+
+  char *v2 = "token=ver:2-hint:92019686956010-did:4242-ETMsDgAAAZnuCZEqABRBRVMvQ0JDL1BLQ1M1UGFkZGluZwEAABAAEFvTRpZh3vTIN0ae";
+  masked[0] = '\0';
+  terminal_mask(v2, strlen(v2), masked, sizeof(masked));
+  assert_string_equal(masked, "token=****");
+
+  char *v3 = "token=ver:3-hint:92019686956010-ETMsDgAAAZnuCZEqABRBRVMvQ0JDL1BLQ1M1UGFkZGluZwEAABAAEFvTRpZh3vTIN0ae";
+  masked[0] = '\0';
+  terminal_mask(v3, strlen(v3), masked, sizeof(masked));
+  assert_string_equal(masked, "token=****");
+
+  char *v4 = "token=ver:4-hint:92019686956010-did:4242-ETMsDgAAAZnuCZEqABRBRVMvQ0JDL1BLQ1M1UGFkZGluZwEAABAAEFvTRpZh3vTIN0ae";
+  masked[0] = '\0';
+  terminal_mask(v4, strlen(v4), masked, sizeof(masked));
+  assert_string_equal(masked, "token=****");
+
+  /* Same value in the shape it takes in a request header. */
+  char *header = "Authorization: Snowflake Token=ver:4-hint:92019686956010-did:4242-ETMsDgAAAZnuCZEqABRBRVMvQ0JDL1BLQ1M1UGFkZGluZw";
+  masked[0] = '\0';
+  terminal_mask(header, strlen(header), masked, sizeof(masked));
+  assert_string_equal(masked, "Authorization: Snowflake Token=****");
+
+  /* A short value stays as it is: the pattern needs at least 8 characters. */
+  char *shortval = "token: null";
+  masked[0] = '\0';
+  terminal_mask(shortval, strlen(shortval), masked, sizeof(masked));
+  assert_string_equal(masked, "token: null");
 }
 
 void test_log_creation() {
@@ -714,6 +811,7 @@ int main(void) {
         cmocka_unit_test(test_null_log_path),
         cmocka_unit_test(test_default_log_path),
         cmocka_unit_test(test_log_str_to_level),
+        cmocka_unit_test(test_curl_trace_header_sanitization),
         cmocka_unit_test(test_invalid_client_config_path),
         cmocka_unit_test(test_client_config_log_invalid_json),
         cmocka_unit_test(test_client_config_log_malformed_json),
@@ -726,6 +824,7 @@ int main(void) {
         cmocka_unit_test(test_client_config_log_no_path),
         cmocka_unit_test(test_client_config_stdout),
         cmocka_unit_test(test_terminal_mask),
+        cmocka_unit_test(test_terminal_mask_session_token_versions),
 #endif
         cmocka_unit_test(test_log_creation),
 #ifndef _WIN32


### PR DESCRIPTION
Session token masking stopped at the : in every ver:<n>- token, while the curl verbose callback logged request targets verbatim and unknown JSON client-config warnings included their raw values. These paths could expose session credentials, AWS SigV4 parameters, Azure SAS tokens, GCS signed URL parameters, or configuration secrets in diagnostic output.

This change accepts : in the session-token value class and rewrites curl header traces to retain only useful protocol structure. Response status lines and header names remain visible, but every header value and request target becomes ****. Request-line parsing is deliberately strict so folded or malformed value text cannot be mistaken for protocol structure. Unknown JSON config warnings now retain only the entry name; the TOML connection-config loader was also audited and already logs no connection values.

Regression coverage exercises V1-V4 session tokens; AWS, Azure, and GCS signed targets; CONNECT; response and ordinary header lines; folded and malformed headers; bounded non-NUL input; and absence of a canary config value from logs. The modified units and tests compile with -Werror, and a focused harness against the actual sanitizer passes. A saved third-party Arrow/AWS ABI mismatch prevents linking the full test executable locally, so CI remains the final execution gate.