### PR TITLE
SNOW-3649730: Restrict WORKLOAD_IDENTITY authentication to recognized Snowflake hosts

### DIFF
--- a/cpp/WifAttestation.cpp
+++ b/cpp/WifAttestation.cpp
@@ -6,7 +6,14 @@
 #include "OIDCAttestation.hpp"
 #include "logger/SFLogger.hpp"
 #include "jwt/Jwt.hpp"
+#include "error.h"
 #include <boost/url.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <sstream>
+#include <vector>
 
 namespace Snowflake {
   namespace Client {
@@ -81,14 +88,26 @@ namespace Snowflake {
             }
             else 
             {
-                log_error("Invalid WIF provider specified: %s. Valid values: AWS, AZURE, GCP, OIDC", conn->wif_provider);
-                return SF_STATUS_ERROR_GENERAL;
+                const char* errorMessage =
+                    "Invalid WIF provider. Valid values: AWS, AZURE, GCP, OIDC";
+                log_error("%s. Got: '%s'", errorMessage, conn->wif_provider);
+                SET_SNOWFLAKE_ERROR(&conn->error,
+                                    SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                                    errorMessage,
+                                    SF_SQLSTATE_UNABLE_TO_CONNECT);
+                return SF_STATUS_ERROR_BAD_CONNECTION_PARAMS;
             }
         }
         else 
         {
-            log_error("WIF provider is required but not specified");
-            return SF_STATUS_ERROR_GENERAL;
+            const char* errorMessage =
+                "WIF provider is required but not specified";
+            log_error("%s", errorMessage);
+            SET_SNOWFLAKE_ERROR(&conn->error,
+                                SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                                errorMessage,
+                                SF_SQLSTATE_UNABLE_TO_CONNECT);
+            return SF_STATUS_ERROR_BAD_CONNECTION_PARAMS;
         }
 
         if (conn->wif_token) 
@@ -118,6 +137,144 @@ namespace Snowflake {
         awsUseOutboundToken = (conn->wif_aws_use_outbound_token == SF_BOOLEAN_TRUE);
 
         return SF_STATUS_SUCCESS;
+    }
+
+    namespace {
+      // --- WORKLOAD_IDENTITY host allowlist -------------------------------
+      //
+      // Suffix-anchored allowlist that restricts Workload Identity
+      // attestation to recognized Snowflake hosts before any cloud
+      // credential is fetched. Matching is plain string operations (no
+      // regex) and is anchored to a label boundary at the end of the host,
+      // so only the listed suffixes and their subdomains are recognized
+      // (e.g. "evilsnowflakecomputing.com" or
+      // "evil.snowflakecomputing.com.untrusted.example" are not matches).
+
+      const char* const kDefaultAllowedHostSuffixes[] = {
+          "snowflakecomputing.com",
+          "snowflakecomputing.cn",
+          "snowflakecomputing.mil",
+      };
+
+      const char* const kWifAllowedHostSuffixesEnvVar = "SNOWFLAKE_WIF_ALLOWED_HOST_SUFFIXES";
+
+      std::string trim(const std::string& s) {
+        size_t begin = s.find_first_not_of(" \t\r\n");
+        if (begin == std::string::npos) {
+          return std::string();
+        }
+        size_t end = s.find_last_not_of(" \t\r\n");
+        return s.substr(begin, end - begin + 1);
+      }
+
+      std::string toLowerAscii(const std::string& s) {
+        std::string result = s;
+        std::transform(result.begin(), result.end(), result.begin(),
+            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return result;
+      }
+
+      // Splits a comma-separated list into normalized (trimmed, lowercased,
+      // trailing-dot-stripped) entries. Empty entries are ignored.
+      std::vector<std::string> splitCsvNormalized(const std::string& csv) {
+        std::vector<std::string> result;
+        std::stringstream ss(csv);
+        std::string item;
+        while (std::getline(ss, item, ',')) {
+          std::string normalized = toLowerAscii(trim(item));
+          if (!normalized.empty() && normalized.back() == '.') {
+            normalized.pop_back();
+          }
+          if (!normalized.empty()) {
+            result.push_back(normalized);
+          }
+        }
+        return result;
+      }
+
+      // Additive, comma-separated extra suffixes from
+      // SNOWFLAKE_WIF_ALLOWED_HOST_SUFFIXES. Read only from the process
+      // environment - never from the DSN, connection parameters or
+      // configuration files - so connection configuration cannot influence
+      // the allowlist. Entries are additive: they extend the
+      // recognized-host list and cannot disable it.
+      std::vector<std::string> envAllowedHostSuffixes() {
+        const char* envVal = std::getenv(kWifAllowedHostSuffixesEnvVar);
+        if (envVal == nullptr) {
+          return {};
+        }
+        std::vector<std::string> extra = splitCsvNormalized(envVal);
+        if (!extra.empty()) {
+          std::string joined;
+          for (size_t i = 0; i < extra.size(); ++i) {
+            if (i > 0) joined += ", ";
+            joined += extra[i];
+          }
+          CXX_LOG_INFO("WORKLOAD_IDENTITY host allowlist extended via %s with additional "
+                        "suffixes: %s. This is additive only and does not disable the "
+                        "default Snowflake host allowlist.",
+                        kWifAllowedHostSuffixesEnvVar, joined.c_str());
+        }
+        return extra;
+      }
+
+      // True iff `host` equals `suffix` or ends with "." + suffix, i.e. the
+      // suffix match is anchored on a label boundary. Both inputs are
+      // assumed already normalized (lowercase, no trailing dot).
+      bool hostMatchesSuffix(const std::string& host, const std::string& suffix) {
+        if (suffix.empty()) {
+          return false;
+        }
+        if (host == suffix) {
+          return true;
+        }
+        const std::string dotSuffix = "." + suffix;
+        if (host.size() <= dotSuffix.size()) {
+          return false;
+        }
+        return host.compare(host.size() - dotSuffix.size(), dotSuffix.size(), dotSuffix) == 0;
+      }
+    }
+
+    bool isSnowflakeHostForWorkloadIdentity(const std::string& host) {
+      std::string h = toLowerAscii(trim(host));
+
+      // Defensive :port strip. Must happen before the trailing-dot strip
+      // below so that an FQDN-with-port host like
+      // "acct.snowflakecomputing.com.:443" ends up as
+      // "acct.snowflakecomputing.com." (dot still attached) rather than
+      // being left as-is with the port never stripped. IPv6 literals (which
+      // also contain ':') never match a Snowflake suffix below, so no
+      // special-casing is needed for them; they are rejected implicitly.
+      size_t colonPos = h.find(':');
+      if (colonPos != std::string::npos) {
+        h = h.substr(0, colonPos);
+      }
+
+      if (!h.empty() && h.back() == '.') {
+        h.pop_back();
+      }
+
+      if (h.empty()) {
+        CXX_LOG_ERROR("WORKLOAD_IDENTITY authenticator rejected: empty host");
+        return false;
+      }
+
+      for (const char* suffix : kDefaultAllowedHostSuffixes) {
+        if (hostMatchesSuffix(h, suffix)) {
+          return true;
+        }
+      }
+      for (const std::string& suffix : envAllowedHostSuffixes()) {
+        if (hostMatchesSuffix(h, suffix)) {
+          return true;
+        }
+      }
+
+      CXX_LOG_ERROR("WORKLOAD_IDENTITY requires a recognized Snowflake host "
+                    "(*.snowflakecomputing.com, .cn or .mil). Got: '%s'",
+                    h.c_str());
+      return false;
     }
 
     boost::optional<Attestation> createAttestation(AttestationConfig& config) {

--- a/cpp/lib/Authenticator.cpp
+++ b/cpp/lib/Authenticator.cpp
@@ -204,11 +204,27 @@ extern "C" {
       }
       if (AUTH_WIF == authenticator)
       {
+          // Verify the host is a recognized Snowflake endpoint before
+          // fetching cloud credentials.
+          if (!Snowflake::Client::isSnowflakeHostForWorkloadIdentity(
+                  conn->host ? conn->host : ""))
+          {
+              const char* errorMessage =
+                  "WORKLOAD_IDENTITY requires a recognized Snowflake host "
+                  "(*.snowflakecomputing.com, .cn or .mil)";
+              log_error("%s. Got: '%s'", errorMessage,
+                        conn->host ? conn->host : "(null)");
+              SET_SNOWFLAKE_ERROR(&conn->error,
+                                  SF_STATUS_ERROR_BAD_CONNECTION_PARAMS,
+                                  errorMessage,
+                                  SF_SQLSTATE_UNABLE_TO_CONNECT);
+              return;
+          }
+
           Snowflake::Client::AttestationConfig config;
-          
+
           if (config.configureWIFAttestation(conn) != SF_STATUS_SUCCESS)
           {
-              log_error("Failed to configure WIF attestation");
               return;
           }
 
@@ -224,7 +240,15 @@ extern "C" {
               snowflake_cJSON_AddStringToObject(data, "PROVIDER",
                   Snowflake::Client::stringFromAttestationType(attestation.type));
           } else {
-              log_error("Failed to create WIF attestation - not running in a supported cloud environment?");
+              const char* errorMessage =
+                  "Failed to create WIF attestation; verify the workload "
+                  "identity provider configuration and environment";
+              log_error("%s", errorMessage);
+              SET_SNOWFLAKE_ERROR(&conn->error,
+                                  SF_STATUS_ERROR_GENERAL,
+                                  errorMessage,
+                                  SF_SQLSTATE_UNABLE_TO_CONNECT);
+              return;
           }
       }
 

--- a/include/snowflake/WifAttestation.hpp
+++ b/include/snowflake/WifAttestation.hpp
@@ -101,6 +101,13 @@ namespace Client {
   };
 
   boost::optional<Attestation> createAttestation(AttestationConfig& config);
+
+  // Suffix-anchored allowlist that restricts Workload Identity attestation
+  // to recognized Snowflake hosts before any cloud credential is fetched.
+  // See WifAttestation.cpp for the exact suffix rule and the
+  // SNOWFLAKE_WIF_ALLOWED_HOST_SUFFIXES environment override, which is read only
+  // from the process environment.
+  bool isSnowflakeHostForWorkloadIdentity(const std::string& host);
 }
 
 }

--- a/lib/client.c
+++ b/lib/client.c
@@ -1542,6 +1542,10 @@ SF_STATUS STDCALL snowflake_connect(SF_CONNECT* sf) {
         sf->timezone,
         sf->autocommit);
     log_debug("Created body");
+    if (sf->error.error_code != SF_STATUS_SUCCESS)
+    {
+        goto cleanup;
+    }
     s_body = snowflake_cJSON_Print(body);
     // TODO delete password before printing
     if (DEBUG) {

--- a/tests/test_create_wif_attestation.cpp
+++ b/tests/test_create_wif_attestation.cpp
@@ -1317,7 +1317,8 @@ void test_unit_wif_attestation_config(void**)
     SF_CONNECT* conn = snowflake_init();
     snowflake_set_attribute(conn, SF_CON_WIF_AZURE_RESOURCE, "dummy_resource");
     
-    assert_int_equal(config.configureWIFAttestation(conn), SF_STATUS_ERROR_GENERAL);
+    assert_int_equal(config.configureWIFAttestation(conn),
+                     SF_STATUS_ERROR_BAD_CONNECTION_PARAMS);
     assert_false(config.snowflakeEntraResource.has_value());
 
     snowflake_set_attribute(conn, SF_CON_WIF_PROVIDER, "AWS");
@@ -1422,6 +1423,175 @@ void test_unit_wif_host_normalization(void**) {
   assert_string_equal(config.getWifHostForGcp().c_str(), "https://iamcredentials.privategoogleapis.com/v1");
 }
 
+// --- isSnowflakeHostForWorkloadIdentity: WORKLOAD_IDENTITY host allowlist --
+//
+// Shared 23-vector table (10 ACCEPT, 10 REJECT, 3 ENV-behavior) exercised
+// against the canonical rule, plus one behavioral test proving the ambient
+// credential is never fetched for a rejected host.
+
+void test_unit_wif_host_accept_apex_com(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("snowflakecomputing.com"));
+}
+
+void test_unit_wif_host_accept_subdomain_com(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("myaccount.snowflakecomputing.com"));
+}
+
+void test_unit_wif_host_accept_nested_subdomain_com(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("myaccount.us-east-1.snowflakecomputing.com"));
+}
+
+void test_unit_wif_host_accept_apex_cn(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("snowflakecomputing.cn"));
+}
+
+void test_unit_wif_host_accept_subdomain_cn(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("myaccount.snowflakecomputing.cn"));
+}
+
+void test_unit_wif_host_accept_apex_mil(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("snowflakecomputing.mil"));
+}
+
+void test_unit_wif_host_accept_subdomain_mil(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("myaccount.snowflakecomputing.mil"));
+}
+
+void test_unit_wif_host_accept_mixed_case(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("MyAccount.SnowflakeComputing.COM"));
+}
+
+void test_unit_wif_host_accept_trailing_dot(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("myaccount.snowflakecomputing.com."));
+}
+
+void test_unit_wif_host_accept_with_port(void **) {
+  assert_true(isSnowflakeHostForWorkloadIdentity("myaccount.snowflakecomputing.com:443"));
+}
+
+void test_unit_wif_host_accept_trailing_dot_with_port(void **) {
+  // The port must be stripped before the trailing dot: "acct.snowflake
+  // computing.com.:443" is the FQDN form with an explicit port, and must
+  // still be accepted.
+  assert_true(isSnowflakeHostForWorkloadIdentity("acct.snowflakecomputing.com.:443"));
+}
+
+void test_unit_wif_host_reject_empty(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity(""));
+}
+
+void test_unit_wif_host_reject_whitespace_only(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("   "));
+}
+
+void test_unit_wif_host_reject_prefix_lookalike(void **) {
+  // Must not match via "contains" - the label boundary is required.
+  assert_false(isSnowflakeHostForWorkloadIdentity("evilsnowflakecomputing.com"));
+}
+
+void test_unit_wif_host_reject_suffix_appended_domain(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("snowflakecomputing.com.untrusted.example"));
+}
+
+void test_unit_wif_host_reject_embedded_lookalike(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("evil.snowflakecomputing.com.untrusted.example"));
+}
+
+void test_unit_wif_host_reject_unrelated_domain(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("example.com"));
+}
+
+void test_unit_wif_host_reject_other_tld(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("snowflakecomputing.net"));
+}
+
+void test_unit_wif_host_reject_ipv4_literal(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("203.0.113.10"));
+}
+
+void test_unit_wif_host_reject_ipv6_literal(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("[2001:db8::1]"));
+}
+
+void test_unit_wif_host_reject_localhost(void **) {
+  assert_false(isSnowflakeHostForWorkloadIdentity("localhost"));
+}
+
+void test_unit_wif_host_reject_substring_without_dot_boundary(void **) {
+  // "xsnowflakecomputing.com" shares the suffix as a raw substring but not
+  // on a label boundary; must be rejected.
+  assert_false(isSnowflakeHostForWorkloadIdentity("xsnowflakecomputing.com"));
+}
+
+void test_unit_wif_host_env_hatch_accepts_extra_suffix(void **) {
+  EnvOverride envOverride("SNOWFLAKE_WIF_ALLOWED_HOST_SUFFIXES", std::string("corp.example.com"));
+  assert_true(isSnowflakeHostForWorkloadIdentity("wif.corp.example.com"));
+}
+
+void test_unit_wif_host_env_hatch_is_additive_not_disabling(void **) {
+  EnvOverride envOverride("SNOWFLAKE_WIF_ALLOWED_HOST_SUFFIXES", std::string("corp.example.com"));
+  // Default suffixes must still work when the env hatch is set.
+  assert_true(isSnowflakeHostForWorkloadIdentity("myaccount.snowflakecomputing.com"));
+  // And hosts outside both the defaults and the extra suffix must still be
+  // rejected - the env var only adds, it never disables the check.
+  assert_false(isSnowflakeHostForWorkloadIdentity("untrusted.example"));
+}
+
+void test_unit_wif_host_env_hatch_multiple_entries_normalized(void **) {
+  EnvOverride envOverride("SNOWFLAKE_WIF_ALLOWED_HOST_SUFFIXES",
+                           std::string(" Corp.Example.COM. , , other.example.org "));
+  assert_true(isSnowflakeHostForWorkloadIdentity("wif.corp.example.com"));
+  assert_true(isSnowflakeHostForWorkloadIdentity("wif.other.example.org"));
+  assert_false(isSnowflakeHostForWorkloadIdentity("other.example.org.untrusted.example"));
+}
+
+void test_unit_wif_host_rejected_host_never_creates_attestation(void **) {
+  // Behavioral test: mirrors the production call site's guard-then-create
+  // pattern. When the host is rejected, createAttestation() (and therefore
+  // any provider that would fetch/mint an ambient cloud credential) must
+  // never be invoked.
+  FakeAwsSdkWrapper awsSdkWrapper(AWS_TEST_REGION, AWS_TEST_CREDS);
+  awsSdkWrapper.webIdentityTokenResult = FAKE_WEB_IDENTITY_TOKEN;
+
+  AttestationConfig config;
+  config.type = AttestationType::AWS;
+  config.awsSdkWrapper = &awsSdkWrapper;
+
+  const std::string rejectedHost = "untrusted.example";
+  assert_false(isSnowflakeHostForWorkloadIdentity(rejectedHost));
+
+  if (isSnowflakeHostForWorkloadIdentity(rejectedHost)) {
+    Snowflake::Client::createAttestation(config);
+  }
+
+  assert_int_equal(awsSdkWrapper.getWebIdentityTokenCallCount, 0);
+  assert_int_equal(awsSdkWrapper.assumeRoleCallCount, 0);
+}
+
+void test_unit_wif_rejected_host_sets_connection_error(void **) {
+  SF_CONNECT conn = {};
+  conn.authenticator = const_cast<char *>(SF_AUTHENTICATOR_WORKLOAD_IDENTITY);
+  conn.host = const_cast<char *>("untrusted.example");
+  conn.wif_provider = const_cast<char *>("OIDC");
+  conn.wif_token = const_cast<char *>(FAKE_WEB_IDENTITY_TOKEN.c_str());
+
+  cJSON *body = snowflake_cJSON_CreateObject();
+  cJSON *data = snowflake_cJSON_CreateObject();
+  snowflake_cJSON_AddItemToObject(body, "data", data);
+
+  // Exercise the production AUTH_WIF branch. The explicit OIDC token makes
+  // reaching createAttestation() observable without contacting a cloud
+  // provider: it would be copied into TOKEN if the host guard were absent.
+  auth_update_json_body(&conn, body);
+
+  assert_int_equal(conn.error.error_code, SF_STATUS_ERROR_BAD_CONNECTION_PARAMS);
+  assert_non_null(strstr(conn.error.msg, "recognized Snowflake host"));
+  assert_null(snowflake_cJSON_GetObjectItem(data, "AUTHENTICATOR"));
+  assert_null(snowflake_cJSON_GetObjectItem(data, "TOKEN"));
+
+  snowflake_cJSON_Delete(body);
+}
+
 int main() {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_unit_aws_attestation_success),
@@ -1472,6 +1642,33 @@ int main() {
       cmocka_unit_test(test_unit_wif_attestation_config),
       cmocka_unit_test(test_unit_wif_aws_use_outbound_token_connection_string),
       cmocka_unit_test(test_unit_wif_host_normalization),
+      cmocka_unit_test(test_unit_wif_host_accept_apex_com),
+      cmocka_unit_test(test_unit_wif_host_accept_subdomain_com),
+      cmocka_unit_test(test_unit_wif_host_accept_nested_subdomain_com),
+      cmocka_unit_test(test_unit_wif_host_accept_apex_cn),
+      cmocka_unit_test(test_unit_wif_host_accept_subdomain_cn),
+      cmocka_unit_test(test_unit_wif_host_accept_apex_mil),
+      cmocka_unit_test(test_unit_wif_host_accept_subdomain_mil),
+      cmocka_unit_test(test_unit_wif_host_accept_mixed_case),
+      cmocka_unit_test(test_unit_wif_host_accept_trailing_dot),
+      cmocka_unit_test(test_unit_wif_host_accept_with_port),
+      cmocka_unit_test(test_unit_wif_host_accept_trailing_dot_with_port),
+      cmocka_unit_test(test_unit_wif_host_reject_empty),
+      cmocka_unit_test(test_unit_wif_host_reject_whitespace_only),
+      cmocka_unit_test(test_unit_wif_host_reject_prefix_lookalike),
+      cmocka_unit_test(test_unit_wif_host_reject_suffix_appended_domain),
+      cmocka_unit_test(test_unit_wif_host_reject_embedded_lookalike),
+      cmocka_unit_test(test_unit_wif_host_reject_unrelated_domain),
+      cmocka_unit_test(test_unit_wif_host_reject_other_tld),
+      cmocka_unit_test(test_unit_wif_host_reject_ipv4_literal),
+      cmocka_unit_test(test_unit_wif_host_reject_ipv6_literal),
+      cmocka_unit_test(test_unit_wif_host_reject_localhost),
+      cmocka_unit_test(test_unit_wif_host_reject_substring_without_dot_boundary),
+      cmocka_unit_test(test_unit_wif_host_env_hatch_accepts_extra_suffix),
+      cmocka_unit_test(test_unit_wif_host_env_hatch_is_additive_not_disabling),
+      cmocka_unit_test(test_unit_wif_host_env_hatch_multiple_entries_normalized),
+      cmocka_unit_test(test_unit_wif_host_rejected_host_never_creates_attestation),
+      cmocka_unit_test(test_unit_wif_rejected_host_sets_connection_error)
   };
 
   return cmocka_run_group_tests(tests, nullptr, nullptr);


### PR DESCRIPTION
`WORKLOAD_IDENTITY` authentication could fetch ambient cloud credentials before confirming that the configured host was a Snowflake endpoint. An attacker who could redirect the host could therefore receive the generated attestation. Rejected hosts also returned from `auth_update_json_body()` after logging only, allowing `snowflake_connect()` to continue into a doomed login request and replace the useful cause with a generic downstream error.

This change normalizes the host and requires either an exact match or a label-boundary subdomain match for `snowflakecomputing.com`, `.cn`, or `.mil` before invoking a WIF provider. The environment-only `SNOWFLAKE_WIF_ALLOWED_HOST_SUFFIXES` hatch can add trusted suffixes but cannot remove the defaults or be influenced by connection parameters. Rejected hosts, missing or invalid providers, and attestation failures now set actionable connection errors, and `snowflake_connect()` stops before network I/O when authentication-body construction reports one.

The tests cover normalization, boundary and lookalike cases, all default suffixes, IP literals, and environment-hatch behavior. A production-path regression test enters the real `AUTH_WIF` branch with a stub connection, then verifies the specific rejected-host error and that no authenticator or token reaches the login body. The modified production and test objects compile with `-Werror`; a saved third-party Arrow/AWS ABI mismatch prevents linking the full test executable locally, so CI remains the execution gate.